### PR TITLE
[KLC-1822] Add seednode command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ db/
 stats/*
 *.pem*
 *.env*
-seednode
 *.log
 test-output.json
 *.trace*

--- a/cmd/seednode/CLI.md
+++ b/cmd/seednode/CLI.md
@@ -1,0 +1,28 @@
+
+# Klever SeedNode CLI
+
+The **Klever SeedNode** exposes the following Command Line Interface:
+
+```
+$ seednode --help
+
+NAME:
+   SeedNode CLI App - This is the entry point for starting a new seed node - the app will help bootnodes connect to the network
+USAGE:
+   seednode [global options]
+   
+AUTHOR:
+   The Klever Team <contact@klever.io>
+   
+GLOBAL OPTIONS:
+   --port [p2p port]     The [p2p port] number on which the application will start. Can use single values such as `0, 10230, 15670` or range of ports such as `5000-10000` (default: "10000")
+   --p2p-seed value      P2P seed will be used when generating credentials for p2p component. Can be any string. (default: "seed")
+   --log-level level(s)  This flag specifies the logger level(s). It can contain multiple comma-separated value. For example, if set to *:INFO the logs for all packages will have the INFO level. However, if set to *:INFO,api:DEBUG the logs for all packages will have the INFO level, excepting the api package which will receive a DEBUG log level. (default: "*:INFO ")
+   --log-save            Boolean option for enabling log saving. If set, it will automatically save all the logs into a file.
+   --config [path]       The [path] for the main configuration file. This TOML file contain the main configurations such as the marshalizer type (default: "./config/config.toml")
+   --help, -h            show help
+   --version, -v         print the version
+   
+
+```
+

--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	logger "github.com/klever-io/klever-go-logger"
+	"github.com/klever-io/klever-go/network/api/logs"
+	"github.com/klever-io/klever-go/tools/marshal"
+)
+
+var log = logger.GetOrCreate("seednode/api")
+
+// Start will boot up the api and appropriate routes, handlers and validators
+func Start(restAPIInterface string, marshalizer marshal.Marshalizer) error {
+	ws := gin.Default()
+	ws.Use(cors.Default())
+
+	registerRoutes(ws, marshalizer)
+
+	return ws.Run(restAPIInterface)
+}
+
+func registerRoutes(ws *gin.Engine, marshalizer marshal.Marshalizer) {
+	registerLoggerWsRoute(ws, marshalizer)
+}
+
+func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
+	upgrader := websocket.Upgrader{}
+
+	ws.GET("/log", func(c *gin.Context) {
+		upgrader.CheckOrigin = func(r *http.Request) bool {
+			return true
+		}
+
+		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+
+		ls, err := logs.NewLogSender(marshalizer, conn, log)
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+
+		ls.StartSendingBlocking()
+	})
+}

--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	logger "github.com/klever-io/klever-go-logger"
+	"github.com/klever-io/klever-go/cmd/seednode/api"
+	"github.com/klever-io/klever-go/common/facade"
+	"github.com/klever-io/klever-go/config"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/network/p2p"
+	"github.com/klever-io/klever-go/network/p2p/libp2p"
+	"github.com/klever-io/klever-go/tools"
+	"github.com/klever-io/klever-go/tools/check"
+	"github.com/klever-io/klever-go/tools/display"
+	"github.com/klever-io/klever-go/tools/logging"
+	"github.com/klever-io/klever-go/tools/marshal"
+	factoryMarshalizer "github.com/klever-io/klever-go/tools/marshal/factory"
+	"github.com/urfave/cli"
+)
+
+const (
+	defaultLogsPath     = "logs"
+	logFilePrefix       = "klever-seed"
+	filePathPlaceholder = "[path]"
+)
+
+var (
+	seedNodeHelpTemplate = `NAME:
+   {{.Name}} - {{.Usage}}
+USAGE:
+   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}
+   {{if len .Authors}}
+AUTHOR:
+   {{range .Authors}}{{ . }}{{end}}
+   {{end}}{{if .Commands}}
+GLOBAL OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}
+VERSION:
+   {{.Version}}
+   {{end}}
+`
+	// port defines a flag for setting the port on which the node will listen for connections
+	port = cli.StringFlag{
+		Name: "port",
+		Usage: "The `[p2p port]` number on which the application will start. Can use single values such as " +
+			"`0, 10230, 15670` or range of ports such as `5000-10000`",
+		Value: "10000",
+	}
+	// restAPIInterfaceFlag defines a flag for the interface on which the rest API will try to bind with
+	restAPIInterfaceFlag = cli.StringFlag{
+		Name: "rest-api-interface",
+		Usage: "The interface `address and port` to which the REST API will attempt to bind. " +
+			"To bind to all available interfaces, set this flag to :8080. If set to `off` then the API won't be available",
+		Value: facade.DefaultRestInterface,
+	}
+	// p2pSeed defines a flag to be used as a seed when generating P2P credentials. Useful for seed nodes.
+	p2pSeed = cli.StringFlag{
+		Name:  "p2p-seed",
+		Usage: "P2P seed will be used when generating credentials for p2p component. Can be any string.",
+		Value: "seed",
+	}
+	// logLevel defines the logger level
+	logLevel = cli.StringFlag{
+		Name: "log-level",
+		Usage: "This flag specifies the logger `level(s)`. It can contain multiple comma-separated value. For example" +
+			", if set to *:INFO the logs for all packages will have the INFO level. However, if set to *:INFO,api:DEBUG" +
+			" the logs for all packages will have the INFO level, excepting the api package which will receive a DEBUG" +
+			" log level.",
+		Value: "*:" + logger.LogInfo.String(),
+	}
+	//logFile is used when the log output needs to be logged in a file
+	logSaveFile = cli.BoolFlag{
+		Name:  "log-save",
+		Usage: "Boolean option for enabling log saving. If set, it will automatically save all the logs into a file.",
+	}
+	// configurationFile defines a flag for the path to the main toml configuration file
+	configurationFile = cli.StringFlag{
+		Name: "config",
+		Usage: "The `" + filePathPlaceholder + "` for the main configuration file. This YAML file contain the main " +
+			"configurations such as the marshalizer type",
+		Value: "./config/seednode/config.yaml",
+	}
+)
+
+var log = logger.GetOrCreate("main")
+
+var appVersion = core.UnVersionedAppString
+
+func main() {
+	app := cli.NewApp()
+	cli.AppHelpTemplate = seedNodeHelpTemplate
+	app.Name = "SeedNode CLI App"
+	app.Usage = "This is the entry point for starting a new seed node - the app will help bootnodes connect to the network"
+	app.Flags = []cli.Flag{
+		port,
+		restAPIInterfaceFlag,
+		p2pSeed,
+		logLevel,
+		logSaveFile,
+		configurationFile,
+	}
+	app.Version = appVersion
+	app.Authors = []cli.Author{
+		{
+			Name:  "The Klever Team",
+			Email: "contact@klever.io",
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		return startNode(c)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+func startNode(ctx *cli.Context) error {
+	var err error
+
+	logLevelFlagValue := ctx.GlobalString(logLevel.Name)
+	err = logger.SetLogLevel(logLevelFlagValue)
+	if err != nil {
+		return err
+	}
+
+	configurationFileName := ctx.GlobalString(configurationFile.Name)
+	cfg, err := config.LoadFromPath(configurationFileName)
+	if err != nil {
+		return err
+	}
+
+	internalMarshalizer, err := factoryMarshalizer.NewMarshalizer(cfg.Marshalizer.Type)
+	if err != nil {
+		return fmt.Errorf("error creating marshalizer (internal): %s", err.Error())
+	}
+
+	withLogFile := ctx.GlobalBool(logSaveFile.Name)
+	var fileLogging tools.FileLoggingHandler
+	if withLogFile {
+		workingDir := getWorkingDir(log)
+		fileLogging, err = logging.NewFileLogging(workingDir, defaultLogsPath, logFilePrefix)
+		if err != nil {
+			return fmt.Errorf("%w creating a log file", err)
+		}
+
+		logFileLifeSpan := time.Second * time.Duration(cfg.Logs.LogFileLifeSpanInSec)
+		logFileSizeSpan := time.Second * time.Duration(cfg.Logs.LogFileSizeSpanInSec)
+
+		err = fileLogging.SetFileRotation(logFileLifeSpan, logFileSizeSpan, cfg.Logs.MaxBackups, cfg.Logs.MaxFileSize)
+		if err != nil {
+			return err
+		}
+	}
+
+	startRestServices(ctx, internalMarshalizer)
+
+	log.Info("starting seednode...")
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	if ctx.IsSet(port.Name) {
+		cfg.P2P.Node.Port = ctx.GlobalString(port.Name)
+	}
+	if ctx.IsSet(p2pSeed.Name) {
+		cfg.P2P.Node.Seed = ctx.GlobalString(p2pSeed.Name)
+	}
+
+	err = checkExpectedPeerCount(cfg.P2P)
+	if err != nil {
+		return err
+	}
+
+	messenger, err := createNode(cfg.P2P, internalMarshalizer)
+	if err != nil {
+		return err
+	}
+
+	err = messenger.Bootstrap()
+	if err != nil {
+		return err
+	}
+
+	log.Info("application is now running...")
+	mainLoop(messenger, sigs)
+
+	log.Debug("closing seednode")
+	if !check.IfNil(fileLogging) {
+		err = fileLogging.Close()
+		log.LogIfError(err)
+	}
+
+	return nil
+}
+
+func mainLoop(messenger p2p.Messenger, stop chan os.Signal) {
+	displayMessengerInfo(messenger)
+	for {
+		select {
+		case <-stop:
+			log.Info("terminating at user's signal...")
+			return
+		case <-time.After(time.Second * 5):
+			displayMessengerInfo(messenger)
+		}
+	}
+}
+
+func createNode(p2pConfig config.P2PConfig, marshalizer marshal.Marshalizer) (p2p.Messenger, error) {
+	arg := libp2p.ArgsNetworkMessenger{
+		Marshalizer:   marshalizer,
+		ListenAddress: libp2p.ListenAddrWithIp4AndTcp,
+		P2pConfig:     p2pConfig,
+		SyncTimer:     &libp2p.LocalSyncTimer{},
+	}
+
+	return libp2p.NewNetworkMessenger(arg)
+}
+
+func displayMessengerInfo(messenger p2p.Messenger) {
+	headerSeedAddresses := []string{"Seednode addresses:"}
+	addresses := make([]*display.LineData, 0)
+
+	for _, address := range messenger.Addresses() {
+		addresses = append(addresses, display.NewLineData(false, []string{address}))
+	}
+
+	tbl, _ := display.CreateTableString(headerSeedAddresses, addresses)
+	log.Info("\n" + tbl)
+
+	mesConnectedAddrs := messenger.ConnectedAddresses()
+	sort.Slice(mesConnectedAddrs, func(i, j int) bool {
+		return strings.Compare(mesConnectedAddrs[i], mesConnectedAddrs[j]) < 0
+	})
+
+	log.Info("known peers", "num peers", len(messenger.Peers()))
+	headerConnectedAddresses := []string{fmt.Sprintf("Seednode is connected to %d peers:", len(mesConnectedAddrs))}
+	connAddresses := make([]*display.LineData, len(mesConnectedAddrs))
+
+	for idx, address := range mesConnectedAddrs {
+		connAddresses[idx] = display.NewLineData(false, []string{address})
+	}
+
+	tbl2, _ := display.CreateTableString(headerConnectedAddresses, connAddresses)
+	log.Info("\n" + tbl2)
+}
+
+func getWorkingDir(log logger.Logger) string {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		log.LogIfError(err)
+		workingDir = ""
+	}
+
+	log.Trace("working directory", "path", workingDir)
+
+	return workingDir
+}
+
+func checkExpectedPeerCount(p2pConfig config.P2PConfig) error {
+	maxExpectedPeerCount := p2pConfig.Node.MaximumExpectedPeerCount
+
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return fmt.Errorf("%w while getting RLimits", err)
+	}
+
+	log.Info("file limits",
+		"current", rLimit.Cur,
+		"max", rLimit.Max,
+		"expected", maxExpectedPeerCount,
+	)
+
+	if maxExpectedPeerCount > rLimit.Cur {
+		return fmt.Errorf("provided maxExpectedPeerCount is less than the current OS configured value")
+	}
+
+	return nil
+}
+
+func startRestServices(ctx *cli.Context, marshalizer marshal.Marshalizer) {
+	restAPIInterface := ctx.GlobalString(restAPIInterfaceFlag.Name)
+	if restAPIInterface != facade.DefaultRestPortOff {
+		go startGinServer(restAPIInterface, marshalizer)
+	} else {
+		log.Info("rest api is disabled")
+	}
+}
+
+func startGinServer(restAPIInterface string, marshalizer marshal.Marshalizer) {
+	err := api.Start(restAPIInterface, marshalizer)
+	if err != nil {
+		log.LogIfError(err)
+	}
+}


### PR DESCRIPTION
This pull request introduces the initial implementation of the Klever SeedNode application, including its CLI, main entrypoint, and a basic REST API. The main changes are the addition of the CLI documentation, the main application logic for starting and managing the seed node, and the setup for a REST API (with a WebSocket log endpoint).

**New CLI and Application Entrypoint:**

* Adds `main.go`, which defines the CLI interface, parses flags, initializes logging, loads configuration, starts the REST API, and manages the P2P seed node lifecycle. This includes graceful shutdown, periodic status display, and file logging support.
* Provides comprehensive CLI documentation in `CLI.md`, detailing all available flags and usage examples.

**REST API Setup:**

* Introduces a new `api` package with a Gin-based HTTP server, including CORS support and a `/log` WebSocket endpoint for real-time log streaming.
* Integrates the REST API startup into the application lifecycle, with configuration to enable/disable the API and bind to specific interfaces.

**P2P Node Bootstrapping and Monitoring:**

* Implements logic to create and bootstrap a P2P node using configuration and a pluggable marshalizer, with periodic display of node and peer information.
* Checks system file descriptor limits to ensure the expected peer count can be supported, improving robustness.