### PR TITLE
[KLC-1910] Migrate GitHub workflows to klever-pipe self-hosted runner

### DIFF
--- a/.github/workflows/go-setup-lint.yaml
+++ b/.github/workflows/go-setup-lint.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   setup-and-lint:
-    runs-on: ubuntu-latest
+    runs-on: klever-pipe
     outputs:
       lint-results: ${{ steps.lint.outputs.results }}
     steps:

--- a/.github/workflows/pr-qa-sec.yaml
+++ b/.github/workflows/pr-qa-sec.yaml
@@ -20,7 +20,7 @@ jobs:
 
   test:
     needs: setup-and-lint
-    runs-on: ubuntu-latest
+    runs-on: klever-pipe
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
 
   sonarqube:
     needs: [setup-and-lint, test]
-    runs-on: ubuntu-latest
+    runs-on: klever-pipe
     if: |
       always() &&
       github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -168,7 +168,7 @@ jobs:
 
   notify:
     needs: [setup-and-lint, test, sonarqube]
-    runs-on: ubuntu-latest
+    runs-on: klever-pipe
     if: |
       always() &&
       github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -350,7 +350,7 @@ jobs:
 
   result-check:
     needs: [sonarqube, test]
-    runs-on: ubuntu-latest
+    runs-on: klever-pipe
     steps:
       - name: Check for failed jobs
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,7 +18,7 @@ jobs:
 
   validate-and-build:
     needs: [setup-and-lint]
-    runs-on: ubuntu-latest
+    runs-on: klever-pipe
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -30,7 +30,7 @@ jobs:
 
   build:
     needs: [setup-and-lint]
-    runs-on: ubuntu-latest
+    runs-on: klever-pipe
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
  Update workflow files to use klever-pipe self-hosted runner instead of ubuntu-latest for improved performance and faster test/build execution.

  Changes:
  - go-setup-lint.yaml: Switch to klever-pipe runner
  - pr-qa-sec.yaml: Update all jobs to klever-pipe runner
  - push.yaml: Migrate validate-and-build job to klever-pipe
  - release-docker.yaml: Switch build job to klever-pipe

  The release.yaml workflow intentionally remains on GitHub-hosted runners (ubuntu-latest, macos-latest, macos-13) for multi-platform binary builds.