### PR TITLE
[KLC-1972] Remove NotInConsensusGroup error from the blacklist

### DIFF
--- a/core/consensus/slot/worker.go
+++ b/core/consensus/slot/worker.go
@@ -427,6 +427,7 @@ func (wrk *Worker) shouldBlacklistPeer(err error) bool {
 	if err == nil ||
 		errors.Is(err, ErrMessageForPastSlot) ||
 		errors.Is(err, ErrMessageForFutureSlot) ||
+		errors.Is(err, ErrNodeIsNotInConsensusGroup) ||
 		errors.Is(err, crypto.ErrPIDMismatch) ||
 		errors.Is(err, crypto.ErrSignatureMismatch) ||
 		errors.Is(err, sharding.ErrEpochNodesConfigDoesNotExist) ||


### PR DESCRIPTION
This PR reverts a change made on on Sep 12, 2024 in the task KLC-920
---
This pull request makes a targeted update to the peer blacklisting logic in the consensus worker. The change ensures that peers returning a specific error indicating they are not in the consensus group are not blacklisted.

- Peer Blacklisting Logic:
  * Updated the `shouldBlacklistPeer` function in `worker.go` to prevent blacklisting peers when the error is `ErrNodeIsNotInConsensusGroup`, aligning blacklisting behavior with consensus group membership checks.

