### PR TITLE
[KLC-1974] feat(validators): implement V2 epoch rewards distribution

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -307,6 +307,12 @@ var ErrNilNodesCoordinator = errors.New("nil nodes coordinator")
 // ErrValidatorNotFound signals that the validator has not been found
 var ErrValidatorNotFound = errors.New("validator not found")
 
+// ErrValidatorMaxDelegatorsReached signals that the validator has reached the maximum number of delegators
+var ErrValidatorMaxDelegatorsReached = errors.New("validator has reached maximum number of delegators")
+
+// ErrProposalMaxVotersReached signals that the proposal has reached the maximum number of voters
+var ErrProposalMaxVotersReached = errors.New("proposal has reached maximum number of voters")
+
 // ErrNilAddress defines the error when trying to work with a nil address
 var ErrNilAddress = errors.New("nil address")
 

--- a/common/mock/forkControllerStub.go
+++ b/common/mock/forkControllerStub.go
@@ -13,6 +13,7 @@ type ForkControllerStub struct {
 	FixDelegationSameEpochValue  bool
 	EnableSmartContractsValue    bool
 	FixAuditChangesValue         bool
+	EpochRewardsV2Value          bool
 	EpochConfirmedCalled         bool
 	LastConfirmedEpoch           uint32
 }
@@ -45,6 +46,8 @@ func (s *ForkControllerStub) SetFork(forkName string, value bool) *ForkControlle
 		s.EnableSmartContractsValue = value
 	case "FixAuditChanges":
 		s.FixAuditChangesValue = value
+	case "EpochRewardsV2":
+		s.EpochRewardsV2Value = value
 	}
 
 	return s
@@ -61,6 +64,7 @@ func (s *ForkControllerStub) SetAll(value bool) {
 	s.FixDelegationSameEpochValue = value
 	s.EnableSmartContractsValue = value
 	s.FixAuditChangesValue = value
+	s.EpochRewardsV2Value = value
 	s.LastConfirmedEpoch = 0
 }
 
@@ -75,6 +79,7 @@ func (s *ForkControllerStub) SetByConfig(config config.EnableEpochs) {
 	s.FixDelegationSameEpochValue = config.FixDelegationSameEpoch == 0
 	s.EnableSmartContractsValue = config.SmartContracts == 0
 	s.FixAuditChangesValue = config.FixAuditChanges == 0
+	s.EpochRewardsV2Value = config.EpochRewardsV2 == 0
 	s.LastConfirmedEpoch = 0
 }
 
@@ -121,6 +126,11 @@ func (s *ForkControllerStub) EnableSmartContracts() bool {
 // FixAuditChanges returns the stubbed value
 func (s *ForkControllerStub) FixAuditChanges() bool {
 	return s.FixAuditChangesValue
+}
+
+// EpochRewardsV2 returns the stubbed value
+func (s *ForkControllerStub) EpochRewardsV2() bool {
+	return s.EpochRewardsV2Value
 }
 
 // EpochConfirmed records that the method was called and stores the epoch

--- a/common/mock/validatorKappStub.go
+++ b/common/mock/validatorKappStub.go
@@ -133,6 +133,18 @@ func (v *ValidatorsKAppStub) DisplayRating(owners [][]byte) {
 	// Stub implementation
 }
 
+// GetPendingRewards retrieves pending rewards for a user address (v2 epoch rewards).
+func (v *ValidatorsKAppStub) GetPendingRewards(address []byte) (int64, error) {
+	// Stub implementation
+	return 0, nil
+}
+
+// ClaimPendingRewards claims pending rewards for a user from the KApp data trie.
+func (v *ValidatorsKAppStub) ClaimPendingRewards(address []byte) (int64, error) {
+	// Stub implementation
+	return 0, nil
+}
+
 // IsInterfaceNil checks if the interface is nil.
 func (v *ValidatorsKAppStub) IsInterfaceNil() bool {
 	// Stub implementation

--- a/common/mock/validatorKappStub.go
+++ b/common/mock/validatorKappStub.go
@@ -11,6 +11,8 @@ type ValidatorsKAppStub struct {
 	ResetValidatorStatisticsAtNewEpochCalled func([]*state.ValidatorInfo) ([]*state.ValidatorInfo, error)
 	ProcessRatingsEndOfEpochCalled           func([]*state.ValidatorInfo) error
 	UndelegateCalled                         func(blockEpoch uint32, validator []byte, sender []byte, tc *transaction.UndelegateContract) (transaction.Transaction_TXResultCode, error)
+	ClaimPendingRewardsCalled                func(address []byte) (int64, error)
+	GetPendingRewardsCalled                  func(address []byte) (int64, error)
 }
 
 // SetKAppController sets the KApp controller.
@@ -135,13 +137,17 @@ func (v *ValidatorsKAppStub) DisplayRating(owners [][]byte) {
 
 // GetPendingRewards retrieves pending rewards for a user address (v2 epoch rewards).
 func (v *ValidatorsKAppStub) GetPendingRewards(address []byte) (int64, error) {
-	// Stub implementation
+	if v.GetPendingRewardsCalled != nil {
+		return v.GetPendingRewardsCalled(address)
+	}
 	return 0, nil
 }
 
 // ClaimPendingRewards claims pending rewards for a user from the KApp data trie.
 func (v *ValidatorsKAppStub) ClaimPendingRewards(address []byte) (int64, error) {
-	// Stub implementation
+	if v.ClaimPendingRewardsCalled != nil {
+		return v.ClaimPendingRewardsCalled(address)
+	}
 	return 0, nil
 }
 

--- a/config/enableEpochs.go
+++ b/config/enableEpochs.go
@@ -24,6 +24,7 @@ type EnableEpochs struct {
 	FixDelegationSameEpoch  uint32 `yaml:"fixDelegationSameEpoch"`
 	SmartContracts          uint32 `yaml:"smartContracts"`
 	FixAuditChanges         uint32 `yaml:"fixAuditChanges"`
+	EpochRewardsV2          uint32 `yaml:"epochRewardsV2"`
 }
 
 // GasScheduleByEpochs represents a gas schedule toml entry that will be applied from the provided epoch

--- a/config/node/enableEpochs.yaml
+++ b/config/node/enableEpochs.yaml
@@ -21,6 +21,8 @@ enableEpochs:
   smartContracts: 0
   # Audit Changes
   fixAuditChanges: 0
+  # Epoch Rewards V2
+  epochRewardsV2: 0
 
 gasSchedule:
   gasScheduleByEpochs:

--- a/core/fork/forks.go
+++ b/core/fork/forks.go
@@ -22,6 +22,7 @@ type forkController struct {
 	flagFixDelegationSameEpoch       atomic.Flag
 	flagEnableSmartContracts         atomic.Flag
 	flagFixAuditChanges              atomic.Flag
+	flagEpochRewardsV2               atomic.Flag
 }
 
 func NewForkController(cfg config.EnableEpochs, epochNotifier process.EpochNotifier) (*forkController, error) {
@@ -73,6 +74,10 @@ func (f *forkController) FixAuditChanges() bool {
 	return f.flagFixAuditChanges.IsSet()
 }
 
+func (f *forkController) EpochRewardsV2() bool {
+	return f.flagEpochRewardsV2.IsSet()
+}
+
 // EpochConfirmed is called whenever a new epoch is confirmed
 func (f *forkController) EpochConfirmed(epoch uint32) {
 	f.flagClaimKFIEnabled.Toggle(epoch >= f.enableEpochs.ClaimKFI)
@@ -101,6 +106,9 @@ func (f *forkController) EpochConfirmed(epoch uint32) {
 
 	f.flagFixAuditChanges.Toggle(epoch >= f.enableEpochs.FixAuditChanges)
 	log.Debug("forkController: FixAuditChanges", "enabled", f.flagFixAuditChanges.IsSet())
+
+	f.flagEpochRewardsV2.Toggle(epoch >= f.enableEpochs.EpochRewardsV2)
+	log.Debug("forkController: EpochRewardsV2", "enabled", f.flagEpochRewardsV2.IsSet())
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/core/interface.go
+++ b/core/interface.go
@@ -78,6 +78,7 @@ type ForkController interface {
 	FixDelegationSameEpoch() bool
 	EnableSmartContracts() bool
 	FixAuditChanges() bool
+	EpochRewardsV2() bool
 	IsInterfaceNil() bool
 }
 

--- a/core/kapp/accounts/accounts.go
+++ b/core/kapp/accounts/accounts.go
@@ -1603,6 +1603,20 @@ func (a *accountsKapp) ClaimAllowance(sender []byte, tc *transaction.ClaimContra
 		return transaction.Transaction_AccountError, err
 	}
 
+	// V2 Epoch Rewards: Transfer pending rewards to allowance before claiming
+	if a.forkController.EpochRewardsV2() {
+		pendingRewards, err := a.KAppController.GetValidatorsKApp().ClaimPendingRewards(sender)
+		if err != nil {
+			return transaction.Transaction_ClaimError, err
+		}
+		if pendingRewards > 0 {
+			err = ownerAcc.AddToAllowance(pendingRewards)
+			if err != nil {
+				return transaction.Transaction_ClaimError, err
+			}
+		}
+	}
+
 	gains, err := a.ClaimBalance(transaction.ClaimContract_AllowanceClaim, kdautils.KLVIdentifier, ctx.Block(), ownerAcc, nil, nil, userKDA)
 	if err != nil {
 		var resultCode transaction.Transaction_TXResultCode

--- a/core/kapp/accounts/accounts.go
+++ b/core/kapp/accounts/accounts.go
@@ -1581,6 +1581,25 @@ func (a *accountsKapp) ClaimStaking(sender []byte, tc *transaction.ClaimContract
 	return transaction.Transaction_Ok, nil
 }
 
+func (a *accountsKapp) transferPendingRewardsToAllowance(sender []byte, ownerAcc state.UserAccountHandler) (transaction.Transaction_TXResultCode, error) {
+	if !a.forkController.EpochRewardsV2() {
+		return transaction.Transaction_Ok, nil
+	}
+
+	pendingRewards, err := a.KAppController.GetValidatorsKApp().ClaimPendingRewards(sender)
+	if err != nil {
+		return transaction.Transaction_ClaimError, err
+	}
+
+	if pendingRewards > 0 {
+		if err = ownerAcc.AddToAllowance(pendingRewards); err != nil {
+			return transaction.Transaction_ClaimError, err
+		}
+	}
+
+	return transaction.Transaction_Ok, nil
+}
+
 func (a *accountsKapp) ClaimAllowance(sender []byte, tc *transaction.ClaimContract) (transaction.Transaction_TXResultCode, error) {
 	ctx := a.KAppController.GetCurrentKAppContext()
 
@@ -1604,26 +1623,15 @@ func (a *accountsKapp) ClaimAllowance(sender []byte, tc *transaction.ClaimContra
 	}
 
 	// V2 Epoch Rewards: Transfer pending rewards to allowance before claiming
-	if a.forkController.EpochRewardsV2() {
-		pendingRewards, err := a.KAppController.GetValidatorsKApp().ClaimPendingRewards(sender)
-		if err != nil {
-			return transaction.Transaction_ClaimError, err
-		}
-		if pendingRewards > 0 {
-			err = ownerAcc.AddToAllowance(pendingRewards)
-			if err != nil {
-				return transaction.Transaction_ClaimError, err
-			}
-		}
+	if resultCode, err := a.transferPendingRewardsToAllowance(sender, ownerAcc); err != nil {
+		return resultCode, err
 	}
 
 	gains, err := a.ClaimBalance(transaction.ClaimContract_AllowanceClaim, kdautils.KLVIdentifier, ctx.Block(), ownerAcc, nil, nil, userKDA)
 	if err != nil {
-		var resultCode transaction.Transaction_TXResultCode
+		resultCode := transaction.Transaction_ClaimError
 		if err == common.ErrMaxSupplyExceeded {
 			resultCode = transaction.Transaction_MaxSupplyExceeded
-		} else {
-			resultCode = transaction.Transaction_ClaimError
 		}
 		return resultCode, err
 	}

--- a/core/kapp/accounts/accounts_test.go
+++ b/core/kapp/accounts/accounts_test.go
@@ -4143,3 +4143,591 @@ func TestIsUninitializedContractAddress(t *testing.T) {
 		})
 	}
 }
+
+////////////////////
+// ClaimAllowance //
+////////////////////
+
+func TestClaimAllowance(t *testing.T) {
+	var (
+		errAccNotFound     = errors.New("account not found")
+		errGetUserKDA      = errors.New("error getting user KDA")
+		errClaimPending    = errors.New("error claiming pending rewards")
+		errAddToAllowance  = errors.New("error adding to allowance")
+		errClaimBalance    = errors.New("error claiming balance")
+		errSetUserKDA      = errors.New("error setting user KDA")
+		errUpdateUser      = errors.New("error updating user")
+		testSender         = []byte("testSenderAddress")
+		testAllowanceGains = map[string]int64{"KLV": 100}
+		testPendingRewards = int64(500)
+	)
+
+	cases := []struct {
+		title             string
+		forkController    core.ForkController
+		accountsCacher    state.AccountsCacher
+		kappController    kapp.KAppController
+		claimContract     *transaction.ClaimContract
+		expectedErr       error
+		expectedTxResCode transaction.Transaction_TXResultCode
+	}{
+		{
+			title:          "Failing to retrieve user account",
+			forkController: &integrationMock.ForkControllerStub{},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return nil, errAccNotFound
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       errAccNotFound,
+			expectedTxResCode: transaction.Transaction_LoadAccountError,
+		},
+		{
+			title:          "Invalid asset ID (non-KLV)",
+			forkController: &integrationMock.ForkControllerStub{},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{}, nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract: &transaction.ClaimContract{
+				ClaimType: transaction.ClaimContract_AllowanceClaim,
+				ID:        []byte("INVALID-ASSET"),
+			},
+			expectedErr:       common.ErrAssetIDInvalid,
+			expectedTxResCode: transaction.Transaction_AssetIDInvalid,
+		},
+		{
+			title:          "Failing to get user KDA",
+			forkController: &integrationMock.ForkControllerStub{},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return nil, errGetUserKDA
+						},
+					}, nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       errGetUserKDA,
+			expectedTxResCode: transaction.Transaction_AccountError,
+		},
+		{
+			title: "V2: Failing to claim pending rewards",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return true },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+					}, nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+				GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+					return &commonMock.ValidatorsKAppStub{
+						ClaimPendingRewardsCalled: func(address []byte) (int64, error) {
+							return 0, errClaimPending
+						},
+					}
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       errClaimPending,
+			expectedTxResCode: transaction.Transaction_ClaimError,
+		},
+		{
+			title: "V2: Failing to add pending rewards to allowance",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return true },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						AddToAllowanceCalled: func(value int64) error {
+							return errAddToAllowance
+						},
+					}, nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+				GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+					return &commonMock.ValidatorsKAppStub{
+						ClaimPendingRewardsCalled: func(address []byte) (int64, error) {
+							return testPendingRewards, nil
+						},
+					}
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       errAddToAllowance,
+			expectedTxResCode: transaction.Transaction_ClaimError,
+		},
+		{
+			title: "Failing to claim balance",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return false },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return nil, errClaimBalance
+						},
+					}, nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       errClaimBalance,
+			expectedTxResCode: transaction.Transaction_ClaimError,
+		},
+		{
+			title: "MaxSupplyExceeded error on claim balance",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return false },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return nil, common.ErrMaxSupplyExceeded
+						},
+					}, nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       common.ErrMaxSupplyExceeded,
+			expectedTxResCode: transaction.Transaction_MaxSupplyExceeded,
+		},
+		{
+			title: "Failing to set user KDA",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return false },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return testAllowanceGains, nil
+						},
+						SetUserKDACalled: func(assetID []byte, nonce []byte, userKDA *kapps.UserKDA) error {
+							return errSetUserKDA
+						},
+						AddressBytesCalled: func() []byte {
+							return testSender
+						},
+					}, nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       errSetUserKDA,
+			expectedTxResCode: transaction.Transaction_AssetError,
+		},
+		{
+			title: "Failing to update user account",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return false },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return testAllowanceGains, nil
+						},
+						SetUserKDACalled: func(assetID []byte, nonce []byte, userKDA *kapps.UserKDA) error {
+							return nil
+						},
+						AddressBytesCalled: func() []byte {
+							return testSender
+						},
+					}, nil
+				},
+				UpdateUserCalled: func(account state.AccountHandler) error {
+					return errUpdateUser
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       errUpdateUser,
+			expectedTxResCode: transaction.Transaction_SaveAccountError,
+		},
+		{
+			title: "Success without V2 epoch rewards",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return false },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return testAllowanceGains, nil
+						},
+						SetUserKDACalled: func(assetID []byte, nonce []byte, userKDA *kapps.UserKDA) error {
+							return nil
+						},
+						AddressBytesCalled: func() []byte {
+							return testSender
+						},
+					}, nil
+				},
+				UpdateUserCalled: func(account state.AccountHandler) error {
+					return nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       nil,
+			expectedTxResCode: transaction.Transaction_Ok,
+		},
+		{
+			title: "Success with V2 epoch rewards and pending rewards",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return true },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						AddToAllowanceCalled: func(value int64) error {
+							assert.Equal(t, testPendingRewards, value)
+							return nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return testAllowanceGains, nil
+						},
+						SetUserKDACalled: func(assetID []byte, nonce []byte, userKDA *kapps.UserKDA) error {
+							return nil
+						},
+						AddressBytesCalled: func() []byte {
+							return testSender
+						},
+					}, nil
+				},
+				UpdateUserCalled: func(account state.AccountHandler) error {
+					return nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+				GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+					return &commonMock.ValidatorsKAppStub{
+						ClaimPendingRewardsCalled: func(address []byte) (int64, error) {
+							return testPendingRewards, nil
+						},
+					}
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       nil,
+			expectedTxResCode: transaction.Transaction_Ok,
+		},
+		{
+			title: "Success with V2 but zero pending rewards (no AddToAllowance call)",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return true },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							return &kapps.UserKDA{}, nil
+						},
+						AddToAllowanceCalled: func(value int64) error {
+							t.Error("AddToAllowance should not be called when pending rewards is 0")
+							return nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return testAllowanceGains, nil
+						},
+						SetUserKDACalled: func(assetID []byte, nonce []byte, userKDA *kapps.UserKDA) error {
+							return nil
+						},
+						AddressBytesCalled: func() []byte {
+							return testSender
+						},
+					}, nil
+				},
+				UpdateUserCalled: func(account state.AccountHandler) error {
+					return nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+				GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+					return &commonMock.ValidatorsKAppStub{
+						ClaimPendingRewardsCalled: func(address []byte) (int64, error) {
+							return 0, nil // Zero pending rewards
+						},
+					}
+				},
+			},
+			claimContract:     &transaction.ClaimContract{ClaimType: transaction.ClaimContract_AllowanceClaim},
+			expectedErr:       nil,
+			expectedTxResCode: transaction.Transaction_Ok,
+		},
+		{
+			title: "Success with nil asset ID defaults to KLV",
+			forkController: &integrationMock.ForkControllerStub{
+				EpochRewardsV2Called: func() bool { return false },
+			},
+			accountsCacher: &commonMock.AccountsCacherStub{
+				GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+					return &commonMock.UserAccountHandlerStub{
+						GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+							assert.Equal(t, kdautils.KLVIdentifier, assetID)
+							return &kapps.UserKDA{}, nil
+						},
+						ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+							return testAllowanceGains, nil
+						},
+						SetUserKDACalled: func(assetID []byte, nonce []byte, userKDA *kapps.UserKDA) error {
+							return nil
+						},
+						AddressBytesCalled: func() []byte {
+							return testSender
+						},
+					}, nil
+				},
+				UpdateUserCalled: func(account state.AccountHandler) error {
+					return nil
+				},
+			},
+			kappController: &kvmStub.KAppControllerStub{
+				GetCurrentKAppContextCalled: func() kapp.KappContext {
+					return kapp.NewKappContext(kapp.ArgsNewKAppContext{
+						OriginalSender: testSender,
+						ContractID:     0,
+						ContractType:   transaction.TXContract_ClaimContractType,
+						Block: &block.Block{
+							Header: &block.BlockHeader{
+								Timestamp: 1000,
+								Epoch:     1,
+							},
+						},
+					})
+				},
+			},
+			claimContract: &transaction.ClaimContract{
+				ClaimType: transaction.ClaimContract_AllowanceClaim,
+				ID:        nil, // nil should default to KLV
+			},
+			expectedErr:       nil,
+			expectedTxResCode: transaction.Transaction_Ok,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			accsKapp, _ := NewAccountKApp(&ArgsNewAccountKApp{
+				Hasher:         &commonMock.HasherMock{},
+				Marshalizer:    &commonMock.MarshalizerMock{},
+				PubkeyConv:     commonMock.NewPubkeyConverterMock(4),
+				ForkController: c.forkController,
+			})
+			require.NoError(t, accsKapp.SetKAppController(c.kappController))
+			require.NoError(t, accsKapp.SetAccountsCacher(c.accountsCacher))
+
+			txResCode, err := accsKapp.ClaimAllowance(testSender, c.claimContract)
+
+			assert.Equal(t, c.expectedTxResCode, txResCode)
+			if c.expectedErr != nil {
+				assert.ErrorIs(t, err, c.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/core/kapp/interface.go
+++ b/core/kapp/interface.go
@@ -38,6 +38,11 @@ type ValidatorsKapp interface {
 	UpdateValidatorInfoOnSuccessfulBlock(validatorList []sharding.Validator, signingBitmap []byte, accumulatedFees int64) error
 	DecreaseAll(validators [][]byte, missedSlots uint64, consensusGroupSize int) error
 	DisplayRating(owners [][]byte)
+
+	// V2 Epoch Rewards methods - for scalable rewards distribution
+	GetPendingRewards(address []byte) (int64, error)
+	ClaimPendingRewards(address []byte) (int64, error)
+
 	IsInterfaceNil() bool
 }
 

--- a/core/kapp/proposal/export_test.go
+++ b/core/kapp/proposal/export_test.go
@@ -48,3 +48,13 @@ func (p *proposalKapp) ValidateCreateInput(tc *transaction.ProposalContract) err
 func (p *proposalKapp) CheckStakingRequirements(staking *kapps.StakingData, sender []byte) (transaction.Transaction_TXResultCode, error) {
 	return p.checkStakingRequirements(staking, sender)
 }
+
+// IsVoterLimitExceeded exports the private isVoterLimitExceeded method for testing
+func (p *proposalKapp) IsVoterLimitExceeded(proposal *kapps.ProposalData, encodedAddr string) bool {
+	return p.isVoterLimitExceeded(proposal, encodedAddr)
+}
+
+// ProcessExistingVote exports the private processExistingVote method for testing
+func (p *proposalKapp) ProcessExistingVote(proposal *kapps.ProposalData, encodedAddr string, newType kapps.ProposalData_VoteDetail_EnumVoteType) int64 {
+	return p.processExistingVote(proposal, encodedAddr, newType)
+}

--- a/core/kapp/proposal/proposal.go
+++ b/core/kapp/proposal/proposal.go
@@ -21,6 +21,11 @@ import (
 
 var _ kapp.ProposalKapp = (*proposalKapp)(nil)
 
+// MaxVotersPerProposal limits the number of unique voters per proposal
+// to prevent exceeding the MaxLeafSize (786KB) storage limit.
+// Each voter entry is ~100 bytes serialized, so 7000 voters ≈ 700KB (safe margin).
+const MaxVotersPerProposal = 7000
+
 type proposalKapp struct {
 	hasher         hashing.Hasher
 	marshalizer    marshal.Marshalizer
@@ -384,6 +389,15 @@ func (p *proposalKapp) Vote(sender []byte, tc *transaction.VoteContract) (transa
 
 	// must use string to marshal proto map due UTF8 issue
 	encodedAddr := hex.EncodeToString(sender)
+
+	// Check if adding a new voter would exceed the maximum limit
+	// (skip check if voter already exists - it's a vote update)
+	// Only enforced after EpochRewardsV2 fork to maintain consensus during upgrade
+	if p.forkController.EpochRewardsV2() {
+		if _, exists := proposal.Voters[encodedAddr]; !exists && len(proposal.Voters) >= MaxVotersPerProposal {
+			return transaction.Transaction_ParameterInvalid, common.ErrProposalMaxVotersReached
+		}
+	}
 
 	oldAmount := int64(0)
 	if v, ok := proposal.Voters[encodedAddr]; ok && v != nil {

--- a/core/kapp/proposal/proposal.go
+++ b/core/kapp/proposal/proposal.go
@@ -336,6 +336,31 @@ func updateActiveProposals(controller *kapps.ProposalController, proposal *kapps
 	}
 }
 
+// isVoterLimitExceeded checks if adding a new voter would exceed the maximum limit.
+// Returns true only if: EpochRewardsV2 is enabled, voter doesn't exist, and limit is reached.
+func (p *proposalKapp) isVoterLimitExceeded(proposal *kapps.ProposalData, encodedAddr string) bool {
+	if !p.forkController.EpochRewardsV2() {
+		return false
+	}
+	_, exists := proposal.Voters[encodedAddr]
+	return !exists && len(proposal.Voters) >= MaxVotersPerProposal
+}
+
+// processExistingVote handles vote type changes and returns the old amount for same-type votes.
+// If the voter changed their vote type, it subtracts from the old type's count and returns 0.
+// If the voter is updating the same type, it returns the old amount for incremental update.
+func (p *proposalKapp) processExistingVote(proposal *kapps.ProposalData, encodedAddr string, newType kapps.ProposalData_VoteDetail_EnumVoteType) int64 {
+	v, ok := proposal.Voters[encodedAddr]
+	if !ok || v == nil {
+		return 0
+	}
+	if v.Type != newType {
+		proposal.Votes[int32(v.Type)] -= v.Amount
+		return 0
+	}
+	return v.Amount
+}
+
 func (p *proposalKapp) Vote(sender []byte, tc *transaction.VoteContract) (transaction.Transaction_TXResultCode, error) {
 	ctx := p.KAppController.GetCurrentKAppContext()
 
@@ -393,21 +418,11 @@ func (p *proposalKapp) Vote(sender []byte, tc *transaction.VoteContract) (transa
 	// Check if adding a new voter would exceed the maximum limit
 	// (skip check if voter already exists - it's a vote update)
 	// Only enforced after EpochRewardsV2 fork to maintain consensus during upgrade
-	if p.forkController.EpochRewardsV2() {
-		if _, exists := proposal.Voters[encodedAddr]; !exists && len(proposal.Voters) >= MaxVotersPerProposal {
-			return transaction.Transaction_ParameterInvalid, common.ErrProposalMaxVotersReached
-		}
+	if p.isVoterLimitExceeded(proposal, encodedAddr) {
+		return transaction.Transaction_ParameterInvalid, common.ErrProposalMaxVotersReached
 	}
 
-	oldAmount := int64(0)
-	if v, ok := proposal.Voters[encodedAddr]; ok && v != nil {
-		if v.Type != kapps.ProposalData_VoteDetail_EnumVoteType(tc.GetType()) {
-			proposal.Votes[int32(v.Type)] -= v.Amount
-		} else {
-			oldAmount = v.Amount
-		}
-	}
-
+	oldAmount := p.processExistingVote(proposal, encodedAddr, kapps.ProposalData_VoteDetail_EnumVoteType(tc.GetType()))
 	proposal.Votes[int32(tc.GetType())] += tc.GetAmount() - oldAmount
 
 	proposal.Voters[encodedAddr] = &kapps.ProposalData_VoteDetail{

--- a/core/kapp/proposal/proposal_test.go
+++ b/core/kapp/proposal/proposal_test.go
@@ -1,11 +1,15 @@
 package proposal
 
 import (
+	"encoding/hex"
+	"fmt"
 	"testing"
 
+	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/kapp"
+	"github.com/klever-io/klever-go/core/process/kda/kdautils"
 	"github.com/klever-io/klever-go/crypto/hashing/sha256"
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/state"
@@ -13,6 +17,7 @@ import (
 	"github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/data/trie"
 	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/kvm/mock/stub"
 	"github.com/klever-io/klever-go/storage"
 	"github.com/klever-io/klever-go/storage/memorydb"
 	"github.com/klever-io/klever-go/storage/storageUnit"
@@ -424,4 +429,465 @@ func TestProposalKApp_SetAndGetProposal(t *testing.T) {
 	require.Equal(t, proposal.Proposer, retrievedProposal.Proposer)
 	require.Equal(t, proposal.ProposalStatus, retrievedProposal.ProposalStatus)
 	require.Equal(t, uint64(1), retrievedController.ProposalCount)
+}
+
+func TestProposalKApp_isVoterLimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns false when EpochRewardsV2 is disabled", func(t *testing.T) {
+		proposalKApp, _, forkController := createTestProposalKApp(t)
+		forkController.EpochRewardsV2Value = false
+
+		proposal := &kapps.ProposalData{
+			Voters: make(map[string]*kapps.ProposalData_VoteDetail),
+		}
+		// Fill to max voters
+		for i := range MaxVotersPerProposal {
+			addr := makeAddress("voter" + string(rune(i)))
+			proposal.Voters[string(addr)] = &kapps.ProposalData_VoteDetail{Amount: 100}
+		}
+
+		result := proposalKApp.IsVoterLimitExceeded(proposal, "newvoter")
+		require.False(t, result)
+	})
+
+	t.Run("returns false when voter already exists", func(t *testing.T) {
+		proposalKApp, _, forkController := createTestProposalKApp(t)
+		forkController.EpochRewardsV2Value = true
+
+		existingVoter := "existingvoter"
+		proposal := &kapps.ProposalData{
+			Voters: make(map[string]*kapps.ProposalData_VoteDetail),
+		}
+		// Fill to max voters including the existing voter
+		for i := range MaxVotersPerProposal {
+			addr := "voter" + string(rune(i))
+			proposal.Voters[addr] = &kapps.ProposalData_VoteDetail{Amount: 100}
+		}
+		proposal.Voters[existingVoter] = &kapps.ProposalData_VoteDetail{Amount: 200}
+
+		result := proposalKApp.IsVoterLimitExceeded(proposal, existingVoter)
+		require.False(t, result)
+	})
+
+	t.Run("returns false when under limit", func(t *testing.T) {
+		proposalKApp, _, forkController := createTestProposalKApp(t)
+		forkController.EpochRewardsV2Value = true
+
+		proposal := &kapps.ProposalData{
+			Voters: make(map[string]*kapps.ProposalData_VoteDetail),
+		}
+		// Add fewer than max voters
+		for i := range 10 {
+			addr := "voter" + string(rune(i))
+			proposal.Voters[addr] = &kapps.ProposalData_VoteDetail{Amount: 100}
+		}
+
+		result := proposalKApp.IsVoterLimitExceeded(proposal, "newvoter")
+		require.False(t, result)
+	})
+
+	t.Run("returns true when at limit and new voter", func(t *testing.T) {
+		proposalKApp, _, forkController := createTestProposalKApp(t)
+		forkController.EpochRewardsV2Value = true
+
+		proposal := &kapps.ProposalData{
+			Voters: make(map[string]*kapps.ProposalData_VoteDetail),
+		}
+		// Fill to exactly max voters
+		for i := range MaxVotersPerProposal {
+			addr := "voter" + string(rune(i))
+			proposal.Voters[addr] = &kapps.ProposalData_VoteDetail{Amount: 100}
+		}
+
+		result := proposalKApp.IsVoterLimitExceeded(proposal, "newvoter")
+		require.True(t, result)
+	})
+}
+
+func TestProposalKApp_processExistingVote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns 0 for non-existing voter", func(t *testing.T) {
+		proposalKApp, _, _ := createTestProposalKApp(t)
+
+		proposal := &kapps.ProposalData{
+			Voters: make(map[string]*kapps.ProposalData_VoteDetail),
+			Votes:  make(map[int32]int64),
+		}
+
+		result := proposalKApp.ProcessExistingVote(proposal, "nonexistent", kapps.ProposalData_VoteDetail_Yes)
+		require.Equal(t, int64(0), result)
+	})
+
+	t.Run("returns 0 for nil voter detail", func(t *testing.T) {
+		proposalKApp, _, _ := createTestProposalKApp(t)
+
+		proposal := &kapps.ProposalData{
+			Voters: map[string]*kapps.ProposalData_VoteDetail{
+				"voter1": nil,
+			},
+			Votes: make(map[int32]int64),
+		}
+
+		result := proposalKApp.ProcessExistingVote(proposal, "voter1", kapps.ProposalData_VoteDetail_Yes)
+		require.Equal(t, int64(0), result)
+	})
+
+	t.Run("subtracts from old type when changing vote type", func(t *testing.T) {
+		proposalKApp, _, _ := createTestProposalKApp(t)
+
+		proposal := &kapps.ProposalData{
+			Voters: map[string]*kapps.ProposalData_VoteDetail{
+				"voter1": {Type: kapps.ProposalData_VoteDetail_Yes, Amount: 500},
+			},
+			Votes: map[int32]int64{
+				int32(kapps.ProposalData_VoteDetail_Yes): 1000,
+				int32(kapps.ProposalData_VoteDetail_No):  200,
+			},
+		}
+
+		// Change from Yes to No
+		result := proposalKApp.ProcessExistingVote(proposal, "voter1", kapps.ProposalData_VoteDetail_No)
+		require.Equal(t, int64(0), result)
+		// Yes votes should be reduced by the old amount
+		require.Equal(t, int64(500), proposal.Votes[int32(kapps.ProposalData_VoteDetail_Yes)])
+	})
+
+	t.Run("returns old amount when same vote type", func(t *testing.T) {
+		proposalKApp, _, _ := createTestProposalKApp(t)
+
+		proposal := &kapps.ProposalData{
+			Voters: map[string]*kapps.ProposalData_VoteDetail{
+				"voter1": {Type: kapps.ProposalData_VoteDetail_Yes, Amount: 500},
+			},
+			Votes: map[int32]int64{
+				int32(kapps.ProposalData_VoteDetail_Yes): 1000,
+			},
+		}
+
+		// Same vote type (Yes -> Yes)
+		result := proposalKApp.ProcessExistingVote(proposal, "voter1", kapps.ProposalData_VoteDetail_Yes)
+		require.Equal(t, int64(500), result)
+		// Votes should remain unchanged
+		require.Equal(t, int64(1000), proposal.Votes[int32(kapps.ProposalData_VoteDetail_Yes)])
+	})
+}
+
+// setupVoteTest creates a proposal kapp with KAppController and necessary dependencies for Vote tests
+func setupVoteTest(t *testing.T) (*proposalKapp, state.AccountsCacher, *mock.ForkControllerStub, *stub.KAppControllerStub) {
+	proposalKApp, accCacher, forkController := createTestProposalKApp(t)
+
+	// Create KAppController stub
+	kappController := &stub.KAppControllerStub{
+		GetCurrentKAppContextCalled: func() kapp.KappContext {
+			return &mock.KAppContextStub{
+				BlockCalled: func() *block.Block {
+					return &block.Block{
+						Header: &block.BlockHeader{
+							Epoch:     5,
+							Timestamp: 1234567890,
+						},
+					}
+				},
+				ContractIDCalled: func() int { return 1 },
+				ReceiptsCalled: func() kapp.ReceiptsContext {
+					return mock.NewReceiptsContextStub()
+				},
+			}
+		},
+		GetKDAKAppCalled: func() kapp.KDAKapp {
+			return &stub.KDAKappStub{
+				GetStakingCalled: func(assetID []byte) (state.KAppAccountHandler, *kapps.StakingData, error) {
+					return nil, &kapps.StakingData{TotalStaked: 10000000}, nil
+				},
+			}
+		},
+		GetProposalControllerCalled: func() kapps.ActiveProposalController {
+			return &mock.ProposalControllerStub{
+				GetParameterIntCalled: func(param kapps.EnumParameter) int64 {
+					if param == kapps.EnumParameter_MinKFIStakedToEnableProposals {
+						return 1000 // Low threshold for testing
+					}
+					return 0
+				},
+			}
+		},
+	}
+
+	err := proposalKApp.SetKAppController(kappController)
+	require.NoError(t, err)
+
+	return proposalKApp, accCacher, forkController, kappController
+}
+
+// createActiveProposal creates and stores an active proposal with the given voters
+func createActiveProposal(t *testing.T, proposalKApp *proposalKapp, accCacher state.AccountsCacher, proposalID uint64, voters map[string]*kapps.ProposalData_VoteDetail) {
+	proposalKappAcc, err := accCacher.LoadKApp(kapps.ProposalKAppAddress)
+	require.NoError(t, err)
+
+	controller := &kapps.ProposalController{
+		ProposalCount:   proposalID,
+		ActiveProposals: make(map[uint32]*kapps.ActiveProposals),
+	}
+
+	proposal := &kapps.ProposalData{
+		Proposer:       proposerAddr,
+		TXHash:         []byte("tx-hash"),
+		ProposalStatus: kapps.ProposalData_ActiveProposal,
+		Parameters:     make(map[int32][]byte),
+		Votes:          make(map[int32]int64),
+		Voters:         voters,
+		EpochStart:     1,
+		EpochEnd:       100,
+		TotalStaked:    1000000,
+	}
+
+	err = proposalKApp.SetProposal(proposalKappAcc, proposalID, proposal, controller)
+	require.NoError(t, err)
+
+	err = accCacher.UpdateKapp(proposalKappAcc)
+	require.NoError(t, err)
+}
+
+// createVoterAccount creates a user account with KFI frozen balance for voting
+func createVoterAccount(t *testing.T, accCacher state.AccountsCacher, voterAddr []byte, frozenBalance int64) {
+	userAcc, err := accCacher.LoadUser(voterAddr)
+	require.NoError(t, err)
+
+	// Set KFI frozen balance for voting power
+	userKDA := &kapps.UserKDA{
+		Balance:       0,
+		FrozenBalance: frozenBalance,
+	}
+	err = userAcc.SetUserKDA(kdautils.KFIIdentifier, nil, userKDA)
+	require.NoError(t, err)
+
+	err = accCacher.UpdateUser(userAcc)
+	require.NoError(t, err)
+}
+
+func TestProposalKApp_Vote(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fails with invalid vote type", func(t *testing.T) {
+		proposalKApp, _, _, _ := setupVoteTest(t)
+
+		tc := &transaction.VoteContract{
+			ProposalID: 1,
+			Amount:     100,
+			Type:       99, // Invalid type
+		}
+
+		resultCode, err := proposalKApp.Vote(proposerAddr, tc)
+		require.Equal(t, transaction.Transaction_ParameterInvalid, resultCode)
+		require.Equal(t, common.ErrInvalidValue, err)
+	})
+
+	t.Run("fails with zero proposal ID", func(t *testing.T) {
+		proposalKApp, _, _, _ := setupVoteTest(t)
+
+		tc := &transaction.VoteContract{
+			ProposalID: 0,
+			Amount:     100,
+			Type:       transaction.VoteContract_Yes,
+		}
+
+		resultCode, err := proposalKApp.Vote(proposerAddr, tc)
+		require.Equal(t, transaction.Transaction_ParameterInvalid, resultCode)
+		require.Equal(t, common.ErrInvalidValue, err)
+	})
+
+	t.Run("fails with zero amount", func(t *testing.T) {
+		proposalKApp, _, _, _ := setupVoteTest(t)
+
+		tc := &transaction.VoteContract{
+			ProposalID: 1,
+			Amount:     0,
+			Type:       transaction.VoteContract_Yes,
+		}
+
+		resultCode, err := proposalKApp.Vote(proposerAddr, tc)
+		require.Equal(t, transaction.Transaction_ParameterInvalid, resultCode)
+		require.Equal(t, common.ErrInvalidValue, err)
+	})
+
+	t.Run("fails when max voters reached (EpochRewardsV2 enabled)", func(t *testing.T) {
+		proposalKApp, accCacher, forkController, _ := setupVoteTest(t)
+		forkController.EpochRewardsV2Value = true
+
+		// Create voters map at max capacity
+		voters := make(map[string]*kapps.ProposalData_VoteDetail)
+		for i := range MaxVotersPerProposal {
+			voterAddr := makeAddress(fmt.Sprintf("existingvoter%d", i))
+			encodedAddr := hex.EncodeToString(voterAddr)
+			voters[encodedAddr] = &kapps.ProposalData_VoteDetail{
+				Type:   kapps.ProposalData_VoteDetail_Yes,
+				Amount: 100,
+			}
+		}
+
+		createActiveProposal(t, proposalKApp, accCacher, 1, voters)
+
+		// Create new voter account
+		newVoter := makeAddress("newvoter")
+		createVoterAccount(t, accCacher, newVoter, 1000)
+
+		tc := &transaction.VoteContract{
+			ProposalID: 1,
+			Amount:     100,
+			Type:       transaction.VoteContract_Yes,
+		}
+
+		resultCode, err := proposalKApp.Vote(newVoter, tc)
+		require.Equal(t, transaction.Transaction_ParameterInvalid, resultCode)
+		require.Equal(t, common.ErrProposalMaxVotersReached, err)
+	})
+
+	t.Run("succeeds when max voters reached but voter already exists (update vote)", func(t *testing.T) {
+		proposalKApp, accCacher, forkController, _ := setupVoteTest(t)
+		forkController.EpochRewardsV2Value = true
+
+		existingVoter := makeAddress("existingvoter0")
+		encodedExistingVoter := hex.EncodeToString(existingVoter)
+
+		// Create voters map at max capacity including existing voter
+		voters := make(map[string]*kapps.ProposalData_VoteDetail)
+		for i := range MaxVotersPerProposal {
+			voterAddr := makeAddress(fmt.Sprintf("existingvoter%d", i))
+			encodedAddr := hex.EncodeToString(voterAddr)
+			voters[encodedAddr] = &kapps.ProposalData_VoteDetail{
+				Type:   kapps.ProposalData_VoteDetail_Yes,
+				Amount: 100,
+			}
+		}
+
+		createActiveProposal(t, proposalKApp, accCacher, 1, voters)
+
+		// Create voter account with more frozen balance
+		createVoterAccount(t, accCacher, existingVoter, 5000)
+
+		tc := &transaction.VoteContract{
+			ProposalID: 1,
+			Amount:     500, // Update with higher amount
+			Type:       transaction.VoteContract_Yes,
+		}
+
+		resultCode, err := proposalKApp.Vote(existingVoter, tc)
+		require.Equal(t, transaction.Transaction_Ok, resultCode)
+		require.NoError(t, err)
+
+		// Verify vote was updated
+		_, updatedProposal, _, err := proposalKApp.GetProposal(1)
+		require.NoError(t, err)
+		require.Equal(t, int64(500), updatedProposal.Voters[encodedExistingVoter].Amount)
+	})
+
+	t.Run("succeeds when EpochRewardsV2 disabled (no voter limit)", func(t *testing.T) {
+		proposalKApp, accCacher, forkController, _ := setupVoteTest(t)
+		forkController.EpochRewardsV2Value = false
+
+		// Create voters map at max capacity
+		voters := make(map[string]*kapps.ProposalData_VoteDetail)
+		for i := range MaxVotersPerProposal {
+			voterAddr := makeAddress(fmt.Sprintf("existingvoter%d", i))
+			encodedAddr := hex.EncodeToString(voterAddr)
+			voters[encodedAddr] = &kapps.ProposalData_VoteDetail{
+				Type:   kapps.ProposalData_VoteDetail_Yes,
+				Amount: 100,
+			}
+		}
+
+		createActiveProposal(t, proposalKApp, accCacher, 1, voters)
+
+		// Create new voter account
+		newVoter := makeAddress("newvoter")
+		createVoterAccount(t, accCacher, newVoter, 1000)
+
+		tc := &transaction.VoteContract{
+			ProposalID: 1,
+			Amount:     100,
+			Type:       transaction.VoteContract_Yes,
+		}
+
+		resultCode, err := proposalKApp.Vote(newVoter, tc)
+		require.Equal(t, transaction.Transaction_Ok, resultCode)
+		require.NoError(t, err)
+
+		// Verify vote was added (exceeding max voters since fork is disabled)
+		_, updatedProposal, _, err := proposalKApp.GetProposal(1)
+		require.NoError(t, err)
+		require.Len(t, updatedProposal.Voters, MaxVotersPerProposal+1)
+	})
+
+	t.Run("vote type change updates vote counts correctly", func(t *testing.T) {
+		proposalKApp, accCacher, forkController, _ := setupVoteTest(t)
+		forkController.EpochRewardsV2Value = true
+
+		voterAddr := makeAddress("voter")
+		encodedVoter := hex.EncodeToString(voterAddr)
+
+		// Create proposal with initial vote
+		voters := map[string]*kapps.ProposalData_VoteDetail{
+			encodedVoter: {
+				Type:   kapps.ProposalData_VoteDetail_Yes,
+				Amount: 500,
+			},
+		}
+
+		// Create proposal with initial Yes votes
+		proposalKappAcc, err := accCacher.LoadKApp(kapps.ProposalKAppAddress)
+		require.NoError(t, err)
+
+		controller := &kapps.ProposalController{
+			ProposalCount:   1,
+			ActiveProposals: make(map[uint32]*kapps.ActiveProposals),
+		}
+
+		proposal := &kapps.ProposalData{
+			Proposer:       proposerAddr,
+			TXHash:         []byte("tx-hash"),
+			ProposalStatus: kapps.ProposalData_ActiveProposal,
+			Parameters:     make(map[int32][]byte),
+			Votes: map[int32]int64{
+				int32(kapps.ProposalData_VoteDetail_Yes): 500,
+				int32(kapps.ProposalData_VoteDetail_No):  0,
+			},
+			Voters:      voters,
+			EpochStart:  1,
+			EpochEnd:    100,
+			TotalStaked: 1000000,
+		}
+
+		err = proposalKApp.SetProposal(proposalKappAcc, 1, proposal, controller)
+		require.NoError(t, err)
+		err = accCacher.UpdateKapp(proposalKappAcc)
+		require.NoError(t, err)
+
+		// Create voter account
+		createVoterAccount(t, accCacher, voterAddr, 1000)
+
+		// Change vote from Yes to No
+		tc := &transaction.VoteContract{
+			ProposalID: 1,
+			Amount:     300,
+			Type:       transaction.VoteContract_No,
+		}
+
+		resultCode, err := proposalKApp.Vote(voterAddr, tc)
+		require.Equal(t, transaction.Transaction_Ok, resultCode)
+		require.NoError(t, err)
+
+		// Verify vote counts were updated correctly
+		_, updatedProposal, _, err := proposalKApp.GetProposal(1)
+		require.NoError(t, err)
+
+		// Yes votes should be reduced by old amount (500) to 0
+		require.Equal(t, int64(0), updatedProposal.Votes[int32(kapps.ProposalData_VoteDetail_Yes)])
+		// No votes should be set to new amount (300)
+		require.Equal(t, int64(300), updatedProposal.Votes[int32(kapps.ProposalData_VoteDetail_No)])
+		// Voter should have new type and amount
+		require.Equal(t, kapps.ProposalData_VoteDetail_No, updatedProposal.Voters[encodedVoter].Type)
+		require.Equal(t, int64(300), updatedProposal.Voters[encodedVoter].Amount)
+	})
 }

--- a/core/kapp/validators/peersUpdate.go
+++ b/core/kapp/validators/peersUpdate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/big"
 
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/kapp"
@@ -279,6 +280,14 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpoch(currentEpoch uint32, validat
 		return err
 	}
 
+	if !v.forkController.EpochRewardsV2() {
+		return v.ProcessEconomicsEndOfEpochV1(currentEpoch, validatorInfos)
+	}
+
+	return v.ProcessEconomicsEndOfEpochV2(currentEpoch, validatorInfos)
+}
+
+func (v *validatorsKApp) ProcessEconomicsEndOfEpochV1(currentEpoch uint32, validatorInfos []*state.ValidatorInfo) error {
 	totalDelegations := make(map[string]int64)
 
 	// Get Validators Param from KAPP
@@ -357,7 +366,7 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpoch(currentEpoch uint32, validat
 
 		remainingFees := peerAcc.GetAccumulatedFees() - commissionAmount
 		accumulatedFees := float64(remainingFees)
-		// move accumulated to top of validators lop
+		// move accumulated to top of validators loop
 		for address, amount := range accumulatedDelegations {
 			userShare := int64(accumulatedFees * (float64(amount) / float64(totalDelegated)))
 			totalDelegations[address] += userShare
@@ -422,6 +431,7 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpoch(currentEpoch uint32, validat
 		}
 	}
 
+	// V1: Legacy approach - load and update each user account (O(N) account loads)
 	err = v.saveKApp(app)
 	if err != nil {
 		return err
@@ -448,6 +458,212 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpoch(currentEpoch uint32, validat
 			return err
 		}
 	}
+
+	return v.accountsCacher.SaveAll()
+}
+
+func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, validatorInfos []*state.ValidatorInfo) error {
+	// Get Validators Param from KAPP
+	minSelfDelegated := int64(0)
+	minTotalDelegated := int64(0)
+	if !check.IfNil(v.KAppController.GetProposalController()) {
+		minSelfDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinSelfDelegatedAmount)
+		minTotalDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinTotalDelegatedAmount)
+	}
+
+	// Cache fork controller results (called many times in hot loops)
+	// These return constant values throughout epoch processing
+	fixDelegationSameEpoch := v.forkController.FixDelegationSameEpoch()
+	enableSmartContracts := v.forkController.EnableSmartContracts()
+	fixStakingBuckets := v.forkController.FixStakingBuckets()
+
+	// get App
+	app, err := v.getKApp()
+	if err != nil {
+		return err
+	}
+
+	totalDelegations := make(map[string]int64)
+
+	for _, validatorInfo := range validatorInfos {
+		addr := validatorInfo.GetOwnerAddress()
+		validatorAddrStr := string(addr)
+
+		// Protected KApp reads
+		pd, err := v.getValidatorBuckets(app, addr)
+		if err != nil {
+			return err
+		}
+
+		// Pre-allocate maps to avoid rehashing
+		accumulatedDelegations := make(map[string]int64, len(pd.Buckets))
+		totalDelegated := int64(0)
+		totalUnDelegated := int64(0)
+		selfDelegated := int64(0)
+		keysToDelete := make([]string, 0, len(pd.Buckets))
+		delegationAddrCache := make(map[string]string, len(pd.Buckets))
+
+		// Process buckets for this validator
+		for key, delegation := range pd.Buckets {
+			delegationValue := delegation.GetValue()
+			delegatedEpoch := delegation.DelegatedEpoch
+			undelegatedEpoch := delegation.UndelegatedEpoch
+
+			if fixDelegationSameEpoch {
+				if undelegatedEpoch <= currentEpoch {
+					keysToDelete = append(keysToDelete, key)
+					totalUnDelegated += delegationValue
+					continue
+				}
+
+				delegatedEpoch += 1
+			}
+
+			delegatorAddrStr, exists := delegationAddrCache[key]
+			if !exists {
+				delegatorAddrStr = string(delegation.GetAddress())
+				delegationAddrCache[key] = delegatorAddrStr
+			}
+
+			// check self staking
+			if (delegatedEpoch == 0 || delegatedEpoch < currentEpoch) &&
+				delegatorAddrStr == validatorAddrStr {
+				selfDelegated += delegationValue
+			}
+
+			// check if user has valid delegation over 1 epoch at least
+			if delegatedEpoch == 0 || delegatedEpoch < currentEpoch {
+				accumulatedDelegations[delegatorAddrStr] += delegationValue
+				totalDelegated += delegationValue
+			}
+		}
+
+		val, err := v.getValidator(app, addr)
+		if err != nil {
+			return err
+		}
+
+		peerAcc, err := v.loadPeerAccount(val.BlsPubKey)
+		if err != nil {
+			return err
+		}
+
+		// Delete marked buckets
+		for _, key := range keysToDelete {
+			delete(pd.Buckets, key)
+		}
+
+		// Calculate commission and delegation rewards
+		accumulatedFees := peerAcc.GetAccumulatedFees()
+		commissionAmount := (accumulatedFees * int64(val.GetCommission())) / int64(core.HundredPercent)
+		rewardsAddrStr := string(val.GetRewardsAddress())
+
+		localDelegations := make(map[string]int64, len(accumulatedDelegations)+1)
+		localDelegations[rewardsAddrStr] = commissionAmount
+
+		remainingFees := accumulatedFees - commissionAmount
+		totalRemainingFees := remainingFees
+
+		// move accumulated to top of validators loop
+		for address, amount := range accumulatedDelegations {
+			// Use big.Int to prevent integer overflow
+			bigRemainingFees := big.NewInt(totalRemainingFees)
+			bigAmount := big.NewInt(amount)
+			bigTotalDelegated := big.NewInt(totalDelegated)
+
+			numerator := new(big.Int).Mul(bigRemainingFees, bigAmount)
+			result := new(big.Int).Div(numerator, bigTotalDelegated)
+			userShare := result.Int64()
+
+			// Safety: cap userShare to remaining fees to prevent negative remainder
+			userShare = min(userShare, remainingFees)
+
+			localDelegations[address] += userShare
+			remainingFees -= userShare
+		}
+
+		// remaining fees should be added to validator
+		if remainingFees != 0 && enableSmartContracts {
+			localDelegations[rewardsAddrStr] += remainingFees
+		}
+
+		for addr, amount := range localDelegations {
+			totalDelegations[addr] += amount
+		}
+
+		// Update validator and peer state
+		val.SelfStaked = val.SelfStake >= minSelfDelegated
+
+		if val.Jailed && peerAcc.GetList() != state.List_jailed {
+			val.Jailed = false
+			val.JailedEpoch = math.MaxUint32
+		}
+
+		// Update Jail/List/Slash status
+		if !val.Jailed && peerAcc.GetList() == state.List_jailed {
+			val.Jailed = true
+			val.JailedEpoch = currentEpoch
+			val.NumJailed++
+		}
+
+		if fixStakingBuckets {
+			if !enableSmartContracts {
+				totalDelegated -= totalUnDelegated
+			}
+
+			err = v.setValidatorBuckets(app, addr, pd)
+			if err != nil {
+				return err
+			}
+		}
+
+		if !val.Jailed {
+			if val.SelfStake < minSelfDelegated {
+				peerAcc.SetList(state.List_inactive)
+			} else if totalDelegated < minTotalDelegated {
+				peerAcc.SetList(state.List_waiting)
+			} else if peerAcc.GetList() != state.List_elected {
+				peerAcc.SetList(state.List_eligible)
+			}
+		}
+
+		val.Waiting = peerAcc.GetList() == state.List_waiting
+
+		val.TotalRewards += peerAcc.GetAccumulatedFees()
+
+		peerAcc.ResetAtNewEpoch()
+
+		err = v.accountsCacher.UpdatePeer(peerAcc)
+		if err != nil {
+			return err
+		}
+
+		err = v.setValidator(app, addr, val)
+		if err != nil {
+			return err
+		}
+	}
+
+	// V2: Store pending rewards in KApp data trie (O(1) account loads)
+	// This is much more scalable as we only save ONE KApp account regardless of user count
+	for address, amount := range totalDelegations {
+		if amount == 0 {
+			continue
+		}
+
+		err = v.addToPendingRewards(app, []byte(address), amount)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = v.saveKApp(app)
+	if err != nil {
+		return err
+	}
+
+	log.Debug("ProcessEconomicsEndOfEpoch v2: stored pending rewards in KApp trie",
+		"usersCount", len(totalDelegations))
 
 	return v.accountsCacher.SaveAll()
 }

--- a/core/kapp/validators/peersUpdate.go
+++ b/core/kapp/validators/peersUpdate.go
@@ -1,7 +1,6 @@
 package validators
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"math/big"
@@ -328,6 +327,344 @@ func (v *validatorsKApp) updatePeerListStatus(val *ValidatorData, peerAcc state.
 	}
 }
 
+// bucketProcessingResultV1 holds the results of processing validator buckets in V1.
+type bucketProcessingResultV1 struct {
+	accumulatedDelegations map[string]int64
+	totalDelegated         int64
+	totalUnDelegated       int64
+}
+
+// processBucketDelegationsV1 processes all buckets for a validator and returns delegation metrics.
+func (v *validatorsKApp) processBucketDelegationsV1(
+	pd *PeerData,
+	currentEpoch uint32,
+) bucketProcessingResultV1 {
+	result := bucketProcessingResultV1{
+		accumulatedDelegations: make(map[string]int64),
+	}
+
+	fixDelegationSameEpoch := v.forkController.FixDelegationSameEpoch()
+
+	for key, delegation := range pd.Buckets {
+		delegatedEpoch := delegation.GetDelegatedEpoch()
+
+		if fixDelegationSameEpoch {
+			if delegation.GetUndelegatedEpoch() <= currentEpoch {
+				delete(pd.Buckets, key)
+				result.totalUnDelegated += delegation.GetValue()
+				continue
+			}
+			delegatedEpoch += 1
+		}
+
+		v.processSingleBucketV1(&result, delegation, delegatedEpoch, currentEpoch)
+
+		if delegation.GetUndelegatedEpoch() <= currentEpoch {
+			delete(pd.Buckets, key)
+			result.totalUnDelegated += delegation.GetValue()
+		}
+	}
+
+	return result
+}
+
+// processSingleBucketV1 processes a single bucket for delegation accumulation.
+func (v *validatorsKApp) processSingleBucketV1(
+	result *bucketProcessingResultV1,
+	delegation *PeerBucket,
+	delegatedEpoch, currentEpoch uint32,
+) {
+	// check if user has valid delegation over 1 epoch at least
+	if delegation.GetDelegatedEpoch() == 0 || delegatedEpoch < currentEpoch {
+		result.accumulatedDelegations[string(delegation.GetAddress())] += delegation.GetValue()
+		result.totalDelegated += delegation.GetValue()
+	}
+}
+
+// calculateDelegationRewardsV1 calculates commission and distributes rewards among delegators.
+func (v *validatorsKApp) calculateDelegationRewardsV1(
+	val *ValidatorData,
+	accumulatedFees int64,
+	accumulatedDelegations map[string]int64,
+	totalDelegated int64,
+	totalDelegations map[string]int64,
+) {
+	validatorCommission := float64(val.GetCommission()) / float64(core.HundredPercent)
+	commissionAmount := int64(float64(accumulatedFees) * validatorCommission)
+
+	totalDelegations[string(val.GetRewardsAddress())] += commissionAmount
+
+	remainingFees := accumulatedFees - commissionAmount
+	accumulatedFeesFloat := float64(remainingFees)
+
+	for address, amount := range accumulatedDelegations {
+		userShare := int64(accumulatedFeesFloat * (float64(amount) / float64(totalDelegated)))
+		totalDelegations[address] += userShare
+		remainingFees -= userShare
+	}
+
+	// remaining fees should be added to validator
+	if remainingFees != 0 && v.forkController.EnableSmartContracts() {
+		totalDelegations[string(val.GetRewardsAddress())] += remainingFees
+	}
+}
+
+// updateUserAllowances updates user account allowances with their delegation rewards.
+func (v *validatorsKApp) updateUserAllowances(totalDelegations map[string]int64) error {
+	for address, amount := range totalDelegations {
+		if amount == 0 {
+			continue
+		}
+
+		userAcc, err := v.accountsCacher.LoadUser([]byte(address))
+		if err != nil {
+			return err
+		}
+
+		if err = userAcc.AddToAllowance(amount); err != nil {
+			return err
+		}
+
+		if err = v.accountsCacher.UpdateUser(userAcc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateStakingBucketsV1 updates staking buckets if the fork is enabled.
+func (v *validatorsKApp) updateStakingBucketsV1(
+	app state.KAppAccountHandler,
+	addr []byte,
+	pd *PeerData,
+	totalDelegated, totalUnDelegated int64,
+) (int64, error) {
+	if !v.forkController.FixStakingBuckets() {
+		return totalDelegated, nil
+	}
+
+	if !v.forkController.EnableSmartContracts() {
+		totalDelegated -= totalUnDelegated
+	}
+
+	err := v.setValidatorBuckets(app, addr, pd)
+	return totalDelegated, err
+}
+
+// processValidatorEpochV1 processes a single validator's epoch economics.
+func (v *validatorsKApp) processValidatorEpochV1(
+	app state.KAppAccountHandler,
+	validatorInfo *state.ValidatorInfo,
+	currentEpoch uint32,
+	minSelfDelegated, minTotalDelegated int64,
+	totalDelegations map[string]int64,
+) error {
+	addr := validatorInfo.GetOwnerAddress()
+
+	pd, err := v.getValidatorBuckets(app, addr)
+	if err != nil {
+		return err
+	}
+
+	bucketResult := v.processBucketDelegationsV1(pd, currentEpoch)
+
+	val, err := v.getValidator(app, addr)
+	if err != nil {
+		return err
+	}
+
+	peerAcc, err := v.loadPeerAccount(val.BlsPubKey)
+	if err != nil {
+		return err
+	}
+
+	v.calculateDelegationRewardsV1(val, peerAcc.GetAccumulatedFees(), bucketResult.accumulatedDelegations, bucketResult.totalDelegated, totalDelegations)
+
+	val.SelfStaked = val.SelfStake >= minSelfDelegated
+	v.updateValidatorJailStatus(val, peerAcc, currentEpoch)
+
+	totalDelegated, err := v.updateStakingBucketsV1(app, addr, pd, bucketResult.totalDelegated, bucketResult.totalUnDelegated)
+	if err != nil {
+		return err
+	}
+
+	v.updatePeerListStatus(val, peerAcc, minSelfDelegated, minTotalDelegated, totalDelegated)
+
+	return v.finalizeValidatorEpoch(app, addr, val, peerAcc)
+}
+
+// bucketProcessingResultV2 holds the results of processing validator buckets in V2.
+type bucketProcessingResultV2 struct {
+	accumulatedDelegations map[string]int64
+	totalDelegated         int64
+	totalUnDelegated       int64
+	keysToDelete           []string
+}
+
+// processBucketDelegationsV2 processes all buckets for a validator and returns delegation metrics (V2 optimized).
+func (v *validatorsKApp) processBucketDelegationsV2(
+	pd *PeerData,
+	currentEpoch uint32,
+	fixDelegationSameEpoch bool,
+) bucketProcessingResultV2 {
+	result := bucketProcessingResultV2{
+		accumulatedDelegations: make(map[string]int64, len(pd.Buckets)),
+		keysToDelete:           make([]string, 0, len(pd.Buckets)),
+	}
+
+	for key, delegation := range pd.Buckets {
+		delegationValue := delegation.GetValue()
+		originalDelegatedEpoch := delegation.GetDelegatedEpoch()
+		delegatedEpoch := originalDelegatedEpoch
+
+		if fixDelegationSameEpoch {
+			if delegation.GetUndelegatedEpoch() <= currentEpoch {
+				result.keysToDelete = append(result.keysToDelete, key)
+				result.totalUnDelegated += delegationValue
+				continue
+			}
+			delegatedEpoch += 1
+		}
+
+		// check if user has valid delegation over 1 epoch at least
+		if originalDelegatedEpoch == 0 || delegatedEpoch < currentEpoch {
+			result.accumulatedDelegations[string(delegation.GetAddress())] += delegationValue
+			result.totalDelegated += delegationValue
+		}
+	}
+
+	return result
+}
+
+// calculateDelegationRewardsV2 calculates commission and distributes rewards using big.Int for overflow prevention.
+func (v *validatorsKApp) calculateDelegationRewardsV2(
+	val *ValidatorData,
+	accumulatedFees int64,
+	accumulatedDelegations map[string]int64,
+	totalDelegated int64,
+	enableSmartContracts bool,
+) map[string]int64 {
+	rewardsAddrStr := string(val.GetRewardsAddress())
+	commissionAmount := (accumulatedFees * int64(val.GetCommission())) / int64(core.HundredPercent)
+
+	localDelegations := make(map[string]int64, len(accumulatedDelegations)+1)
+	localDelegations[rewardsAddrStr] = commissionAmount
+
+	remainingFees := accumulatedFees - commissionAmount
+	totalRemainingFees := remainingFees
+
+	for address, amount := range accumulatedDelegations {
+		userShare := v.calculateUserShareV2(totalRemainingFees, amount, totalDelegated)
+		userShare = min(userShare, remainingFees)
+
+		localDelegations[address] += userShare
+		remainingFees -= userShare
+	}
+
+	if remainingFees != 0 && enableSmartContracts {
+		localDelegations[rewardsAddrStr] += remainingFees
+	}
+
+	return localDelegations
+}
+
+// calculateUserShareV2 calculates a user's share using big.Int to prevent overflow.
+func (v *validatorsKApp) calculateUserShareV2(totalRemainingFees, amount, totalDelegated int64) int64 {
+	bigRemainingFees := big.NewInt(totalRemainingFees)
+	bigAmount := big.NewInt(amount)
+	bigTotalDelegated := big.NewInt(totalDelegated)
+
+	numerator := new(big.Int).Mul(bigRemainingFees, bigAmount)
+	result := new(big.Int).Div(numerator, bigTotalDelegated)
+	return result.Int64()
+}
+
+// updateStakingBucketsV2 updates staking buckets for V2 with cached fork flags.
+func (v *validatorsKApp) updateStakingBucketsV2(
+	app state.KAppAccountHandler,
+	addr []byte,
+	pd *PeerData,
+	keysToDelete []string,
+	totalDelegated, totalUnDelegated int64,
+	fixStakingBuckets, enableSmartContracts bool,
+) (int64, error) {
+	for _, key := range keysToDelete {
+		delete(pd.Buckets, key)
+	}
+
+	if !fixStakingBuckets {
+		return totalDelegated, nil
+	}
+
+	if !enableSmartContracts {
+		totalDelegated -= totalUnDelegated
+	}
+
+	err := v.setValidatorBuckets(app, addr, pd)
+	return totalDelegated, err
+}
+
+// processValidatorEpochV2 processes a single validator's epoch economics (V2 optimized).
+func (v *validatorsKApp) processValidatorEpochV2(
+	app state.KAppAccountHandler,
+	validatorInfo *state.ValidatorInfo,
+	currentEpoch uint32,
+	minSelfDelegated, minTotalDelegated int64,
+	totalDelegations map[string]int64,
+	fixDelegationSameEpoch, enableSmartContracts, fixStakingBuckets bool,
+) error {
+	addr := validatorInfo.GetOwnerAddress()
+
+	pd, err := v.getValidatorBuckets(app, addr)
+	if err != nil {
+		return err
+	}
+
+	bucketResult := v.processBucketDelegationsV2(pd, currentEpoch, fixDelegationSameEpoch)
+
+	val, err := v.getValidator(app, addr)
+	if err != nil {
+		return err
+	}
+
+	peerAcc, err := v.loadPeerAccount(val.BlsPubKey)
+	if err != nil {
+		return err
+	}
+
+	localDelegations := v.calculateDelegationRewardsV2(val, peerAcc.GetAccumulatedFees(), bucketResult.accumulatedDelegations, bucketResult.totalDelegated, enableSmartContracts)
+
+	for a, amount := range localDelegations {
+		totalDelegations[a] += amount
+	}
+
+	val.SelfStaked = val.SelfStake >= minSelfDelegated
+	v.updateValidatorJailStatus(val, peerAcc, currentEpoch)
+
+	totalDelegated, err := v.updateStakingBucketsV2(app, addr, pd, bucketResult.keysToDelete, bucketResult.totalDelegated, bucketResult.totalUnDelegated, fixStakingBuckets, enableSmartContracts)
+	if err != nil {
+		return err
+	}
+
+	v.updatePeerListStatus(val, peerAcc, minSelfDelegated, minTotalDelegated, totalDelegated)
+
+	return v.finalizeValidatorEpoch(app, addr, val, peerAcc)
+}
+
+// savePendingRewardsV2 saves all pending rewards to the KApp data trie.
+func (v *validatorsKApp) savePendingRewardsV2(app state.KAppAccountHandler, totalDelegations map[string]int64) error {
+	for address, amount := range totalDelegations {
+		if amount == 0 {
+			continue
+		}
+
+		if err := v.addToPendingRewards(app, []byte(address), amount); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // finalizeValidatorEpoch updates validator state and saves both peer and validator accounts.
 func (v *validatorsKApp) finalizeValidatorEpoch(app state.KAppAccountHandler, addr []byte, val *ValidatorData, peerAcc state.PeerAccountHandler) error {
 	val.Waiting = peerAcc.GetList() == state.List_waiting
@@ -344,139 +681,25 @@ func (v *validatorsKApp) finalizeValidatorEpoch(app state.KAppAccountHandler, ad
 
 func (v *validatorsKApp) ProcessEconomicsEndOfEpochV1(currentEpoch uint32, validatorInfos []*state.ValidatorInfo) error {
 	totalDelegations := make(map[string]int64)
-
 	minSelfDelegated, minTotalDelegated := v.getValidatorParams()
 
-	// get App
 	app, err := v.getKApp()
 	if err != nil {
 		return err
 	}
 
 	for _, validatorInfo := range validatorInfos {
-		addr := validatorInfo.GetOwnerAddress()
-		pd, err := v.getValidatorBuckets(app, addr)
-		if err != nil {
-			return err
-		}
-
-		accumulatedDelegations := make(map[string]int64)
-		totalDelegated := int64(0)
-		totalUnDelegated := int64(0)
-		selfDelegated := int64(0)
-		for key, delegation := range pd.Buckets {
-
-			delegatedEpoch := delegation.DelegatedEpoch
-
-			if v.forkController.FixDelegationSameEpoch() {
-				if delegation.UndelegatedEpoch <= currentEpoch {
-					// Delete staking from validator
-					delete(pd.Buckets, key)
-					totalUnDelegated += delegation.GetValue()
-					continue
-				}
-
-				delegatedEpoch += 1
-			}
-
-			// check self staking
-			if (delegation.DelegatedEpoch == 0 || delegation.DelegatedEpoch < currentEpoch) &&
-				bytes.Equal(addr, delegation.GetAddress()) {
-				selfDelegated += delegation.GetValue()
-			}
-
-			// check if user has valid delegation over 1 epoch at least
-			if delegation.DelegatedEpoch == 0 || delegatedEpoch < currentEpoch {
-				accumulatedDelegations[string(delegation.GetAddress())] += delegation.GetValue()
-				totalDelegated += delegation.GetValue()
-			}
-
-			if delegation.UndelegatedEpoch <= currentEpoch {
-				// Delete staking from validator
-				delete(pd.Buckets, key)
-				totalUnDelegated += delegation.GetValue()
-			}
-		}
-
-		val, err := v.getValidator(app, addr)
-		if err != nil {
-			return err
-		}
-
-		peerAcc, err := v.loadPeerAccount(val.BlsPubKey)
-		if err != nil {
-			return err
-		}
-
-		validatorCommission := float64(val.GetCommission()) / float64(core.HundredPercent)
-		commissionAmount := int64(float64(peerAcc.GetAccumulatedFees()) * validatorCommission)
-
-		totalDelegations[string(val.GetRewardsAddress())] += commissionAmount
-
-		remainingFees := peerAcc.GetAccumulatedFees() - commissionAmount
-		accumulatedFees := float64(remainingFees)
-		// move accumulated to top of validators loop
-		for address, amount := range accumulatedDelegations {
-			userShare := int64(accumulatedFees * (float64(amount) / float64(totalDelegated)))
-			totalDelegations[address] += userShare
-			remainingFees -= userShare
-		}
-
-		// remaining fees should be added to validator
-		if remainingFees != 0 &&
-			v.forkController.EnableSmartContracts() {
-			totalDelegations[string(val.GetRewardsAddress())] += remainingFees
-		}
-
-		val.SelfStaked = val.SelfStake >= minSelfDelegated
-
-		v.updateValidatorJailStatus(val, peerAcc, currentEpoch)
-
-		if v.forkController.FixStakingBuckets() {
-			if !v.forkController.EnableSmartContracts() {
-				totalDelegated -= totalUnDelegated
-			}
-
-			err = v.setValidatorBuckets(app, addr, pd)
-			if err != nil {
-				return err
-			}
-		}
-
-		v.updatePeerListStatus(val, peerAcc, minSelfDelegated, minTotalDelegated, totalDelegated)
-
-		err = v.finalizeValidatorEpoch(app, addr, val, peerAcc)
-		if err != nil {
+		if err := v.processValidatorEpochV1(app, validatorInfo, currentEpoch, minSelfDelegated, minTotalDelegated, totalDelegations); err != nil {
 			return err
 		}
 	}
 
-	// V1: Legacy approach - load and update each user account (O(N) account loads)
-	err = v.saveKApp(app)
-	if err != nil {
+	if err = v.saveKApp(app); err != nil {
 		return err
 	}
 
-	// update to account allowance (REAWARDS to claim)
-	for address, amount := range totalDelegations {
-		if amount == 0 {
-			continue
-		}
-
-		userAcc, err := v.accountsCacher.LoadUser([]byte(address))
-		if err != nil {
-			return err
-		}
-
-		err = userAcc.AddToAllowance(amount)
-		if err != nil {
-			return err
-		}
-
-		err = v.accountsCacher.UpdateUser(userAcc)
-		if err != nil {
-			return err
-		}
+	if err = v.updateUserAllowances(totalDelegations); err != nil {
+		return err
 	}
 
 	return v.accountsCacher.SaveAll()
@@ -486,12 +709,10 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, valid
 	minSelfDelegated, minTotalDelegated := v.getValidatorParams()
 
 	// Cache fork controller results (called many times in hot loops)
-	// These return constant values throughout epoch processing
 	fixDelegationSameEpoch := v.forkController.FixDelegationSameEpoch()
 	enableSmartContracts := v.forkController.EnableSmartContracts()
 	fixStakingBuckets := v.forkController.FixStakingBuckets()
 
-	// get App
 	app, err := v.getKApp()
 	if err != nil {
 		return err
@@ -500,147 +721,16 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, valid
 	totalDelegations := make(map[string]int64)
 
 	for _, validatorInfo := range validatorInfos {
-		addr := validatorInfo.GetOwnerAddress()
-		validatorAddrStr := string(addr)
-
-		// Protected KApp reads
-		pd, err := v.getValidatorBuckets(app, addr)
-		if err != nil {
-			return err
-		}
-
-		// Pre-allocate maps to avoid rehashing
-		accumulatedDelegations := make(map[string]int64, len(pd.Buckets))
-		totalDelegated := int64(0)
-		totalUnDelegated := int64(0)
-		selfDelegated := int64(0)
-		keysToDelete := make([]string, 0, len(pd.Buckets))
-
-		// Process buckets for this validator
-		for key, delegation := range pd.Buckets {
-			delegationValue := delegation.GetValue()
-			originalDelegatedEpoch := delegation.DelegatedEpoch
-			delegatedEpoch := originalDelegatedEpoch
-			undelegatedEpoch := delegation.UndelegatedEpoch
-
-			if fixDelegationSameEpoch {
-				if undelegatedEpoch <= currentEpoch {
-					keysToDelete = append(keysToDelete, key)
-					totalUnDelegated += delegationValue
-					continue
-				}
-
-				delegatedEpoch += 1
-			}
-
-			delegatorAddrStr := string(delegation.GetAddress())
-
-			// check self staking (use original epoch to match V1 behavior)
-			if (originalDelegatedEpoch == 0 || originalDelegatedEpoch < currentEpoch) &&
-				delegatorAddrStr == validatorAddrStr {
-				selfDelegated += delegationValue
-			}
-
-			// check if user has valid delegation over 1 epoch at least
-			// Use original epoch for == 0 check, modified epoch for < currentEpoch (matches V1)
-			if originalDelegatedEpoch == 0 || delegatedEpoch < currentEpoch {
-				accumulatedDelegations[delegatorAddrStr] += delegationValue
-				totalDelegated += delegationValue
-			}
-		}
-
-		val, err := v.getValidator(app, addr)
-		if err != nil {
-			return err
-		}
-
-		peerAcc, err := v.loadPeerAccount(val.BlsPubKey)
-		if err != nil {
-			return err
-		}
-
-		// Delete marked buckets
-		for _, key := range keysToDelete {
-			delete(pd.Buckets, key)
-		}
-
-		// Calculate commission and delegation rewards
-		accumulatedFees := peerAcc.GetAccumulatedFees()
-		commissionAmount := (accumulatedFees * int64(val.GetCommission())) / int64(core.HundredPercent)
-		rewardsAddrStr := string(val.GetRewardsAddress())
-
-		localDelegations := make(map[string]int64, len(accumulatedDelegations)+1)
-		localDelegations[rewardsAddrStr] = commissionAmount
-
-		remainingFees := accumulatedFees - commissionAmount
-		totalRemainingFees := remainingFees
-
-		// move accumulated to top of validators loop
-		for address, amount := range accumulatedDelegations {
-			// Use big.Int to prevent integer overflow
-			bigRemainingFees := big.NewInt(totalRemainingFees)
-			bigAmount := big.NewInt(amount)
-			bigTotalDelegated := big.NewInt(totalDelegated)
-
-			numerator := new(big.Int).Mul(bigRemainingFees, bigAmount)
-			result := new(big.Int).Div(numerator, bigTotalDelegated)
-			userShare := result.Int64()
-
-			// Safety: cap userShare to remaining fees to prevent negative remainder
-			userShare = min(userShare, remainingFees)
-
-			localDelegations[address] += userShare
-			remainingFees -= userShare
-		}
-
-		// remaining fees should be added to validator
-		if remainingFees != 0 && enableSmartContracts {
-			localDelegations[rewardsAddrStr] += remainingFees
-		}
-
-		for addr, amount := range localDelegations {
-			totalDelegations[addr] += amount
-		}
-
-		// Update validator and peer state
-		val.SelfStaked = val.SelfStake >= minSelfDelegated
-
-		v.updateValidatorJailStatus(val, peerAcc, currentEpoch)
-
-		if fixStakingBuckets {
-			if !enableSmartContracts {
-				totalDelegated -= totalUnDelegated
-			}
-
-			err = v.setValidatorBuckets(app, addr, pd)
-			if err != nil {
-				return err
-			}
-		}
-
-		v.updatePeerListStatus(val, peerAcc, minSelfDelegated, minTotalDelegated, totalDelegated)
-
-		err = v.finalizeValidatorEpoch(app, addr, val, peerAcc)
-		if err != nil {
+		if err := v.processValidatorEpochV2(app, validatorInfo, currentEpoch, minSelfDelegated, minTotalDelegated, totalDelegations, fixDelegationSameEpoch, enableSmartContracts, fixStakingBuckets); err != nil {
 			return err
 		}
 	}
 
-	// V2: Store pending rewards in KApp data trie (O(1) account loads)
-	// This is much more scalable as we only save ONE KApp account regardless of user count
-	for address, amount := range totalDelegations {
-		if amount == 0 {
-			continue
-		}
-
-		err = v.addToPendingRewards(app, []byte(address), amount)
-		if err != nil {
-			return err
-		}
+	if err = v.savePendingRewardsV2(app, totalDelegations); err != nil {
+		return err
 	}
 
-	err = v.saveKApp(app)
-	if err != nil {
+	if err = v.saveKApp(app); err != nil {
 		return err
 	}
 

--- a/core/kapp/validators/peersUpdate.go
+++ b/core/kapp/validators/peersUpdate.go
@@ -505,7 +505,6 @@ type bucketProcessingResultV2 struct {
 func (v *validatorsKApp) processBucketDelegationsV2(
 	pd *PeerData,
 	currentEpoch uint32,
-	fixDelegationSameEpoch bool,
 ) bucketProcessingResultV2 {
 	result := bucketProcessingResultV2{
 		accumulatedDelegations: make(map[string]int64, len(pd.Buckets)),
@@ -517,7 +516,7 @@ func (v *validatorsKApp) processBucketDelegationsV2(
 		originalDelegatedEpoch := delegation.GetDelegatedEpoch()
 		delegatedEpoch := originalDelegatedEpoch
 
-		if fixDelegationSameEpoch {
+		if v.forkController.FixDelegationSameEpoch() {
 			if delegation.GetUndelegatedEpoch() <= currentEpoch {
 				result.keysToDelete = append(result.keysToDelete, key)
 				result.totalUnDelegated += delegationValue
@@ -542,7 +541,6 @@ func (v *validatorsKApp) calculateDelegationRewardsV2(
 	accumulatedFees int64,
 	accumulatedDelegations map[string]int64,
 	totalDelegated int64,
-	enableSmartContracts bool,
 ) map[string]int64 {
 	rewardsAddrStr := string(val.GetRewardsAddress())
 	commissionAmount := (accumulatedFees * int64(val.GetCommission())) / int64(core.HundredPercent)
@@ -561,7 +559,7 @@ func (v *validatorsKApp) calculateDelegationRewardsV2(
 		remainingFees -= userShare
 	}
 
-	if remainingFees != 0 && enableSmartContracts {
+	if remainingFees != 0 && v.forkController.EnableSmartContracts() {
 		localDelegations[rewardsAddrStr] += remainingFees
 	}
 
@@ -579,24 +577,23 @@ func (v *validatorsKApp) calculateUserShareV2(totalRemainingFees, amount, totalD
 	return result.Int64()
 }
 
-// updateStakingBucketsV2 updates staking buckets for V2 with cached fork flags.
+// updateStakingBucketsV2 updates staking buckets for V2.
 func (v *validatorsKApp) updateStakingBucketsV2(
 	app state.KAppAccountHandler,
 	addr []byte,
 	pd *PeerData,
 	keysToDelete []string,
 	totalDelegated, totalUnDelegated int64,
-	fixStakingBuckets, enableSmartContracts bool,
 ) (int64, error) {
 	for _, key := range keysToDelete {
 		delete(pd.Buckets, key)
 	}
 
-	if !fixStakingBuckets {
+	if !v.forkController.FixStakingBuckets() {
 		return totalDelegated, nil
 	}
 
-	if !enableSmartContracts {
+	if !v.forkController.EnableSmartContracts() {
 		totalDelegated -= totalUnDelegated
 	}
 
@@ -611,7 +608,6 @@ func (v *validatorsKApp) processValidatorEpochV2(
 	currentEpoch uint32,
 	minSelfDelegated, minTotalDelegated int64,
 	totalDelegations map[string]int64,
-	fixDelegationSameEpoch, enableSmartContracts, fixStakingBuckets bool,
 ) error {
 	addr := validatorInfo.GetOwnerAddress()
 
@@ -620,7 +616,7 @@ func (v *validatorsKApp) processValidatorEpochV2(
 		return err
 	}
 
-	bucketResult := v.processBucketDelegationsV2(pd, currentEpoch, fixDelegationSameEpoch)
+	bucketResult := v.processBucketDelegationsV2(pd, currentEpoch)
 
 	val, err := v.getValidator(app, addr)
 	if err != nil {
@@ -632,7 +628,7 @@ func (v *validatorsKApp) processValidatorEpochV2(
 		return err
 	}
 
-	localDelegations := v.calculateDelegationRewardsV2(val, peerAcc.GetAccumulatedFees(), bucketResult.accumulatedDelegations, bucketResult.totalDelegated, enableSmartContracts)
+	localDelegations := v.calculateDelegationRewardsV2(val, peerAcc.GetAccumulatedFees(), bucketResult.accumulatedDelegations, bucketResult.totalDelegated)
 
 	for a, amount := range localDelegations {
 		totalDelegations[a] += amount
@@ -641,7 +637,7 @@ func (v *validatorsKApp) processValidatorEpochV2(
 	val.SelfStaked = val.SelfStake >= minSelfDelegated
 	v.updateValidatorJailStatus(val, peerAcc, currentEpoch)
 
-	totalDelegated, err := v.updateStakingBucketsV2(app, addr, pd, bucketResult.keysToDelete, bucketResult.totalDelegated, bucketResult.totalUnDelegated, fixStakingBuckets, enableSmartContracts)
+	totalDelegated, err := v.updateStakingBucketsV2(app, addr, pd, bucketResult.keysToDelete, bucketResult.totalDelegated, bucketResult.totalUnDelegated)
 	if err != nil {
 		return err
 	}
@@ -708,11 +704,6 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV1(currentEpoch uint32, valid
 func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, validatorInfos []*state.ValidatorInfo) error {
 	minSelfDelegated, minTotalDelegated := v.getValidatorParams()
 
-	// Cache fork controller results (called many times in hot loops)
-	fixDelegationSameEpoch := v.forkController.FixDelegationSameEpoch()
-	enableSmartContracts := v.forkController.EnableSmartContracts()
-	fixStakingBuckets := v.forkController.FixStakingBuckets()
-
 	app, err := v.getKApp()
 	if err != nil {
 		return err
@@ -721,7 +712,7 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, valid
 	totalDelegations := make(map[string]int64)
 
 	for _, validatorInfo := range validatorInfos {
-		if err := v.processValidatorEpochV2(app, validatorInfo, currentEpoch, minSelfDelegated, minTotalDelegated, totalDelegations, fixDelegationSameEpoch, enableSmartContracts, fixStakingBuckets); err != nil {
+		if err := v.processValidatorEpochV2(app, validatorInfo, currentEpoch, minSelfDelegated, minTotalDelegated, totalDelegations); err != nil {
 			return err
 		}
 	}

--- a/core/kapp/validators/peersUpdate.go
+++ b/core/kapp/validators/peersUpdate.go
@@ -501,12 +501,12 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, valid
 		totalUnDelegated := int64(0)
 		selfDelegated := int64(0)
 		keysToDelete := make([]string, 0, len(pd.Buckets))
-		delegationAddrCache := make(map[string]string, len(pd.Buckets))
 
 		// Process buckets for this validator
 		for key, delegation := range pd.Buckets {
 			delegationValue := delegation.GetValue()
-			delegatedEpoch := delegation.DelegatedEpoch
+			originalDelegatedEpoch := delegation.DelegatedEpoch
+			delegatedEpoch := originalDelegatedEpoch
 			undelegatedEpoch := delegation.UndelegatedEpoch
 
 			if fixDelegationSameEpoch {
@@ -519,20 +519,17 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, valid
 				delegatedEpoch += 1
 			}
 
-			delegatorAddrStr, exists := delegationAddrCache[key]
-			if !exists {
-				delegatorAddrStr = string(delegation.GetAddress())
-				delegationAddrCache[key] = delegatorAddrStr
-			}
+			delegatorAddrStr := string(delegation.GetAddress())
 
-			// check self staking
-			if (delegatedEpoch == 0 || delegatedEpoch < currentEpoch) &&
+			// check self staking (use original epoch to match V1 behavior)
+			if (originalDelegatedEpoch == 0 || originalDelegatedEpoch < currentEpoch) &&
 				delegatorAddrStr == validatorAddrStr {
 				selfDelegated += delegationValue
 			}
 
 			// check if user has valid delegation over 1 epoch at least
-			if delegatedEpoch == 0 || delegatedEpoch < currentEpoch {
+			// Use original epoch for == 0 check, modified epoch for < currentEpoch (matches V1)
+			if originalDelegatedEpoch == 0 || delegatedEpoch < currentEpoch {
 				accumulatedDelegations[delegatorAddrStr] += delegationValue
 				totalDelegated += delegationValue
 			}

--- a/core/kapp/validators/peersUpdate.go
+++ b/core/kapp/validators/peersUpdate.go
@@ -287,16 +287,65 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpoch(currentEpoch uint32, validat
 	return v.ProcessEconomicsEndOfEpochV2(currentEpoch, validatorInfos)
 }
 
+// getValidatorParams returns the minimum self-delegated and total-delegated amounts from proposal controller.
+func (v *validatorsKApp) getValidatorParams() (minSelfDelegated, minTotalDelegated int64) {
+	if check.IfNil(v.KAppController.GetProposalController()) {
+		return 0, 0
+	}
+	minSelfDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinSelfDelegatedAmount)
+	minTotalDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinTotalDelegatedAmount)
+	return minSelfDelegated, minTotalDelegated
+}
+
+// updateValidatorJailStatus synchronizes the validator's jail status with the peer account list.
+func (v *validatorsKApp) updateValidatorJailStatus(val *ValidatorData, peerAcc state.PeerAccountHandler, currentEpoch uint32) {
+	// Clear jail if peer is no longer in jailed list
+	if val.Jailed && peerAcc.GetList() != state.List_jailed {
+		val.Jailed = false
+		val.JailedEpoch = math.MaxUint32
+	}
+
+	// Set jail if peer was just jailed
+	if !val.Jailed && peerAcc.GetList() == state.List_jailed {
+		val.Jailed = true
+		val.JailedEpoch = currentEpoch
+		val.NumJailed++
+	}
+}
+
+// updatePeerListStatus updates the peer account's list status based on delegation amounts.
+func (v *validatorsKApp) updatePeerListStatus(val *ValidatorData, peerAcc state.PeerAccountHandler, minSelfDelegated, minTotalDelegated, totalDelegated int64) {
+	if val.Jailed {
+		return
+	}
+
+	if val.SelfStake < minSelfDelegated {
+		peerAcc.SetList(state.List_inactive)
+	} else if totalDelegated < minTotalDelegated {
+		peerAcc.SetList(state.List_waiting)
+	} else if peerAcc.GetList() != state.List_elected {
+		peerAcc.SetList(state.List_eligible)
+	}
+}
+
+// finalizeValidatorEpoch updates validator state and saves both peer and validator accounts.
+func (v *validatorsKApp) finalizeValidatorEpoch(app state.KAppAccountHandler, addr []byte, val *ValidatorData, peerAcc state.PeerAccountHandler) error {
+	val.Waiting = peerAcc.GetList() == state.List_waiting
+	val.TotalRewards += peerAcc.GetAccumulatedFees()
+
+	peerAcc.ResetAtNewEpoch()
+
+	if err := v.accountsCacher.UpdatePeer(peerAcc); err != nil {
+		return err
+	}
+
+	return v.setValidator(app, addr, val)
+}
+
 func (v *validatorsKApp) ProcessEconomicsEndOfEpochV1(currentEpoch uint32, validatorInfos []*state.ValidatorInfo) error {
 	totalDelegations := make(map[string]int64)
 
-	// Get Validators Param from KAPP
-	minSelfDelegated := int64(0)
-	minTotalDelegated := int64(0)
-	if !check.IfNil(v.KAppController.GetProposalController()) {
-		minSelfDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinSelfDelegatedAmount)
-		minTotalDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinTotalDelegatedAmount)
-	}
+	minSelfDelegated, minTotalDelegated := v.getValidatorParams()
 
 	// get App
 	app, err := v.getKApp()
@@ -381,17 +430,7 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV1(currentEpoch uint32, valid
 
 		val.SelfStaked = val.SelfStake >= minSelfDelegated
 
-		if val.Jailed && peerAcc.GetList() != state.List_jailed {
-			val.Jailed = false
-			val.JailedEpoch = math.MaxUint32
-		}
-
-		// Update Jail/List/Slash status
-		if !val.Jailed && peerAcc.GetList() == state.List_jailed {
-			val.Jailed = true
-			val.JailedEpoch = currentEpoch
-			val.NumJailed++
-		}
+		v.updateValidatorJailStatus(val, peerAcc, currentEpoch)
 
 		if v.forkController.FixStakingBuckets() {
 			if !v.forkController.EnableSmartContracts() {
@@ -404,28 +443,9 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV1(currentEpoch uint32, valid
 			}
 		}
 
-		if !val.Jailed {
-			if val.SelfStake < minSelfDelegated {
-				peerAcc.SetList(state.List_inactive)
-			} else if totalDelegated < minTotalDelegated {
-				peerAcc.SetList(state.List_waiting)
-			} else if peerAcc.GetList() != state.List_elected {
-				peerAcc.SetList(state.List_eligible)
-			}
-		}
+		v.updatePeerListStatus(val, peerAcc, minSelfDelegated, minTotalDelegated, totalDelegated)
 
-		val.Waiting = peerAcc.GetList() == state.List_waiting
-
-		val.TotalRewards += peerAcc.GetAccumulatedFees()
-
-		peerAcc.ResetAtNewEpoch()
-
-		err = v.accountsCacher.UpdatePeer(peerAcc)
-		if err != nil {
-			return err
-		}
-
-		err = v.setValidator(app, addr, val)
+		err = v.finalizeValidatorEpoch(app, addr, val, peerAcc)
 		if err != nil {
 			return err
 		}
@@ -463,13 +483,7 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV1(currentEpoch uint32, valid
 }
 
 func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, validatorInfos []*state.ValidatorInfo) error {
-	// Get Validators Param from KAPP
-	minSelfDelegated := int64(0)
-	minTotalDelegated := int64(0)
-	if !check.IfNil(v.KAppController.GetProposalController()) {
-		minSelfDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinSelfDelegatedAmount)
-		minTotalDelegated = v.KAppController.GetProposalController().GetParameterInt(kapps.EnumParameter_MinTotalDelegatedAmount)
-	}
+	minSelfDelegated, minTotalDelegated := v.getValidatorParams()
 
 	// Cache fork controller results (called many times in hot loops)
 	// These return constant values throughout epoch processing
@@ -591,17 +605,7 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, valid
 		// Update validator and peer state
 		val.SelfStaked = val.SelfStake >= minSelfDelegated
 
-		if val.Jailed && peerAcc.GetList() != state.List_jailed {
-			val.Jailed = false
-			val.JailedEpoch = math.MaxUint32
-		}
-
-		// Update Jail/List/Slash status
-		if !val.Jailed && peerAcc.GetList() == state.List_jailed {
-			val.Jailed = true
-			val.JailedEpoch = currentEpoch
-			val.NumJailed++
-		}
+		v.updateValidatorJailStatus(val, peerAcc, currentEpoch)
 
 		if fixStakingBuckets {
 			if !enableSmartContracts {
@@ -614,28 +618,9 @@ func (v *validatorsKApp) ProcessEconomicsEndOfEpochV2(currentEpoch uint32, valid
 			}
 		}
 
-		if !val.Jailed {
-			if val.SelfStake < minSelfDelegated {
-				peerAcc.SetList(state.List_inactive)
-			} else if totalDelegated < minTotalDelegated {
-				peerAcc.SetList(state.List_waiting)
-			} else if peerAcc.GetList() != state.List_elected {
-				peerAcc.SetList(state.List_eligible)
-			}
-		}
+		v.updatePeerListStatus(val, peerAcc, minSelfDelegated, minTotalDelegated, totalDelegated)
 
-		val.Waiting = peerAcc.GetList() == state.List_waiting
-
-		val.TotalRewards += peerAcc.GetAccumulatedFees()
-
-		peerAcc.ResetAtNewEpoch()
-
-		err = v.accountsCacher.UpdatePeer(peerAcc)
-		if err != nil {
-			return err
-		}
-
-		err = v.setValidator(app, addr, val)
+		err = v.finalizeValidatorEpoch(app, addr, val, peerAcc)
 		if err != nil {
 			return err
 		}

--- a/core/kapp/validators/peersUpdate_bench_test.go
+++ b/core/kapp/validators/peersUpdate_bench_test.go
@@ -1,0 +1,391 @@
+package validators
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/process/rating"
+	"github.com/klever-io/klever-go/crypto/hashing/sha256"
+	"github.com/klever-io/klever-go/data/state"
+	"github.com/klever-io/klever-go/data/state/factory"
+	"github.com/klever-io/klever-go/data/trie"
+	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/kvm/mock/stub"
+	"github.com/klever-io/klever-go/storage"
+	"github.com/klever-io/klever-go/storage/leveldb"
+	"github.com/klever-io/klever-go/storage/storageUnit"
+	"github.com/klever-io/klever-go/tools/marshal"
+)
+
+// BenchmarkProcessEconomicsEndOfEpoch_Production simulates production-like conditions:
+// - 21 validators (like mainnet)
+// - 5000 buckets per validator (~100k delegators)
+// - Pre-populated user trie with 500k dummy accounts to simulate deep trie
+// - Cache reset between iterations to simulate cold storage
+//
+// This benchmark shows the full ProcessEconomicsEndOfEpoch performance including
+// bucket iteration and reward distribution.
+func BenchmarkProcessEconomicsEndOfEpoch_Production(b *testing.B) {
+	const prodValidators = 21
+	const prodBucketsPerValidator = 4500 // Max ~5500 due to MaxLeafSize=786KB limit in trackableDataTrie.go
+	const dummyAccounts = 500000         // Pre-populate trie to make it deep
+
+	b.Run("V1_Allowance", func(b *testing.B) {
+		v, validatorInfos, accCacher, cleanup := setupProductionBenchmark(b, prodValidators, prodBucketsPerValidator, dummyAccounts, false)
+		defer cleanup()
+
+		currentEpoch := uint32(10)
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			accCacher.ResetAll(true)
+
+			for _, vi := range validatorInfos {
+				peerAcc, _ := v.accountsCacher.LoadPeer(vi.PublicKey)
+				peerAcc.AddToAccumulatedFees(1000000)
+			}
+
+			err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+			if err != nil {
+				b.Fatalf("ProcessEconomicsEndOfEpoch failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("V2_PendingRewards", func(b *testing.B) {
+		v, validatorInfos, accCacher, cleanup := setupProductionBenchmark(b, prodValidators, prodBucketsPerValidator, dummyAccounts, true)
+		defer cleanup()
+
+		currentEpoch := uint32(10)
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			accCacher.ResetAll(true)
+
+			for _, vi := range validatorInfos {
+				peerAcc, _ := v.accountsCacher.LoadPeer(vi.PublicKey)
+				peerAcc.AddToAccumulatedFees(1000000)
+			}
+
+			err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+			if err != nil {
+				b.Fatalf("ProcessEconomicsEndOfEpoch failed: %v", err)
+			}
+		}
+	})
+}
+
+// BenchmarkUserAccountLoading_V1vsV2 isolates the critical difference between V1 and V2:
+// - V1: Loads N user accounts from trie and updates allowance (expensive)
+// - V2: Writes N entries to KApp storage (cheap)
+//
+// This benchmark clearly shows the bottleneck that V2 solves:
+// V1 must traverse the user accounts trie for each delegator,
+// while V2 only writes to a single KApp account's storage.
+func BenchmarkUserAccountLoading_V1vsV2(b *testing.B) {
+	const numUsers = 100000
+	const dummyAccounts = 500000
+
+	b.Run("V1_LoadUserAccounts", func(b *testing.B) {
+		tempDir, _ := os.MkdirTemp("", "bench_v1_*")
+		defer os.RemoveAll(tempDir)
+
+		userStorer := createLevelDBStorer(b, tempDir+"/users")
+		defer userStorer.DestroyUnit()
+
+		hasher := &sha256.Sha256{}
+		marshalizer := marshal.NewProtoMarshalizer()
+		userTrieManager, _ := trie.NewTrieStorageManagerWithoutPruning(userStorer)
+		userTrie, _ := trie.NewTrie(userTrieManager, marshalizer, hasher, 5)
+		userAccountsDB, _ := state.NewAccountsDB(userTrie, hasher, marshalizer, factory.NewAccountCreator(), core.Normal)
+
+		// Pre-populate with dummy accounts for deep trie
+		b.Logf("Creating %d dummy accounts...", dummyAccounts)
+		dummyAddrs := generateRandomAddresses(dummyAccounts)
+		for i, addr := range dummyAddrs {
+			acc, _ := userAccountsDB.LoadAccount(addr)
+			userAccountsDB.SaveAccount(acc)
+			if i%100000 == 0 {
+				userAccountsDB.Commit()
+			}
+		}
+		userAccountsDB.Commit()
+
+		// Create target user addresses
+		userAddrs := generateRandomAddresses(numUsers)
+		for _, addr := range userAddrs {
+			acc, _ := userAccountsDB.LoadAccount(addr)
+			userAccountsDB.SaveAccount(acc)
+		}
+		userAccountsDB.Commit()
+		b.Logf("Setup complete: %d users in trie with %d dummy accounts", numUsers, dummyAccounts)
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			// V1: Load each user account and update allowance
+			for _, addr := range userAddrs {
+				acc, _ := userAccountsDB.LoadAccount(addr)
+				userAcc := acc.(state.UserAccountHandler)
+				userAcc.AddToAllowance(1000)
+				userAccountsDB.SaveAccount(acc)
+			}
+			userAccountsDB.Commit()
+		}
+	})
+
+	b.Run("V2_KAppStorageWrite", func(b *testing.B) {
+		tempDir, _ := os.MkdirTemp("", "bench_v2_*")
+		defer os.RemoveAll(tempDir)
+
+		kappStorer := createLevelDBStorer(b, tempDir+"/kapps")
+		defer kappStorer.DestroyUnit()
+
+		hasher := &sha256.Sha256{}
+		marshalizer := marshal.NewProtoMarshalizer()
+		kappTrieManager, _ := trie.NewTrieStorageManagerWithoutPruning(kappStorer)
+		kappTrie, _ := trie.NewTrie(kappTrieManager, marshalizer, hasher, 5)
+		kappAccountsDB, _ := state.NewAccountsDB(kappTrie, hasher, marshalizer, factory.NewKAppAccountCreator(), core.Normal)
+
+		// Load KApp account
+		kappAcc, _ := kappAccountsDB.LoadAccount(kapps.ValidatorsKAppAddress)
+
+		// Create target user addresses
+		userAddrs := generateRandomAddresses(numUsers)
+		b.Logf("Setup complete: ready to write %d pending rewards entries", numUsers)
+
+		b.ResetTimer()
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			// V2: Write pending rewards to KApp storage
+			kappHandler := kappAcc.(state.KAppAccountHandler)
+			for _, addr := range userAddrs {
+				key := append([]byte("pendingRewards_"), addr...)
+				// Simulate adding to pending rewards (8 bytes for int64)
+				kappHandler.SetStorage(key, make([]byte, 8))
+			}
+			kappAccountsDB.SaveAccount(kappAcc)
+			kappAccountsDB.Commit()
+		}
+	})
+}
+
+// setupProductionBenchmark creates a production-like environment with a deep user accounts trie
+func setupProductionBenchmark(b *testing.B, numValidators, bucketsPerValidator, dummyAccounts int, useV2 bool) (*validatorsKApp, []*state.ValidatorInfo, state.AccountsCacher, func()) {
+	b.Helper()
+
+	tempDir, err := os.MkdirTemp("", "bench_prod_*")
+	if err != nil {
+		b.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	userStorer := createLevelDBStorer(b, tempDir+"/users")
+	kappStorer := createLevelDBStorer(b, tempDir+"/kapps")
+	peerStorer := createLevelDBStorer(b, tempDir+"/peers")
+
+	hasher := &sha256.Sha256{}
+	marshalizer := marshal.NewProtoMarshalizer()
+
+	userTrieManager, _ := trie.NewTrieStorageManagerWithoutPruning(userStorer)
+	kappTrieManager, _ := trie.NewTrieStorageManagerWithoutPruning(kappStorer)
+	peerTrieManager, _ := trie.NewTrieStorageManagerWithoutPruning(peerStorer)
+
+	userTrie, _ := trie.NewTrie(userTrieManager, marshalizer, hasher, 5)
+	kappTrie, _ := trie.NewTrie(kappTrieManager, marshalizer, hasher, 5)
+	peerTrie, _ := trie.NewTrie(peerTrieManager, marshalizer, hasher, 5)
+
+	userAccountsDB, _ := state.NewAccountsDB(userTrie, hasher, marshalizer, factory.NewAccountCreator(), core.Normal)
+	kappAccountsDB, _ := state.NewAccountsDB(kappTrie, hasher, marshalizer, factory.NewKAppAccountCreator(), core.Normal)
+	peerAccountsDB, _ := state.NewAccountsDB(peerTrie, hasher, marshalizer, factory.NewPeerAccountCreator(), core.Normal)
+
+	accCacher, _ := state.NewAccountsCacher(state.ArgsAcccountCacher{
+		Accounts: userAccountsDB,
+		Kapps:    kappAccountsDB,
+		Peers:    peerAccountsDB,
+	})
+	accCacher.ResetAll(true)
+
+	// PRE-POPULATE user trie with dummy accounts to simulate production depth
+	b.Logf("Pre-populating user trie with %d dummy accounts...", dummyAccounts)
+	dummyAddresses := generateRandomAddresses(dummyAccounts)
+	for i, addr := range dummyAddresses {
+		userAcc, _ := accCacher.LoadUser(addr)
+		userAcc.AddToBalance(1000000, nil, false) // Give them some balance
+		if i%50000 == 0 {
+			// Save periodically to avoid memory buildup
+			accCacher.SaveAll()
+			accCacher.ResetAll(true)
+		}
+	}
+	accCacher.SaveAll()
+	accCacher.ResetAll(true)
+	b.Logf("User trie pre-populated")
+
+	// Create validators KApp
+	args := createMockArgs()
+	v, _ := NewValidatorKApp(args)
+	v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = useV2
+	v.forkController.(*mock.ForkControllerStub).FixDelegationSameEpochValue = true
+
+	mockProposalController := &mock.ProposalControllerStub{
+		GetParameterIntCalled: func(param kapps.EnumParameter) int64 {
+			switch param {
+			case kapps.EnumParameter_MinSelfDelegatedAmount:
+				return 100000
+			case kapps.EnumParameter_MinTotalDelegatedAmount:
+				return 500000
+			default:
+				return 0
+			}
+		},
+	}
+	v.KAppController = &stub.KAppControllerStub{
+		GetProposalControllerCalled: func() kapps.ActiveProposalController {
+			return mockProposalController
+		},
+	}
+	v.SetAccountsCacher(accCacher)
+
+	rd := createDefaultRatingsData()
+	bsr, _ := rating.NewBlockSigningRater(rd)
+	v.SetRater(bsr)
+
+	// Generate delegator addresses (separate from dummy accounts)
+	userAddresses := generateRandomAddresses(numValidators * bucketsPerValidator)
+	validatorInfos := make([]*state.ValidatorInfo, numValidators)
+
+	kappAcc, _ := accCacher.LoadKApp(kapps.ValidatorsKAppAddress)
+
+	for i := 0; i < numValidators; i++ {
+		validatorAddr := []byte(fmt.Sprintf("validator%04d________________", i))[:32]
+		blsPubKey := []byte(fmt.Sprintf("blspubkey%04d_______________", i))[:32]
+
+		validatorInfos[i] = &state.ValidatorInfo{
+			PublicKey:    blsPubKey,
+			OwnerAddress: validatorAddr,
+			List:         string(state.List_eligible),
+			TempRating:   5000000,
+		}
+
+		peerAcc, _ := accCacher.LoadPeer(blsPubKey)
+		peerAcc.SetListAndIndex(state.List_eligible, 0)
+		peerAcc.SetTempRating(5000000)
+
+		validatorData := &ValidatorData{
+			BlsPubKey:      blsPubKey,
+			RewardsAddress: validatorAddr,
+			Commission:     1000,
+			SelfStake:      1000000,
+		}
+		validatorKey := []byte(VALIDATOR_PREFIX + kapps.Sp + string(validatorAddr))
+		data, _ := v.marshalizer.Marshal(validatorData)
+		kappAcc.SetStorage(validatorKey, data)
+
+		buckets := make(map[string]*PeerBucket, bucketsPerValidator)
+		for j := 0; j < bucketsPerValidator; j++ {
+			userIdx := i*bucketsPerValidator + j
+			userAddr := userAddresses[userIdx]
+			bucketID := fmt.Sprintf("bucket%04d%06d", i, j)
+
+			buckets[bucketID] = &PeerBucket{
+				DelegatedEpoch:   5,
+				UndelegatedEpoch: math.MaxUint32,
+				Value:            100000,
+				Address:          userAddr,
+			}
+
+			// Create user account in trie (will need to be loaded by V1)
+			_, _ = accCacher.LoadUser(userAddr)
+		}
+
+		peerData := &PeerData{Buckets: buckets}
+		peerDataKey := []byte(VALIDATOR_BUCKETS + kapps.Sp + string(validatorAddr))
+		peerDataBytes, err := v.marshalizer.Marshal(peerData)
+		if err != nil {
+			b.Fatalf("Failed to marshal peerData for validator %d: %v (buckets: %d)", i, err, len(buckets))
+		}
+		if len(peerDataBytes) == 0 {
+			b.Fatalf("peerDataBytes is empty for validator %d (buckets: %d)", i, len(buckets))
+		}
+		if err := kappAcc.SetStorage(peerDataKey, peerDataBytes); err != nil {
+			b.Fatalf("Failed to SetStorage for validator %d: %v (size: %d bytes, MaxLeafSize: 786KB)", i, err, len(peerDataBytes))
+		}
+		if i == 0 {
+			b.Logf("Validator %d: %d buckets, serialized size: %d bytes", i, len(buckets), len(peerDataBytes))
+		}
+	}
+
+	b.Logf("Total buckets created: %d across %d validators", numValidators*bucketsPerValidator, numValidators)
+	accCacher.SaveAll()
+
+	// Verify data can be retrieved after reset
+	accCacher.ResetAll(true)
+	verifyKapp, _ := accCacher.LoadKApp(kapps.ValidatorsKAppAddress)
+	testKey := []byte(VALIDATOR_BUCKETS + kapps.Sp + string(validatorInfos[0].OwnerAddress))
+	testData := verifyKapp.GetStorage(testKey)
+	if len(testData) == 0 {
+		b.Fatalf("VERIFICATION FAILED: Cannot retrieve bucket data after reset (key length: %d)", len(testKey))
+	}
+	testPeerData := &PeerData{}
+	if err := v.marshalizer.Unmarshal(testPeerData, testData); err != nil {
+		b.Fatalf("VERIFICATION FAILED: Cannot unmarshal bucket data: %v", err)
+	}
+	b.Logf("VERIFICATION OK: Retrieved %d buckets for validator 0 after reset", len(testPeerData.Buckets))
+	accCacher.ResetAll(true)
+
+	cleanup := func() {
+		userStorer.DestroyUnit()
+		kappStorer.DestroyUnit()
+		peerStorer.DestroyUnit()
+		os.RemoveAll(tempDir)
+	}
+
+	return v, validatorInfos, accCacher, cleanup
+}
+
+func createLevelDBStorer(b *testing.B, path string) storage.Storer {
+	b.Helper()
+
+	cache, err := storageUnit.NewCache(storageUnit.CacheConfig{
+		Type:        storageUnit.LRUCache,
+		Capacity:    10000,
+		Shards:      1,
+		SizeInBytes: 0,
+	})
+	if err != nil {
+		b.Fatalf("Failed to create cache: %v", err)
+	}
+
+	lvdb, err := leveldb.NewDB(path, 10, 100, 10)
+	if err != nil {
+		b.Fatalf("Failed to create LevelDB: %v", err)
+	}
+
+	unit, err := storageUnit.NewStorageUnit(cache, lvdb)
+	if err != nil {
+		b.Fatalf("Failed to create storage unit: %v", err)
+	}
+
+	return unit
+}
+
+func generateRandomAddresses(count int) [][]byte {
+	addresses := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		addr := make([]byte, 32)
+		rand.Read(addr)
+		// Use hex encoding to ensure valid address format
+		addresses[i] = []byte(hex.EncodeToString(addr)[:32])
+	}
+	return addresses
+}

--- a/core/kapp/validators/peersUpdate_test.go
+++ b/core/kapp/validators/peersUpdate_test.go
@@ -1147,7 +1147,10 @@ func TestUpdateValidatorInfoOnSuccessfulBlock(t *testing.T) {
 	})
 }
 
-func TestProcessEconomicsEndOfEpoch(t *testing.T) {
+// TestProcessEconomicsEndOfEpoch_V1V2 tests epoch rewards distribution for both v1 and v2 modes
+// V1 (EpochRewardsV2=false): rewards go directly to user account allowance
+// V2 (EpochRewardsV2=true): rewards go to KApp pending rewards trie
+func TestProcessEconomicsEndOfEpoch_V1V2(t *testing.T) {
 	t.Parallel()
 
 	setupTest := func() *validatorsKApp {
@@ -1185,7 +1188,7 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 		}
 	}
 
-	kappStorage := func(storage map[string]interface{}, v *validatorsKApp) {
+	kappStorage := func(storage map[string]any, v *validatorsKApp) {
 		rawData := make(map[string][]byte)
 		for key, value := range storage {
 			data, _ := v.marshalizer.Marshal(value)
@@ -1203,269 +1206,126 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 				},
 			}, nil
 		}
-
 	}
 
+	// getRewards is a helper that retrieves rewards for an address based on fork mode
+	getRewards := func(v *validatorsKApp, address []byte, isV2 bool) int64 {
+		if isV2 {
+			rewards, err := v.GetPendingRewards(address)
+			if err != nil {
+				return 0
+			}
+			return rewards
+		}
+		// V1: rewards in user account allowance
+		userAcc, err := v.accountsCacher.LoadUser(address)
+		if err != nil {
+			return 0
+		}
+		return userAcc.GetAllowance()
+	}
+
+	// Common test fixtures
 	validatorAddress := []byte("validator1")
 	blsPubKey := []byte("blspubkey1")
-	storageData := map[string]interface{}{
-		"VALB/validator1": &PeerData{
-			Buckets: map[string]*PeerBucket{
-				"bucket1": {
-					DelegatedEpoch:   5,
-					UndelegatedEpoch: math.MaxUint32,
-					Value:            200000,
-					Address:          validatorAddress,
-				},
-				"bucket2": {
-					DelegatedEpoch:   8,
-					UndelegatedEpoch: 11,
-					Value:            100000,
-					Address:          []byte("delegator1"),
+	delegatorAddress := []byte("delegator1")
+	const currentEpoch = uint32(10)
+
+	// defaultStorageData creates the standard storage data for single validator tests
+	defaultStorageData := func() map[string]any {
+		return map[string]any{
+			"VALB/validator1": &PeerData{
+				Buckets: map[string]*PeerBucket{
+					"bucket1": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32,
+						Value:            200000,
+						Address:          validatorAddress,
+					},
+					"bucket2": {
+						DelegatedEpoch:   8,
+						UndelegatedEpoch: math.MaxUint32,
+						Value:            100000,
+						Address:          delegatorAddress,
+					},
 				},
 			},
-		},
-		"VAL/validator1": &ValidatorData{
-			BlsPubKey:      blsPubKey,
-			RewardsAddress: validatorAddress,
-			Commission:     1000, // 10%
-			SelfStake:      200000,
-		},
+			"VAL/validator1": &ValidatorData{
+				BlsPubKey:      blsPubKey,
+				RewardsAddress: validatorAddress,
+				Commission:     1000, // 10%
+				SelfStake:      200000,
+			},
+		}
 	}
 
-	t.Run("Happy path - single validator", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
+	t.Run("V1 vs V2 - Single validator happy path", func(t *testing.T) {
+		storageData := defaultStorageData()
+
+		tests := []struct {
+			name                    string
+			epochRewardsV2          bool
+			expectedValidatorReward int64
+			expectedDelegatorReward int64
+		}{
+			{
+				name:           "V1 - rewards to user allowance",
+				epochRewardsV2: false,
+				// Validator: 2/3 of rewards (200k/300k) + 10% commission = 666666 + 33333 = 699999
+				// Plus remaining fees (1): 700000
+				expectedValidatorReward: 700000,
+				// Delegator: 1/3 of rewards (100k/300k) - 10% commission = 333333 - 33333 = 300000
+				expectedDelegatorReward: 300000,
+			},
+			{
+				name:           "V2 - rewards to KApp pending trie",
+				epochRewardsV2: true,
+				// Same distribution but stored in KApp trie
+				expectedValidatorReward: 700000,
+				expectedDelegatorReward: 300000,
+			},
 		}
 
-		kappStorage(storageData, v)
-		// set accumulated fees
-		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-		peerAcc.AddToAccumulatedFees(1000000)
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
 
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
 
-		// Verify results
-		kappHandler, err := v.getKApp()
-		require.NoError(t, err)
-		updatedValidator, _ := v.getValidator(kappHandler, validatorAddress)
-		assert.True(t, updatedValidator.SelfStaked)
-		assert.False(t, updatedValidator.Jailed)
-		assert.Equal(t, int64(1000000), updatedValidator.TotalRewards)
+				kappStorage(storageData, v)
 
-		// Verify delegations
-		userAcc, _ := v.accountsCacher.LoadUser(validatorAddress)
-		// 2/3 of the rewards (self stake) + (1/3) 10% commission
-		// 666666 - 33333 = 699999
-		// validator gets roundup value after distributing rewards, total 700000
-		assert.Equal(t, int64(700000), userAcc.GetAllowance())
+				// Set accumulated fees
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(1000000)
 
-		delegatorAcc, _ := v.accountsCacher.LoadUser([]byte("delegator1"))
-		// 1/3 of the rewards - 10% commission
-		// 333333 - 10% = 300000
-		assert.Equal(t, int64(300000), delegatorAcc.GetAllowance())
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify rewards distribution
+				validatorReward := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				delegatorReward := getRewards(v, delegatorAddress, tc.epochRewardsV2)
+
+				assert.Equal(t, tc.expectedValidatorReward, validatorReward,
+					"validator reward mismatch for %s", tc.name)
+				assert.Equal(t, tc.expectedDelegatorReward, delegatorReward,
+					"delegator reward mismatch for %s", tc.name)
+
+				// Verify validator state updates (same for both v1 and v2)
+				kappHandler, err := v.getKApp()
+				require.NoError(t, err)
+				updatedValidator, _ := v.getValidator(kappHandler, validatorAddress)
+				assert.True(t, updatedValidator.SelfStaked)
+				assert.False(t, updatedValidator.Jailed)
+				assert.Equal(t, int64(1000000), updatedValidator.TotalRewards)
+			})
+		}
 	})
 
-	t.Run("Validator gets jailed", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
-		}
-
-		kappStorage(storageData, v)
-		// set accumulated fees
-		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-		peerAcc.AddToAccumulatedFees(1000000)
-		peerAcc.SetList(state.List_jailed)
-
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
-
-		// Verify results
-		kappHandler, err := v.getKApp()
-		require.NoError(t, err)
-		updatedValidator, err := v.getValidator(kappHandler, validatorAddress)
-		require.NoError(t, err)
-		assert.True(t, updatedValidator.Jailed)
-		assert.Equal(t, currentEpoch, updatedValidator.JailedEpoch)
-		assert.Equal(t, uint32(1), updatedValidator.NumJailed)
-	})
-
-	t.Run("Validator becomes inactive due to low self stake", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
-		}
-		kappStorage(storageData, v)
-
-		// Setup mock validator with low self stake
-		kapp, _ := v.accountsCacher.LoadKApp(nil)
-		data, _ := v.marshalizer.Marshal(&ValidatorData{
-			BlsPubKey:      blsPubKey,
-			RewardsAddress: validatorAddress,
-			Commission:     1000,  // 10%
-			SelfStake:      50000, // Below minSelfDelegated
-		})
-		require.NoError(t, kapp.SetStorage([]byte("VAL/validator1"), data))
-
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
-
-		// Verify results
-		updatedPeerAcc, _ := v.loadPeerAccount(blsPubKey)
-		assert.Equal(t, state.List_inactive, updatedPeerAcc.GetList())
-	})
-
-	t.Run("Multiple validators with different statuses", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorAddress1 := []byte("validator1")
-		validatorAddress2 := []byte("validator2")
-		blsPubKey1 := []byte("blspubkey1")
-		blsPubKey2 := []byte("blspubkey2")
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress1, blsPubKey1),
-			createMockValidatorInfo(validatorAddress2, blsPubKey2),
-		}
-
-		storageData := map[string]interface{}{
-			"VALB/validator1": &PeerData{
-				Buckets: map[string]*PeerBucket{
-					"bucket1": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: math.MaxUint32,
-						Value:            200000,
-						Address:          validatorAddress1,
-					},
-				},
-			},
-			"VAL/validator1": &ValidatorData{
-				BlsPubKey:      blsPubKey1,
-				RewardsAddress: validatorAddress1,
-				Commission:     1000,
-				SelfStake:      200000,
-			},
-			"VALB/validator2": &PeerData{
-				Buckets: map[string]*PeerBucket{
-					"bucket1": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: math.MaxUint32,
-						Value:            400000,
-						Address:          validatorAddress2,
-					},
-				},
-			},
-			"VAL/validator2": &ValidatorData{
-				BlsPubKey:      blsPubKey2,
-				RewardsAddress: validatorAddress2,
-				Commission:     2000,
-				SelfStake:      400000,
-			},
-		}
-
-		kappStorage(storageData, v)
-
-		peerAcc1, _ := v.accountsCacher.LoadPeer(blsPubKey1)
-		peerAcc1.AddToAccumulatedFees(1000000)
-		peerAcc1.SetList(state.List_eligible)
-
-		peerAcc2, _ := v.accountsCacher.LoadPeer(blsPubKey2)
-		peerAcc2.AddToAccumulatedFees(2000000)
-		peerAcc2.SetList(state.List_waiting)
-
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
-
-		// Verify results for validator1
-		kappHandler, _ := v.getKApp()
-		updatedValidator1, _ := v.getValidator(kappHandler, validatorAddress1)
-		assert.True(t, updatedValidator1.SelfStaked)
-		assert.False(t, updatedValidator1.Jailed)
-		assert.Equal(t, int64(1000000), updatedValidator1.TotalRewards)
-
-		// Verify results for validator2
-		updatedValidator2, _ := v.getValidator(kappHandler, validatorAddress2)
-		assert.True(t, updatedValidator2.SelfStaked)
-		assert.False(t, updatedValidator2.Jailed)
-		assert.Equal(t, int64(2000000), updatedValidator2.TotalRewards)
-		assert.True(t, updatedValidator2.Waiting)
-
-		updatedPeerAcc2, _ := v.loadPeerAccount(blsPubKey2)
-		assert.Equal(t, state.List_waiting, updatedPeerAcc2.GetList())
-	})
-
-	t.Run("Delegation and undelegation in the same epoch", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorAddress := []byte("validator1")
-		blsPubKey := []byte("blspubkey1")
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
-		}
-
-		storageData := map[string]interface{}{
-			"VALB/validator1": &PeerData{
-				Buckets: map[string]*PeerBucket{
-					"bucket1": {
-						DelegatedEpoch:   10,
-						UndelegatedEpoch: 10,
-						Value:            100000,
-						Address:          []byte("delegator1"),
-					},
-					"bucket2": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: math.MaxUint32,
-						Value:            200000,
-						Address:          validatorAddress,
-					},
-				},
-			},
-			"VAL/validator1": &ValidatorData{
-				BlsPubKey:      blsPubKey,
-				RewardsAddress: validatorAddress,
-				Commission:     1000,
-				SelfStake:      200000,
-			},
-		}
-
-		kappStorage(storageData, v)
-
-		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-		peerAcc.AddToAccumulatedFees(1000000)
-
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
-
-		// Verify that the bucket delegated and undelegated in the same epoch is removed
-		kappHandler, _ := v.getKApp()
-		updatedBuckets, _ := v.getValidatorBuckets(kappHandler, validatorAddress)
-		assert.Len(t, updatedBuckets.Buckets, 1)
-		assert.NotContains(t, updatedBuckets.Buckets, "bucket1")
-	})
-
-	t.Run("Validator with zero accumulated fees", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorAddress := []byte("validator1")
-		blsPubKey := []byte("blspubkey1")
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
-		}
-
-		storageData := map[string]interface{}{
+	t.Run("V1 vs V2 - Zero accumulated fees", func(t *testing.T) {
+		storageData := map[string]any{
 			"VALB/validator1": &PeerData{
 				Buckets: map[string]*PeerBucket{
 					"bucket1": {
@@ -1484,28 +1344,38 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 			},
 		}
 
-		kappStorage(storageData, v)
-
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
-
-		// Verify that no rewards are distributed
-		userAcc, _ := v.accountsCacher.LoadUser(validatorAddress)
-		assert.Equal(t, int64(0), userAcc.GetAllowance())
-	})
-
-	t.Run("Validator with maximum commission", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorAddress := []byte("validator1")
-		blsPubKey := []byte("blspubkey1")
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
+		tests := []struct {
+			name           string
+			epochRewardsV2 bool
+		}{
+			{name: "V1 - zero fees", epochRewardsV2: false},
+			{name: "V2 - zero fees", epochRewardsV2: true},
 		}
 
-		storageData := map[string]interface{}{
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
+
+				kappStorage(storageData, v)
+				// No fees accumulated
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify no rewards distributed
+				validatorReward := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				assert.Equal(t, int64(0), validatorReward)
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Maximum commission (100%)", func(t *testing.T) {
+		storageData := map[string]any{
 			"VALB/validator1": &PeerData{
 				Buckets: map[string]*PeerBucket{
 					"bucket1": {
@@ -1518,7 +1388,7 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 						DelegatedEpoch:   5,
 						UndelegatedEpoch: math.MaxUint32,
 						Value:            100000,
-						Address:          []byte("delegator1"),
+						Address:          delegatorAddress,
 					},
 				},
 			},
@@ -1530,6 +1400,334 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 			},
 		}
 
+		tests := []struct {
+			name                    string
+			epochRewardsV2          bool
+			expectedValidatorReward int64
+			expectedDelegatorReward int64
+		}{
+			{
+				name:                    "V1 - max commission",
+				epochRewardsV2:          false,
+				expectedValidatorReward: 1000000, // All rewards go to validator
+				expectedDelegatorReward: 0,       // Delegator gets nothing
+			},
+			{
+				name:                    "V2 - max commission",
+				epochRewardsV2:          true,
+				expectedValidatorReward: 1000000,
+				expectedDelegatorReward: 0,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
+
+				kappStorage(storageData, v)
+
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(1000000)
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				validatorReward := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				delegatorReward := getRewards(v, delegatorAddress, tc.epochRewardsV2)
+
+				assert.Equal(t, tc.expectedValidatorReward, validatorReward)
+				assert.Equal(t, tc.expectedDelegatorReward, delegatorReward)
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Remaining fees distribution", func(t *testing.T) {
+		storageData := map[string]any{
+			"VALB/validator1": &PeerData{
+				Buckets: map[string]*PeerBucket{
+					"bucket1": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32,
+						Value:            200000,
+						Address:          validatorAddress,
+					},
+					"bucket2": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32,
+						Value:            100000,
+						Address:          delegatorAddress,
+					},
+				},
+			},
+			"VAL/validator1": &ValidatorData{
+				BlsPubKey:      blsPubKey,
+				RewardsAddress: validatorAddress,
+				Commission:     1000, // 10%
+				SelfStake:      200000,
+			},
+		}
+
+		tests := []struct {
+			name                    string
+			epochRewardsV2          bool
+			enableSmartContracts    bool
+			expectedValidatorReward int64
+			expectedDelegatorReward int64
+		}{
+			{
+				name:                    "V1 - with smart contracts (remaining fees to validator)",
+				epochRewardsV2:          false,
+				enableSmartContracts:    true,
+				expectedValidatorReward: 700001, // 700000 + 1 remaining
+				expectedDelegatorReward: 300000,
+			},
+			{
+				name:                    "V1 - without smart contracts",
+				epochRewardsV2:          false,
+				enableSmartContracts:    false,
+				expectedValidatorReward: 700000, // No remaining fees added
+				expectedDelegatorReward: 300000,
+			},
+			{
+				name:                    "V2 - with smart contracts (remaining fees to validator)",
+				epochRewardsV2:          true,
+				enableSmartContracts:    true,
+				expectedValidatorReward: 700001,
+				expectedDelegatorReward: 300000,
+			},
+			{
+				name:                    "V2 - without smart contracts",
+				epochRewardsV2:          true,
+				enableSmartContracts:    false,
+				expectedValidatorReward: 700000,
+				expectedDelegatorReward: 300000,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+				v.forkController.(*mock.ForkControllerStub).EnableSmartContractsValue = tc.enableSmartContracts
+
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
+
+				kappStorage(storageData, v)
+
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(1000001) // Odd number to create remaining fees
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				validatorReward := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				delegatorReward := getRewards(v, delegatorAddress, tc.epochRewardsV2)
+
+				assert.Equal(t, tc.expectedValidatorReward, validatorReward,
+					"validator reward mismatch for %s", tc.name)
+				assert.Equal(t, tc.expectedDelegatorReward, delegatorReward,
+					"delegator reward mismatch for %s", tc.name)
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Multiple validators", func(t *testing.T) {
+		validator2Address := []byte("validator2")
+		blsPubKey2 := []byte("blspubkey2")
+
+		storageData := map[string]any{
+			"VALB/validator1": &PeerData{
+				Buckets: map[string]*PeerBucket{
+					"bucket1": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32,
+						Value:            200000,
+						Address:          validatorAddress,
+					},
+				},
+			},
+			"VAL/validator1": &ValidatorData{
+				BlsPubKey:      blsPubKey,
+				RewardsAddress: validatorAddress,
+				Commission:     1000,
+				SelfStake:      200000,
+			},
+			"VALB/validator2": &PeerData{
+				Buckets: map[string]*PeerBucket{
+					"bucket1": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32,
+						Value:            400000,
+						Address:          validator2Address,
+					},
+				},
+			},
+			"VAL/validator2": &ValidatorData{
+				BlsPubKey:      blsPubKey2,
+				RewardsAddress: validator2Address,
+				Commission:     2000, // 20%
+				SelfStake:      400000,
+			},
+		}
+
+		tests := []struct {
+			name                     string
+			epochRewardsV2           bool
+			expectedValidator1Reward int64
+			expectedValidator2Reward int64
+		}{
+			{
+				name:                     "V1 - multiple validators",
+				epochRewardsV2:           false,
+				expectedValidator1Reward: 1000000, // 100% of 1M (only self-staked)
+				expectedValidator2Reward: 2000000, // 100% of 2M (only self-staked)
+			},
+			{
+				name:                     "V2 - multiple validators",
+				epochRewardsV2:           true,
+				expectedValidator1Reward: 1000000,
+				expectedValidator2Reward: 2000000,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					{
+						PublicKey:    blsPubKey,
+						OwnerAddress: validatorAddress,
+						List:         string(state.List_eligible),
+						TempRating:   5000000,
+					},
+					{
+						PublicKey:    blsPubKey2,
+						OwnerAddress: validator2Address,
+						List:         string(state.List_waiting),
+						TempRating:   5000000,
+					},
+				}
+
+				kappStorage(storageData, v)
+
+				peerAcc1, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc1.AddToAccumulatedFees(1000000)
+				peerAcc1.SetList(state.List_eligible)
+
+				peerAcc2, _ := v.accountsCacher.LoadPeer(blsPubKey2)
+				peerAcc2.AddToAccumulatedFees(2000000)
+				peerAcc2.SetList(state.List_waiting)
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				validator1Reward := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				validator2Reward := getRewards(v, validator2Address, tc.epochRewardsV2)
+
+				assert.Equal(t, tc.expectedValidator1Reward, validator1Reward)
+				assert.Equal(t, tc.expectedValidator2Reward, validator2Reward)
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Accumulated rewards across epochs", func(t *testing.T) {
+		storageData := map[string]any{
+			"VALB/validator1": &PeerData{
+				Buckets: map[string]*PeerBucket{
+					"bucket1": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32,
+						Value:            200000,
+						Address:          validatorAddress,
+					},
+				},
+			},
+			"VAL/validator1": &ValidatorData{
+				BlsPubKey:      blsPubKey,
+				RewardsAddress: validatorAddress,
+				Commission:     0, // No commission for simplicity
+				SelfStake:      200000,
+			},
+		}
+
+		tests := []struct {
+			name                           string
+			epochRewardsV2                 bool
+			expectedRewardAfterFirstEpoch  int64
+			expectedRewardAfterSecondEpoch int64
+		}{
+			{
+				name:                           "V1 - accumulates in allowance",
+				epochRewardsV2:                 false,
+				expectedRewardAfterFirstEpoch:  500000,
+				expectedRewardAfterSecondEpoch: 1000000,
+			},
+			{
+				name:                           "V2 - accumulates in pending rewards",
+				epochRewardsV2:                 true,
+				expectedRewardAfterFirstEpoch:  500000,
+				expectedRewardAfterSecondEpoch: 1000000,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					{
+						PublicKey:    blsPubKey,
+						OwnerAddress: validatorAddress,
+						List:         string(state.List_eligible),
+						TempRating:   5000000,
+					},
+				}
+
+				kappStorage(storageData, v)
+
+				// First epoch
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(500000)
+
+				err := v.ProcessEconomicsEndOfEpoch(10, validatorInfos)
+				assert.NoError(t, err)
+
+				rewardAfterFirst := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				assert.Equal(t, tc.expectedRewardAfterFirstEpoch, rewardAfterFirst)
+
+				// Second epoch - reload peer account (it was reset)
+				peerAcc, _ = v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(500000)
+
+				err = v.ProcessEconomicsEndOfEpoch(11, validatorInfos)
+				assert.NoError(t, err)
+
+				rewardAfterSecond := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				assert.Equal(t, tc.expectedRewardAfterSecondEpoch, rewardAfterSecond)
+			})
+		}
+	})
+
+	t.Run("V2 - Verify pending rewards storage mechanism", func(t *testing.T) {
+		v := setupTest()
+		v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = true
+
+		storageData := defaultStorageData()
+
+		validatorInfos := []*state.ValidatorInfo{
+			createMockValidatorInfo(validatorAddress, blsPubKey),
+		}
+
 		kappStorage(storageData, v)
 
 		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
@@ -1538,26 +1736,309 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
 		assert.NoError(t, err)
 
-		// Verify that all rewards go to the validator
-		userAcc, _ := v.accountsCacher.LoadUser(validatorAddress)
-		assert.Equal(t, int64(1000000), userAcc.GetAllowance())
+		// V2 specific: Verify rewards are in KApp trie, NOT in user account
+		validatorPendingRewards, err := v.GetPendingRewards(validatorAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(700000), validatorPendingRewards)
 
-		delegatorAcc, _ := v.accountsCacher.LoadUser([]byte("delegator1"))
-		assert.Equal(t, int64(0), delegatorAcc.GetAllowance())
+		delegatorPendingRewards, err := v.GetPendingRewards(delegatorAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(300000), delegatorPendingRewards)
+
+		// Verify user accounts have NO allowance in V2 (rewards not directly added)
+		validatorUserAcc, _ := v.accountsCacher.LoadUser(validatorAddress)
+		assert.Equal(t, int64(0), validatorUserAcc.GetAllowance(),
+			"V2 should NOT add rewards to user allowance directly")
+
+		delegatorUserAcc, _ := v.accountsCacher.LoadUser(delegatorAddress)
+		assert.Equal(t, int64(0), delegatorUserAcc.GetAllowance(),
+			"V2 should NOT add rewards to user allowance directly")
 	})
 
-	t.Run("Validator becomes eligible", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
+	t.Run("V1 vs V2 - Undelegated buckets removal and rewards", func(t *testing.T) {
+		delegator1Address := []byte("delegator1")
+		delegator2Address := []byte("delegator2")
 
-		validatorAddress := []byte("validator1")
-		blsPubKey := []byte("blspubkey1")
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
+		// Setup: 3 buckets with different undelegation states
+		// - bucket1: undelegated in epoch 9 (previous epoch) -> should be deleted, no rewards
+		// - bucket2: undelegated in epoch 10 (current epoch) -> should be deleted, no rewards
+		// - bucket3: still delegated (MaxUint32) -> should remain, receives rewards
+		storageData := map[string]any{
+			"VALB/validator1": &PeerData{
+				Buckets: map[string]*PeerBucket{
+					"bucket1": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: 9, // Undelegated in previous epoch
+						Value:            100000,
+						Address:          delegator1Address,
+					},
+					"bucket2": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: 10, // Undelegated in current epoch
+						Value:            200000,
+						Address:          delegator2Address,
+					},
+					"bucket3": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32, // Still delegated
+						Value:            300000,
+						Address:          validatorAddress,
+					},
+				},
+			},
+			"VAL/validator1": &ValidatorData{
+				BlsPubKey:      blsPubKey,
+				RewardsAddress: validatorAddress,
+				Commission:     0, // No commission for simpler calculation
+				SelfStake:      300000,
+			},
 		}
 
-		storageData := map[string]interface{}{
+		tests := []struct {
+			name                     string
+			epochRewardsV2           bool
+			expectedValidatorReward  int64
+			expectedDelegator1Reward int64
+			expectedDelegator2Reward int64
+		}{
+			{
+				name:                     "V1 - undelegated buckets deleted, only active gets rewards",
+				epochRewardsV2:           false,
+				expectedValidatorReward:  1000000, // All rewards (only active bucket)
+				expectedDelegator1Reward: 0,       // Undelegated, no rewards
+				expectedDelegator2Reward: 0,       // Undelegated, no rewards
+			},
+			{
+				name:                     "V2 - undelegated buckets deleted, only active gets rewards",
+				epochRewardsV2:           true,
+				expectedValidatorReward:  1000000,
+				expectedDelegator1Reward: 0,
+				expectedDelegator2Reward: 0,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
+
+				kappStorage(storageData, v)
+
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(1000000)
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify undelegated buckets are removed (same for V1 and V2)
+				kappHandler, err := v.getKApp()
+				require.NoError(t, err)
+				updatedBuckets, err := v.getValidatorBuckets(kappHandler, validatorAddress)
+				require.NoError(t, err)
+
+				assert.Len(t, updatedBuckets.Buckets, 1, "only 1 bucket should remain")
+				assert.NotContains(t, updatedBuckets.Buckets, "bucket1", "bucket1 should be deleted")
+				assert.NotContains(t, updatedBuckets.Buckets, "bucket2", "bucket2 should be deleted")
+				assert.Contains(t, updatedBuckets.Buckets, "bucket3", "bucket3 should remain")
+
+				// Verify rewards distribution
+				validatorReward := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				delegator1Reward := getRewards(v, delegator1Address, tc.epochRewardsV2)
+				delegator2Reward := getRewards(v, delegator2Address, tc.epochRewardsV2)
+
+				assert.Equal(t, tc.expectedValidatorReward, validatorReward,
+					"validator should receive all rewards as only active delegation")
+				assert.Equal(t, tc.expectedDelegator1Reward, delegator1Reward,
+					"delegator1 should not receive rewards (undelegated)")
+				assert.Equal(t, tc.expectedDelegator2Reward, delegator2Reward,
+					"delegator2 should not receive rewards (undelegated)")
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Delegation and undelegation same epoch", func(t *testing.T) {
+		// Setup: bucket delegated and undelegated in the same epoch should be removed
+		// and should not receive any rewards
+		storageData := map[string]any{
+			"VALB/validator1": &PeerData{
+				Buckets: map[string]*PeerBucket{
+					"bucket1": {
+						DelegatedEpoch:   10, // Delegated in current epoch
+						UndelegatedEpoch: 10, // Undelegated in current epoch
+						Value:            100000,
+						Address:          delegatorAddress,
+					},
+					"bucket2": {
+						DelegatedEpoch:   5,
+						UndelegatedEpoch: math.MaxUint32, // Still delegated
+						Value:            200000,
+						Address:          validatorAddress,
+					},
+				},
+			},
+			"VAL/validator1": &ValidatorData{
+				BlsPubKey:      blsPubKey,
+				RewardsAddress: validatorAddress,
+				Commission:     0,
+				SelfStake:      200000,
+			},
+		}
+
+		tests := []struct {
+			name                    string
+			epochRewardsV2          bool
+			expectedValidatorReward int64
+			expectedDelegatorReward int64
+		}{
+			{
+				name:                    "V1 - same epoch delegate/undelegate removed",
+				epochRewardsV2:          false,
+				expectedValidatorReward: 1000000, // All rewards
+				expectedDelegatorReward: 0,
+			},
+			{
+				name:                    "V2 - same epoch delegate/undelegate removed",
+				epochRewardsV2:          true,
+				expectedValidatorReward: 1000000,
+				expectedDelegatorReward: 0,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
+
+				kappStorage(storageData, v)
+
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(1000000)
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify bucket1 (same epoch delegate/undelegate) is removed
+				kappHandler, err := v.getKApp()
+				require.NoError(t, err)
+				updatedBuckets, err := v.getValidatorBuckets(kappHandler, validatorAddress)
+				require.NoError(t, err)
+
+				assert.Len(t, updatedBuckets.Buckets, 1)
+				assert.NotContains(t, updatedBuckets.Buckets, "bucket1",
+					"bucket delegated and undelegated in same epoch should be removed")
+				assert.Contains(t, updatedBuckets.Buckets, "bucket2")
+
+				// Verify rewards
+				validatorReward := getRewards(v, validatorAddress, tc.epochRewardsV2)
+				delegatorReward := getRewards(v, delegatorAddress, tc.epochRewardsV2)
+
+				assert.Equal(t, tc.expectedValidatorReward, validatorReward)
+				assert.Equal(t, tc.expectedDelegatorReward, delegatorReward,
+					"delegator should not receive rewards (same epoch undelegate)")
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Validator gets jailed", func(t *testing.T) {
+		storageData := defaultStorageData()
+
+		tests := []struct {
+			name           string
+			epochRewardsV2 bool
+		}{
+			{name: "V1 - validator jailed", epochRewardsV2: false},
+			{name: "V2 - validator jailed", epochRewardsV2: true},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
+
+				kappStorage(storageData, v)
+
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.AddToAccumulatedFees(1000000)
+				peerAcc.SetList(state.List_jailed) // Peer is jailed
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify validator is marked as jailed
+				kappHandler, err := v.getKApp()
+				require.NoError(t, err)
+				updatedValidator, err := v.getValidator(kappHandler, validatorAddress)
+				require.NoError(t, err)
+				assert.True(t, updatedValidator.Jailed)
+				assert.Equal(t, currentEpoch, updatedValidator.JailedEpoch)
+				assert.Equal(t, uint32(1), updatedValidator.NumJailed)
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Validator becomes inactive due to low self stake", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			epochRewardsV2 bool
+		}{
+			{name: "V1 - low self stake becomes inactive", epochRewardsV2: false},
+			{name: "V2 - low self stake becomes inactive", epochRewardsV2: true},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
+
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
+
+				storageData := map[string]any{
+					"VALB/validator1": &PeerData{
+						Buckets: map[string]*PeerBucket{
+							"bucket1": {
+								DelegatedEpoch:   5,
+								UndelegatedEpoch: math.MaxUint32,
+								Value:            50000, // Below minSelfDelegated
+								Address:          validatorAddress,
+							},
+						},
+					},
+					"VAL/validator1": &ValidatorData{
+						BlsPubKey:      blsPubKey,
+						RewardsAddress: validatorAddress,
+						Commission:     1000,
+						SelfStake:      50000, // Below minSelfDelegated (100000)
+					},
+				}
+
+				kappStorage(storageData, v)
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify validator becomes inactive
+				updatedPeerAcc, _ := v.loadPeerAccount(blsPubKey)
+				assert.Equal(t, state.List_inactive, updatedPeerAcc.GetList())
+			})
+		}
+	})
+
+	t.Run("V1 vs V2 - Validator becomes eligible", func(t *testing.T) {
+		storageData := map[string]any{
 			"VALB/validator1": &PeerData{
 				Buckets: map[string]*PeerBucket{
 					"bucket1": {
@@ -1576,21 +2057,42 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 			},
 		}
 
-		kappStorage(storageData, v)
+		tests := []struct {
+			name           string
+			epochRewardsV2 bool
+		}{
+			{name: "V1 - waiting becomes eligible", epochRewardsV2: false},
+			{name: "V2 - waiting becomes eligible", epochRewardsV2: true},
+		}
 
-		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-		peerAcc.SetList(state.List_waiting)
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
 
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
 
-		// Verify that the validator becomes eligible
-		updatedPeerAcc, _ := v.loadPeerAccount(blsPubKey)
-		assert.Equal(t, state.List_eligible, updatedPeerAcc.GetList())
+				kappStorage(storageData, v)
+
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.SetList(state.List_waiting) // Start as waiting
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify validator becomes eligible
+				updatedPeerAcc, _ := v.loadPeerAccount(blsPubKey)
+				assert.Equal(t, state.List_eligible, updatedPeerAcc.GetList())
+			})
+		}
 	})
 
-	t.Run("Remaining fees check fork", func(t *testing.T) {
-		storageData := map[string]interface{}{
+	t.Run("V1 vs V2 - Jailed validator gets unjailed", func(t *testing.T) {
+		// Validator data has Jailed=true, but peer account is NOT jailed
+		// This means validator should be unjailed
+		storageData := map[string]any{
 			"VALB/validator1": &PeerData{
 				Buckets: map[string]*PeerBucket{
 					"bucket1": {
@@ -1599,64 +2101,55 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 						Value:            200000,
 						Address:          validatorAddress,
 					},
-					"bucket2": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: math.MaxUint32,
-						Value:            100000,
-						Address:          []byte("delegator1"),
-					},
 				},
 			},
 			"VAL/validator1": &ValidatorData{
 				BlsPubKey:      blsPubKey,
 				RewardsAddress: validatorAddress,
-				Commission:     1000, // 10%
+				Commission:     1000,
 				SelfStake:      200000,
+				Jailed:         true, // Validator data says jailed
+				JailedEpoch:    5,
 			},
 		}
 
 		tests := []struct {
-			enableSmartContracts bool
-			value                int64
+			name           string
+			epochRewardsV2 bool
 		}{
-			{true, 700001},
-			{false, 700000},
+			{name: "V1 - jailed validator unjailed", epochRewardsV2: false},
+			{name: "V2 - jailed validator unjailed", epochRewardsV2: true},
 		}
 
-		for _, test := range tests {
-			v := setupTest()
-			currentEpoch := uint32(10)
-			validatorInfos := []*state.ValidatorInfo{
-				createMockValidatorInfo(validatorAddress, blsPubKey),
-			}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
 
-			kappStorage(storageData, v)
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
 
-			peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-			peerAcc.AddToAccumulatedFees(1000001) // Odd number to ensure remaining fees
+				kappStorage(storageData, v)
 
-			// Enable smart contracts
-			v.forkController.(*mock.ForkControllerStub).EnableSmartContractsValue = test.enableSmartContracts
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.SetList(state.List_eligible) // Peer is NOT jailed
 
-			err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-			assert.NoError(t, err)
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
 
-			// Verify that remaining fee is added to validator's rewards
-			userAcc, _ := v.accountsCacher.LoadUser(validatorAddress)
-			// 200000/300000 * 900000 (90% of rewards) + 100000 (10% commission) + 1 (remaining fee) = 700001
-			assert.Equal(t, test.value, userAcc.GetAllowance())
+				// Verify validator is unjailed
+				kappHandler, _ := v.getKApp()
+				updatedValidator, _ := v.getValidator(kappHandler, validatorAddress)
+				assert.False(t, updatedValidator.Jailed)
+				assert.Equal(t, uint32(math.MaxUint32), updatedValidator.JailedEpoch)
+			})
 		}
 	})
 
-	t.Run("Jailed validator status update", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
-		}
-
-		storageData := map[string]interface{}{
+	t.Run("V1 vs V2 - Validator remains jailed", func(t *testing.T) {
+		// Both validator data and peer account are jailed
+		storageData := map[string]any{
 			"VALB/validator1": &PeerData{
 				Buckets: map[string]*PeerBucket{
 					"bucket1": {
@@ -1677,132 +2170,38 @@ func TestProcessEconomicsEndOfEpoch(t *testing.T) {
 			},
 		}
 
-		kappStorage(storageData, v)
+		tests := []struct {
+			name           string
+			epochRewardsV2 bool
+		}{
+			{name: "V1 - validator remains jailed", epochRewardsV2: false},
+			{name: "V2 - validator remains jailed", epochRewardsV2: true},
+		}
 
-		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-		peerAcc.SetList(state.List_eligible) // Peer account is not jailed
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				v := setupTest()
+				v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = tc.epochRewardsV2
 
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
+				validatorInfos := []*state.ValidatorInfo{
+					createMockValidatorInfo(validatorAddress, blsPubKey),
+				}
 
-		// Verify that the validator is no longer jailed
-		kappHandler, _ := v.getKApp()
-		updatedValidator, _ := v.getValidator(kappHandler, validatorAddress)
-		assert.False(t, updatedValidator.Jailed)
-		assert.Equal(t, uint32(math.MaxUint32), updatedValidator.JailedEpoch)
+				kappStorage(storageData, v)
+
+				peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
+				peerAcc.SetList(state.List_jailed) // Peer is also jailed
+
+				err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
+				assert.NoError(t, err)
+
+				// Verify validator remains jailed
+				kappHandler, _ := v.getKApp()
+				updatedValidator, _ := v.getValidator(kappHandler, validatorAddress)
+				assert.True(t, updatedValidator.Jailed)
+				assert.Equal(t, uint32(5), updatedValidator.JailedEpoch) // Original jailed epoch preserved
+			})
+		}
 	})
 
-	t.Run("Validator remains jailed", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorAddress := []byte("validator1")
-		blsPubKey := []byte("blspubkey1")
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
-		}
-
-		storageData := map[string]interface{}{
-			"VALB/validator1": &PeerData{
-				Buckets: map[string]*PeerBucket{
-					"bucket1": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: math.MaxUint32,
-						Value:            200000,
-						Address:          validatorAddress,
-					},
-				},
-			},
-			"VAL/validator1": &ValidatorData{
-				BlsPubKey:      blsPubKey,
-				RewardsAddress: validatorAddress,
-				Commission:     1000,
-				SelfStake:      200000,
-				Jailed:         true,
-				JailedEpoch:    5,
-			},
-		}
-
-		kappStorage(storageData, v)
-
-		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-		peerAcc.SetList(state.List_jailed) // Peer account is jailed
-
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
-
-		// Verify that the validator remains jailed
-		kappHandler, _ := v.getKApp()
-		updatedValidator, _ := v.getValidator(kappHandler, validatorAddress)
-		assert.True(t, updatedValidator.Jailed)
-		assert.Equal(t, uint32(5), updatedValidator.JailedEpoch)
-	})
-
-	t.Run("Remove undelegated buckets and calculate total undelegated amount", func(t *testing.T) {
-		v := setupTest()
-		currentEpoch := uint32(10)
-
-		validatorInfos := []*state.ValidatorInfo{
-			createMockValidatorInfo(validatorAddress, blsPubKey),
-		}
-
-		storageData := map[string]interface{}{
-			"VALB/validator1": &PeerData{
-				Buckets: map[string]*PeerBucket{
-					"bucket1": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: 9, // Undelegated in previous epoch
-						Value:            100000,
-						Address:          []byte("delegator1"),
-					},
-					"bucket2": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: 10, // Undelegated in current epoch
-						Value:            200000,
-						Address:          []byte("delegator2"),
-					},
-					"bucket3": {
-						DelegatedEpoch:   5,
-						UndelegatedEpoch: math.MaxUint32, // Still delegated
-						Value:            300000,
-						Address:          validatorAddress,
-					},
-				},
-			},
-			"VAL/validator1": &ValidatorData{
-				BlsPubKey:      blsPubKey,
-				RewardsAddress: validatorAddress,
-				Commission:     1000,
-				SelfStake:      300000,
-			},
-		}
-
-		kappStorage(storageData, v)
-
-		peerAcc, _ := v.accountsCacher.LoadPeer(blsPubKey)
-		peerAcc.AddToAccumulatedFees(1000000)
-
-		err := v.ProcessEconomicsEndOfEpoch(currentEpoch, validatorInfos)
-		assert.NoError(t, err)
-
-		// Verify that undelegated buckets are removed
-		kappHandler, _ := v.getKApp()
-		updatedBuckets, _ := v.getValidatorBuckets(kappHandler, validatorAddress)
-		assert.Len(t, updatedBuckets.Buckets, 1)
-		assert.NotContains(t, updatedBuckets.Buckets, "bucket1")
-		assert.NotContains(t, updatedBuckets.Buckets, "bucket2")
-		assert.Contains(t, updatedBuckets.Buckets, "bucket3")
-
-		// Verify rewards distribution
-		validatorAcc, _ := v.accountsCacher.LoadUser(validatorAddress)
-		// Validator gets all rewards as it's the only remaining delegation
-		assert.Equal(t, int64(1000000), validatorAcc.GetAllowance())
-
-		delegator1Acc, _ := v.accountsCacher.LoadUser([]byte("delegator1"))
-		assert.Equal(t, int64(0), delegator1Acc.GetAllowance())
-
-		delegator2Acc, _ := v.accountsCacher.LoadUser([]byte("delegator2"))
-		assert.Equal(t, int64(0), delegator2Acc.GetAllowance())
-	})
 }

--- a/core/kapp/validators/validators.go
+++ b/core/kapp/validators/validators.go
@@ -31,6 +31,11 @@ const (
 	VALIDATOR_BLS_PREFIX = "BLS"
 	VALIDATOR_BUCKETS    = "VALB"
 	PENDING_REWARDS      = "PREW"
+
+	// MaxBucketsPerValidator limits the number of delegator buckets per validator
+	// to prevent exceeding the MaxLeafSize (786KB) storage limit.
+	// Each bucket is ~142 bytes serialized, so 4500 buckets ≈ 639KB (safe margin).
+	MaxBucketsPerValidator = 4500
 )
 
 type validatorActionType uint8
@@ -559,6 +564,15 @@ func (v *validatorsKApp) delegate(
 
 	// must use string to marshal proto map due UTF8 issue
 	encodedBucketID := hex.EncodeToString(bucketID)
+
+	// Check if adding a new bucket would exceed the maximum limit
+	// (skip check if bucket already exists - it's a re-delegation)
+	// Only enforced after EpochRewardsV2 fork to maintain consensus during upgrade
+	if v.forkController.EpochRewardsV2() {
+		if _, exists := pd.Buckets[encodedBucketID]; !exists && len(pd.Buckets) >= MaxBucketsPerValidator {
+			return common.ErrValidatorMaxDelegatorsReached
+		}
+	}
 
 	pd.Buckets[encodedBucketID] = &PeerBucket{
 		DelegatedAt:      blockTime,

--- a/core/kapp/validators/validators.go
+++ b/core/kapp/validators/validators.go
@@ -1043,6 +1043,10 @@ func (v *validatorsKApp) getPendingRewards(app state.KAppAccountHandler, address
 
 // setPendingRewards stores pending rewards for a user in the KApp data trie
 func (v *validatorsKApp) setPendingRewards(app state.KAppAccountHandler, address []byte, amount int64) error {
+	if amount < 0 {
+		return common.ErrInvalidValue
+	}
+
 	key := v.pendingRewardsKey(address)
 
 	if amount == 0 {

--- a/core/kapp/validators/validators.go
+++ b/core/kapp/validators/validators.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"math"
 	"unicode/utf8"
@@ -29,6 +30,7 @@ const (
 	VALIDATOR_S_PREFIX   = "VALS"
 	VALIDATOR_BLS_PREFIX = "BLS"
 	VALIDATOR_BUCKETS    = "VALB"
+	PENDING_REWARDS      = "PREW"
 )
 
 type validatorActionType uint8
@@ -1003,6 +1005,97 @@ func (v *validatorsKApp) verifySignaturesBelowSignedThreshold(
 // IsInterfaceNil verifies if the underlying object is nil or not
 func (v *validatorsKApp) IsInterfaceNil() bool {
 	return v == nil
+}
+
+// pendingRewardsKey returns the key for storing pending rewards for a user address
+func (v *validatorsKApp) pendingRewardsKey(address []byte) []byte {
+	return append([]byte(PENDING_REWARDS+kapps.Sp), address...)
+}
+
+// getPendingRewards retrieves pending rewards for a user from the KApp data trie
+func (v *validatorsKApp) getPendingRewards(app state.KAppAccountHandler, address []byte) (int64, error) {
+	key := v.pendingRewardsKey(address)
+	data := app.GetStorage(key)
+	if len(data) == 0 {
+		return 0, nil
+	}
+
+	if len(data) != 8 {
+		return 0, common.ErrInvalidValue
+	}
+
+	return int64(binary.BigEndian.Uint64(data)), nil
+}
+
+// setPendingRewards stores pending rewards for a user in the KApp data trie
+func (v *validatorsKApp) setPendingRewards(app state.KAppAccountHandler, address []byte, amount int64) error {
+	key := v.pendingRewardsKey(address)
+
+	if amount == 0 {
+		// Remove entry if amount is zero
+		return app.SetStorage(key, nil)
+	}
+
+	data := make([]byte, 8)
+	binary.BigEndian.PutUint64(data, uint64(amount))
+
+	return app.SetStorage(key, data)
+}
+
+// addToPendingRewards adds to existing pending rewards for a user
+func (v *validatorsKApp) addToPendingRewards(app state.KAppAccountHandler, address []byte, amount int64) error {
+	if amount == 0 {
+		return nil
+	}
+
+	current, err := v.getPendingRewards(app, address)
+	if err != nil {
+		return err
+	}
+
+	return v.setPendingRewards(app, address, current+amount)
+}
+
+// GetPendingRewards retrieves pending rewards for a user address (public method for external access)
+func (v *validatorsKApp) GetPendingRewards(address []byte) (int64, error) {
+	app, err := v.getKApp()
+	if err != nil {
+		return 0, err
+	}
+
+	return v.getPendingRewards(app, address)
+}
+
+// ClaimPendingRewards claims pending rewards for a user from the KApp data trie
+// and returns the amount that was claimed. The caller is responsible for
+// adding this amount to the user's allowance.
+func (v *validatorsKApp) ClaimPendingRewards(address []byte) (int64, error) {
+	app, err := v.getKApp()
+	if err != nil {
+		return 0, err
+	}
+
+	pendingAmount, err := v.getPendingRewards(app, address)
+	if err != nil {
+		return 0, err
+	}
+
+	if pendingAmount == 0 {
+		return 0, nil
+	}
+
+	// Clear pending rewards from KApp trie
+	err = v.setPendingRewards(app, address, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	err = v.saveKApp(app)
+	if err != nil {
+		return 0, err
+	}
+
+	return pendingAmount, nil
 }
 
 func (v *validatorsKApp) PeerAccountToValidatorInfo(pubkey []byte, revoked bool, peerAcc state.PeerAccountHandler) *state.ValidatorInfo {

--- a/core/kapp/validators/validators_test.go
+++ b/core/kapp/validators/validators_test.go
@@ -616,7 +616,7 @@ func delegateBucket(t *testing.T, v *validatorsKApp, validator, sender, bucketID
 		return senderAcc, nil
 	}
 
-	_, _, err := v.Delegate([]byte("sender"), 1000, 1, tc)
+	_, _, err := v.Delegate(sender, 1000, 1, tc)
 	assert.NoError(t, err)
 }
 
@@ -634,4 +634,345 @@ func jailValidator(t *testing.T, v *validatorsKApp, validatorAddress []byte) {
 	peerAcc.SetListAndIndex(state.List_jailed, 0)
 	err = v.accountsCacher.UpdatePeer(peerAcc)
 	require.Nil(t, err)
+}
+
+// TestPendingRewards tests the pending rewards storage mechanism
+func TestPendingRewards(t *testing.T) {
+	t.Parallel()
+
+	setupTest := func(t *testing.T) *validatorsKApp {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+
+		// Setup mock KApp storage
+		storage := make(map[string][]byte)
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppCalled = func(address []byte) (state.KAppAccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{
+				GetStorageCalled: func(key []byte) []byte {
+					return storage[string(key)]
+				},
+				SetStorageCalled: func(key []byte, value []byte) error {
+					if value == nil {
+						delete(storage, string(key))
+					} else {
+						storage[string(key)] = value
+					}
+					return nil
+				},
+			}, nil
+		}
+
+		return v
+	}
+
+	t.Run("GetPendingRewards - no pending rewards", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		rewards, err := v.GetPendingRewards(userAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), rewards)
+	})
+
+	t.Run("GetPendingRewards - with pending rewards", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		// Set some pending rewards first
+		app, err := v.getKApp()
+		require.NoError(t, err)
+		err = v.setPendingRewards(app, userAddress, 500000)
+		require.NoError(t, err)
+
+		rewards, err := v.GetPendingRewards(userAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(500000), rewards)
+	})
+
+	t.Run("setPendingRewards - with zero amount clears entry", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		// First set a non-zero amount
+		err = v.setPendingRewards(app, userAddress, 100000)
+		require.NoError(t, err)
+
+		rewards, err := v.getPendingRewards(app, userAddress)
+		require.NoError(t, err)
+		assert.Equal(t, int64(100000), rewards)
+
+		// Now set to zero - should clear the entry
+		err = v.setPendingRewards(app, userAddress, 0)
+		require.NoError(t, err)
+
+		rewards, err = v.getPendingRewards(app, userAddress)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), rewards, "setting amount to 0 should clear the entry")
+	})
+
+	t.Run("addToPendingRewards - accumulates rewards", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		// Add first amount
+		err = v.addToPendingRewards(app, userAddress, 100000)
+		require.NoError(t, err)
+
+		// Add second amount
+		err = v.addToPendingRewards(app, userAddress, 200000)
+		require.NoError(t, err)
+
+		rewards, err := v.getPendingRewards(app, userAddress)
+		require.NoError(t, err)
+		assert.Equal(t, int64(300000), rewards)
+	})
+
+	t.Run("addToPendingRewards - with zero amount does nothing", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		// Set initial amount
+		err = v.setPendingRewards(app, userAddress, 100000)
+		require.NoError(t, err)
+
+		// Add zero - should not change anything
+		err = v.addToPendingRewards(app, userAddress, 0)
+		require.NoError(t, err)
+
+		rewards, err := v.getPendingRewards(app, userAddress)
+		require.NoError(t, err)
+		assert.Equal(t, int64(100000), rewards, "adding 0 should not change the value")
+	})
+
+	t.Run("getPendingRewards - invalid data length returns error", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		userAddress := makeAddress("user1")
+
+		// Setup storage with invalid data (not 8 bytes)
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppCalled = func(address []byte) (state.KAppAccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{
+				GetStorageCalled: func(key []byte) []byte {
+					return []byte{0x01, 0x02, 0x03} // Invalid: only 3 bytes instead of 8
+				},
+			}, nil
+		}
+
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		rewards, err := v.getPendingRewards(app, userAddress)
+		assert.Equal(t, common.ErrInvalidValue, err)
+		assert.Equal(t, int64(0), rewards)
+	})
+
+	t.Run("addToPendingRewards - error from getPendingRewards propagates", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		userAddress := makeAddress("user1")
+
+		// Setup storage with invalid data to trigger error in getPendingRewards
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppCalled = func(address []byte) (state.KAppAccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{
+				GetStorageCalled: func(key []byte) []byte {
+					return []byte{0x01, 0x02} // Invalid data
+				},
+			}, nil
+		}
+
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		err = v.addToPendingRewards(app, userAddress, 50000)
+		assert.Equal(t, common.ErrInvalidValue, err)
+	})
+}
+
+// TestClaimPendingRewards tests the claim pending rewards functionality
+func TestClaimPendingRewards(t *testing.T) {
+	t.Parallel()
+
+	setupTest := func(t *testing.T) *validatorsKApp {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+
+		// Setup mock KApp storage with save capability
+		storage := make(map[string][]byte)
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppCalled = func(address []byte) (state.KAppAccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{
+				GetStorageCalled: func(key []byte) []byte {
+					return storage[string(key)]
+				},
+				SetStorageCalled: func(key []byte, value []byte) error {
+					if value == nil {
+						delete(storage, string(key))
+					} else {
+						storage[string(key)] = value
+					}
+					return nil
+				},
+			}, nil
+		}
+
+		// Mock SaveKApp - just return nil for now
+		v.accountsCacher.(*mock.AccountsCacherStub).UpdateKappCalled = func(account state.AccountHandler) error {
+			return nil
+		}
+
+		return v
+	}
+
+	t.Run("ClaimPendingRewards - no pending rewards returns zero", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		claimed, err := v.ClaimPendingRewards(userAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), claimed)
+	})
+
+	t.Run("ClaimPendingRewards - claims and clears pending rewards", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		// Set some pending rewards first
+		app, err := v.getKApp()
+		require.NoError(t, err)
+		err = v.setPendingRewards(app, userAddress, 750000)
+		require.NoError(t, err)
+		err = v.saveKApp(app)
+		require.NoError(t, err)
+
+		// Claim rewards
+		claimed, err := v.ClaimPendingRewards(userAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(750000), claimed)
+
+		// Verify rewards are cleared
+		remaining, err := v.GetPendingRewards(userAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), remaining, "pending rewards should be cleared after claim")
+	})
+
+	t.Run("ClaimPendingRewards - multiple claims", func(t *testing.T) {
+		v := setupTest(t)
+		userAddress := makeAddress("user1")
+
+		// Set some pending rewards
+		app, err := v.getKApp()
+		require.NoError(t, err)
+		err = v.setPendingRewards(app, userAddress, 500000)
+		require.NoError(t, err)
+		err = v.saveKApp(app)
+		require.NoError(t, err)
+
+		// First claim
+		claimed1, err := v.ClaimPendingRewards(userAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(500000), claimed1)
+
+		// Second claim should return 0
+		claimed2, err := v.ClaimPendingRewards(userAddress)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), claimed2, "second claim should return 0")
+	})
+
+	t.Run("ClaimPendingRewards - error getting KApp", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppCalled = func(address []byte) (state.KAppAccountHandler, error) {
+			return nil, errors.New("kapp not found")
+		}
+
+		userAddress := makeAddress("user1")
+		claimed, err := v.ClaimPendingRewards(userAddress)
+		assert.Error(t, err)
+		assert.Equal(t, int64(0), claimed)
+	})
+
+	t.Run("ClaimPendingRewards - error from setPendingRewards", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		userAddress := makeAddress("user1")
+
+		storage := make(map[string][]byte)
+		setStorageError := errors.New("storage write error")
+
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppCalled = func(address []byte) (state.KAppAccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{
+				GetStorageCalled: func(key []byte) []byte {
+					return storage[string(key)]
+				},
+				SetStorageCalled: func(key []byte, value []byte) error {
+					// Allow writes initially, fail on clear (value == nil)
+					if value == nil {
+						return setStorageError
+					}
+					storage[string(key)] = value
+					return nil
+				},
+			}, nil
+		}
+
+		// Set some pending rewards first
+		app, err := v.getKApp()
+		require.NoError(t, err)
+		err = v.setPendingRewards(app, userAddress, 100000)
+		require.NoError(t, err)
+
+		// Claim should fail when trying to clear rewards
+		claimed, err := v.ClaimPendingRewards(userAddress)
+		assert.Equal(t, setStorageError, err)
+		assert.Equal(t, int64(0), claimed)
+	})
+
+	t.Run("ClaimPendingRewards - error from saveKApp", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		userAddress := makeAddress("user1")
+
+		storage := make(map[string][]byte)
+		saveKAppError := errors.New("save kapp error")
+
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppCalled = func(address []byte) (state.KAppAccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{
+				GetStorageCalled: func(key []byte) []byte {
+					return storage[string(key)]
+				},
+				SetStorageCalled: func(key []byte, value []byte) error {
+					if value == nil {
+						delete(storage, string(key))
+					} else {
+						storage[string(key)] = value
+					}
+					return nil
+				},
+			}, nil
+		}
+
+		v.accountsCacher.(*mock.AccountsCacherStub).UpdateKappCalled = func(account state.AccountHandler) error {
+			return saveKAppError
+		}
+
+		// Set some pending rewards first
+		app, err := v.getKApp()
+		require.NoError(t, err)
+		err = v.setPendingRewards(app, userAddress, 100000)
+		require.NoError(t, err)
+
+		// Claim should fail when trying to save KApp
+		claimed, err := v.ClaimPendingRewards(userAddress)
+		assert.Equal(t, saveKAppError, err)
+		assert.Equal(t, int64(0), claimed)
+	})
 }

--- a/core/kapp/validators/validators_test.go
+++ b/core/kapp/validators/validators_test.go
@@ -3,6 +3,7 @@ package validators
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/klever-io/klever-go/common"
@@ -363,6 +364,203 @@ func TestValidatorsKApp_Delegate(t *testing.T) {
 		assert.Equal(t, transaction.Transaction_BucketIDInvalid, resultCode)
 		assert.Equal(t, common.ErrInvalidValue, err)
 		assert.Len(t, update, 0)
+	})
+
+	t.Run("Delegation fails when max buckets reached (EpochRewardsV2 enabled)", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		addStorageCacher(v)
+
+		// Ensure EpochRewardsV2 is enabled (default in mock)
+		v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = true
+
+		registerValidator(t, v, validatorAddress, []byte("blspubkey"))
+
+		// Pre-populate validator with max buckets
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		pd := &PeerData{Buckets: make(map[string]*PeerBucket)}
+		for i := range MaxBucketsPerValidator {
+			bucketKey := hex.EncodeToString(fmt.Appendf(nil, "existingbucket%d", i))
+			pd.Buckets[bucketKey] = &PeerBucket{
+				Value:            1000,
+				DelegatedEpoch:   1,
+				UndelegatedEpoch: core.DefaultUndelegatedEpoch,
+				Address:          []byte("existingsender"),
+			}
+		}
+		err = v.setValidatorBuckets(app, validatorAddress, pd)
+		require.NoError(t, err)
+		err = v.saveKApp(app)
+		require.NoError(t, err)
+
+		// Try to delegate a new bucket
+		newBucketID := []byte("newbucket")
+		tc := &transaction.DelegateContract{
+			ToAddress: validatorAddress,
+			BucketID:  newBucketID,
+		}
+
+		senderAcc := &mock.UserAccountHandlerStub{
+			GetBucketsCalled: func(_ []byte, _ bool) map[string]*kapps.UserBucket {
+				return map[string]*kapps.UserBucket{
+					hex.EncodeToString(newBucketID): {
+						Value:         500,
+						UnstakedEpoch: core.DefaultUnstakedEpoch,
+					},
+				}
+			},
+		}
+		v.accountsCacher.(*mock.AccountsCacherStub).GetExistingUserCalled = func(address []byte) (state.UserAccountHandler, error) {
+			return senderAcc, nil
+		}
+
+		resultCode, update, err := v.Delegate([]byte("newsender"), 2000, 2, tc)
+
+		assert.Equal(t, transaction.Transaction_AccountError, resultCode)
+		assert.Equal(t, common.ErrValidatorMaxDelegatorsReached, err)
+		assert.Len(t, update, 0)
+	})
+
+	t.Run("Delegation allowed when EpochRewardsV2 disabled (no bucket limit)", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		addStorageCacher(v)
+
+		// Disable EpochRewardsV2 fork
+		v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = false
+
+		registerValidator(t, v, validatorAddress, []byte("blspubkey"))
+
+		// Pre-populate validator with max buckets
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		pd := &PeerData{Buckets: make(map[string]*PeerBucket)}
+		for i := range MaxBucketsPerValidator {
+			bucketKey := hex.EncodeToString(fmt.Appendf(nil, "existingbucket%d", i))
+			pd.Buckets[bucketKey] = &PeerBucket{
+				Value:            1000,
+				DelegatedEpoch:   1,
+				UndelegatedEpoch: core.DefaultUndelegatedEpoch,
+				Address:          []byte("existingsender"),
+			}
+		}
+		err = v.setValidatorBuckets(app, validatorAddress, pd)
+		require.NoError(t, err)
+		err = v.saveKApp(app)
+		require.NoError(t, err)
+
+		// Try to delegate a new bucket - should succeed since fork is disabled
+		newBucketID := []byte("newbucket")
+		tc := &transaction.DelegateContract{
+			ToAddress: validatorAddress,
+			BucketID:  newBucketID,
+		}
+
+		senderAcc := &mock.UserAccountHandlerStub{
+			GetBucketsCalled: func(_ []byte, _ bool) map[string]*kapps.UserBucket {
+				return map[string]*kapps.UserBucket{
+					hex.EncodeToString(newBucketID): {
+						Value:         500,
+						UnstakedEpoch: core.DefaultUnstakedEpoch,
+					},
+				}
+			},
+		}
+		v.accountsCacher.(*mock.AccountsCacherStub).GetExistingUserCalled = func(address []byte) (state.UserAccountHandler, error) {
+			return senderAcc, nil
+		}
+
+		resultCode, update, err := v.Delegate([]byte("newsender"), 2000, 2, tc)
+
+		assert.Equal(t, transaction.Transaction_Ok, resultCode)
+		assert.Nil(t, err)
+		assert.Len(t, update, 1)
+
+		// Verify bucket count now exceeds max (only possible when fork disabled)
+		app, _ = v.getKApp()
+		pd, err = v.getValidatorBuckets(app, validatorAddress)
+		require.NoError(t, err)
+		assert.Equal(t, MaxBucketsPerValidator+1, len(pd.Buckets))
+	})
+
+	t.Run("Re-delegation allowed even when at max buckets (EpochRewardsV2 enabled)", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		addStorageCacher(v)
+
+		// Enable EpochRewardsV2 fork
+		v.forkController.(*mock.ForkControllerStub).EpochRewardsV2Value = true
+
+		registerValidator(t, v, validatorAddress, []byte("blspubkey"))
+
+		// Pre-populate validator with max buckets, including the one we'll re-delegate
+		app, err := v.getKApp()
+		require.NoError(t, err)
+
+		existingBucketID := []byte("existingbucket0")
+		encodedExistingBucketID := hex.EncodeToString(existingBucketID)
+
+		pd := &PeerData{Buckets: make(map[string]*PeerBucket)}
+		// First bucket is the one we'll re-delegate
+		pd.Buckets[encodedExistingBucketID] = &PeerBucket{
+			Value:            500,
+			DelegatedEpoch:   1,
+			UndelegatedEpoch: core.DefaultUndelegatedEpoch,
+			Address:          []byte("originalsender"),
+		}
+		// Fill remaining buckets to reach max
+		for i := 1; i < MaxBucketsPerValidator; i++ {
+			bucketKey := hex.EncodeToString(fmt.Appendf(nil, "existingbucket%d", i))
+			pd.Buckets[bucketKey] = &PeerBucket{
+				Value:            1000,
+				DelegatedEpoch:   1,
+				UndelegatedEpoch: core.DefaultUndelegatedEpoch,
+				Address:          []byte("existingsender"),
+			}
+		}
+		err = v.setValidatorBuckets(app, validatorAddress, pd)
+		require.NoError(t, err)
+		err = v.saveKApp(app)
+		require.NoError(t, err)
+
+		// Re-delegate the existing bucket with updated value
+		tc := &transaction.DelegateContract{
+			ToAddress: validatorAddress,
+			BucketID:  existingBucketID,
+		}
+
+		senderAcc := &mock.UserAccountHandlerStub{
+			GetBucketsCalled: func(_ []byte, _ bool) map[string]*kapps.UserBucket {
+				return map[string]*kapps.UserBucket{
+					encodedExistingBucketID: {
+						Value:         1500, // Updated value
+						UnstakedEpoch: core.DefaultUnstakedEpoch,
+					},
+				}
+			},
+		}
+		v.accountsCacher.(*mock.AccountsCacherStub).GetExistingUserCalled = func(address []byte) (state.UserAccountHandler, error) {
+			return senderAcc, nil
+		}
+
+		resultCode, update, err := v.Delegate([]byte("originalsender"), 2000, 2, tc)
+
+		// Should succeed because bucket already exists (re-delegation)
+		assert.Equal(t, transaction.Transaction_Ok, resultCode)
+		assert.Nil(t, err)
+		assert.Len(t, update, 1)
+
+		// Verify bucket count remains at max (no new bucket added)
+		app, _ = v.getKApp()
+		pd, err = v.getValidatorBuckets(app, validatorAddress)
+		require.NoError(t, err)
+		assert.Equal(t, MaxBucketsPerValidator, len(pd.Buckets))
+
+		// Verify the re-delegated bucket has updated value
+		assert.Equal(t, int64(1500), pd.Buckets[encodedExistingBucketID].Value)
 	})
 }
 

--- a/core/process/transaction/txProcessRewards_test.go
+++ b/core/process/transaction/txProcessRewards_test.go
@@ -90,8 +90,10 @@ func TestRewards_ValidatorRewards_BeforeFixDelegationSameEpochFork(t *testing.T)
 	initialBalance := int64(100_000_000_000)
 	freezeBalance := int64(100_000_000)
 
+	// V1: Disable both FixDelegationSameEpoch and EpochRewardsV2
 	c.UpdateForkController(config.EnableEpochs{
 		FixDelegationSameEpoch: 100_000,
+		EpochRewardsV2:         100_000,
 	})
 
 	// Create Users
@@ -160,6 +162,11 @@ func TestRewards_ValidatorRewards_AfterFixDelegationSameEpochFork(t *testing.T) 
 	initialBalance := int64(100_000_000_000)
 	freezeBalance := int64(100_000_000)
 
+	// V1: Disable EpochRewardsV2 by setting it to a high epoch
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 100_000,
+	})
+
 	// Create Users
 	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
 	c.AddUser(userB, initialBalance, kdautils.KLVIdentifier)
@@ -216,9 +223,66 @@ func TestRewards_ValidatorRewards_AfterFixDelegationSameEpochFork(t *testing.T) 
 	err = c.kappController.GetValidatorsKApp().ProcessEconomicsEndOfEpoch(3, validatorInfo)
 	require.Nil(t, err)
 
+	// V1: rewards go to user allowance
 	assert.Equal(t, rewardsA, c.GetAllowance(userA))
 	assert.Equal(t, rewardsB, c.GetAllowance(userB))
+}
 
+func TestRewards_ValidatorRewards_V2_EpochRewards(t *testing.T) {
+	c := NewController(t)
+
+	initialBalance := int64(100_000_000_000)
+	freezeBalance := int64(100_000_000)
+
+	// Enable V2 epoch rewards
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 0, // Enable from epoch 0
+	})
+
+	// Create Users
+	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(userB, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(validatorA, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(validatorB, initialBalance, kdautils.KLVIdentifier)
+
+	// Create Validators
+	blk := c.CreateBlockHeader(0, 1, 1)
+	CreateValidators(c, blk)
+
+	validatorInfo := []*state.ValidatorInfo{{OwnerAddress: validatorA, PublicKey: peerAddressA}, {OwnerAddress: validatorB, PublicKey: peerAddressB}}
+
+	// Users need to Freeze KLV
+	blk = c.CreateBlockHeader(0, 1, 2)
+	bucketUserA := c.RunFreezeTX(blk, userA, kdautils.KLVIdentifier, freezeBalance)
+	bucketUserB := c.RunFreezeTX(blk, userB, kdautils.KLVIdentifier, freezeBalance)
+
+	// User A and B delegate to validator A
+	blk = c.CreateBlockHeader(0, 1, 3)
+	c.RunDelegateTX(blk, userA, bucketUserA, validatorA)
+	c.RunDelegateTX(blk, userB, bucketUserB, validatorA)
+
+	// Change Delegation of User B before epoch change
+	blk = c.CreateBlockHeader(0, 1, 4)
+	c.RunDelegateTX(blk, userB, bucketUserB, validatorB)
+
+	rewardsA := int64(100)
+	rewardsB := int64(50)
+
+	err := c.AddFeesToPeer(peerAddressA, rewardsA)
+	require.Nil(t, err)
+	err = c.AddFeesToPeer(peerAddressB, rewardsB)
+	require.Nil(t, err)
+
+	err = c.kappController.GetValidatorsKApp().ProcessEconomicsEndOfEpoch(3, validatorInfo)
+	require.Nil(t, err)
+
+	// V2: rewards go to pending rewards (NOT to user allowance)
+	assert.Equal(t, int64(0), c.GetAllowance(userA), "V2 should NOT add rewards to user allowance")
+	assert.Equal(t, int64(0), c.GetAllowance(userB), "V2 should NOT add rewards to user allowance")
+
+	// V2: rewards are stored in pending rewards trie
+	assert.Equal(t, rewardsA, c.GetPendingRewards(userA))
+	assert.Equal(t, rewardsB, c.GetPendingRewards(userB))
 }
 
 func TestRewards_ValidatorRewards_RemainFees(t *testing.T) {
@@ -226,6 +290,11 @@ func TestRewards_ValidatorRewards_RemainFees(t *testing.T) {
 
 	initialBalance := int64(100_000_000_000)
 	freezeBalance := int64(100_000_000)
+
+	// V1: Disable EpochRewardsV2 by setting it to a high epoch
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 100_000,
+	})
 
 	// Create Users
 	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
@@ -276,6 +345,12 @@ func Test_ValidatorRewards_Comission_20(t *testing.T) {
 	initialBalance := int64(100_000_000_000)
 
 	c := NewController(t)
+
+	// V1: Disable EpochRewardsV2 by setting it to a high epoch
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 100_000,
+	})
+
 	// we want to create a user to delegate to validator A only because we don't want this validator get any remaining Fees
 	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
 	c.AddUser(validatorA, initialBalance, kdautils.KLVIdentifier)
@@ -347,6 +422,12 @@ func Test_ValidatorRewards_Comission_2000(t *testing.T) {
 	initialBalance := int64(100_000_000_000)
 
 	c := NewController(t)
+
+	// V1: Disable EpochRewardsV2 by setting it to a high epoch
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 100_000,
+	})
+
 	// we want to create a user to delegate to validator A only because we don't want this validator get any remaining Fees
 	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
 	c.AddUser(validatorA, initialBalance, kdautils.KLVIdentifier)
@@ -402,4 +483,214 @@ func Test_ValidatorRewards_Comission_2000(t *testing.T) {
 
 	assert.Equal(t, expectedValidatorReward, c.GetAllowance(testReferralAddress)) // 200000 is 20% of 1000000
 	assert.Equal(t, rewardsA-expectedValidatorReward, c.GetAllowance(userA))      // userA receives 800000
+}
+
+func TestRewards_ValidatorRewards_V2_RemainFees(t *testing.T) {
+	c := NewController(t)
+
+	initialBalance := int64(100_000_000_000)
+	freezeBalance := int64(100_000_000)
+
+	// Enable V2 epoch rewards
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 0,
+	})
+
+	// Create Users
+	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(userB, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(userC, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(validatorA, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(validatorB, initialBalance, kdautils.KLVIdentifier)
+
+	// Create Validators
+	blk := c.CreateBlockHeader(0, 1, 1)
+	CreateValidators(c, blk)
+
+	// Users need to Freeze KLV
+	blk = c.CreateBlockHeader(0, 1, 2)
+	bucketUserA := c.RunFreezeTX(blk, userA, kdautils.KLVIdentifier, freezeBalance)
+	bucketUserB := c.RunFreezeTX(blk, userB, kdautils.KLVIdentifier, freezeBalance)
+	bucketUserC := c.RunFreezeTX(blk, userC, kdautils.KLVIdentifier, freezeBalance)
+
+	// User A, B and C delegate their current bucket to validator A
+	blk = c.CreateBlockHeader(0, 1, 3)
+	c.RunDelegateTX(blk, userA, bucketUserA, validatorA)
+	c.RunDelegateTX(blk, userB, bucketUserB, validatorA)
+	c.RunDelegateTX(blk, userC, bucketUserC, validatorA)
+
+	// Simulate rewards distribution
+	rewardsA := int64(100)
+
+	err := c.AddFeesToPeer(peerAddressA, rewardsA)
+	require.Nil(t, err)
+
+	validatorInfo := []*state.ValidatorInfo{{OwnerAddress: validatorA, PublicKey: peerAddressA}}
+
+	err = c.kappController.GetValidatorsKApp().ProcessEconomicsEndOfEpoch(3, validatorInfo)
+	require.Nil(t, err)
+
+	// V2: rewards go to pending rewards (NOT to user allowance)
+	assert.Equal(t, int64(0), c.GetAllowance(userA), "V2 should NOT add rewards to user allowance")
+	assert.Equal(t, int64(0), c.GetAllowance(userB), "V2 should NOT add rewards to user allowance")
+	assert.Equal(t, int64(0), c.GetAllowance(userC), "V2 should NOT add rewards to user allowance")
+
+	// V2: rewards are stored in pending rewards trie
+	assert.Equal(t, int64(33), c.GetPendingRewards(userA))
+	assert.Equal(t, int64(33), c.GetPendingRewards(userB))
+	assert.Equal(t, int64(33), c.GetPendingRewards(userC))
+	assert.Equal(t, int64(1), c.GetPendingRewards(testReferralAddress)) // remaining fees go to validator reward address
+}
+
+func Test_ValidatorRewards_V2_Commission_20(t *testing.T) {
+	initialBalance := int64(100_000_000_000)
+
+	c := NewController(t)
+
+	// Enable V2 epoch rewards
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 0,
+	})
+
+	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(validatorA, initialBalance, kdautils.KLVIdentifier)
+
+	blk := c.CreateBlockHeader(0, 1, 1)
+
+	freezeContract := transaction.FreezeContract{
+		AssetID: kdautils.KLVIdentifier,
+		Amount:  MinFreezeAmount,
+	}
+
+	// Validator A Self Stake
+	freezeTx, _ := createTransactionMock(&freezeContract, transaction.TXContract_FreezeContractType, validatorA, 0)
+	_, freezeHashTx, err := c.execTx.PreProcessTransaction(freezeTx)
+	require.Nil(c.t, err)
+
+	err = c.execTx.ProcessTransaction(blk, freezeHashTx, freezeTx)
+	require.Equal(c.t, nil, err)
+
+	createValidatorContract := transaction.CreateValidatorContract{
+		OwnerAddress: validatorA,
+		Config: &transaction.ValidatorConfig{
+			BLSPublicKey:        peerAddressA,
+			RewardAddress:       testReferralAddress,
+			CanDelegate:         true,
+			MaxDelegationAmount: 100_000_000_000,
+			Commission:          20, // 20 Represents a commission of 0.2%
+		},
+	}
+
+	createValidatorTx, _ := createTransactionMock(&createValidatorContract, transaction.TXContract_CreateValidatorContractType, validatorA, 0)
+	_, createValidatorTxHash, err := c.execTx.PreProcessTransaction(createValidatorTx)
+	require.Nil(c.t, err)
+
+	err = c.execTx.ProcessTransaction(blk, createValidatorTxHash, createValidatorTx)
+	require.Equal(c.t, nil, err)
+
+	blk = c.CreateBlockHeader(0, 1, 2)
+
+	// User A Freezes and delegate the bucket to Validator A
+	bucketUserA := c.RunFreezeTX(blk, userA, freezeContract.AssetID, freezeContract.Amount)
+	blk = c.CreateBlockHeader(0, 1, 3)
+	c.RunDelegateTX(blk, userA, bucketUserA, validatorA)
+
+	rewardsA := int64(1_000_000) // 1 KLV of reward
+	require.NoError(t, c.AddFeesToPeer(peerAddressA, rewardsA))
+
+	validatorInfo := []*state.ValidatorInfo{{OwnerAddress: validatorA, PublicKey: peerAddressA}}
+	err = c.kappController.GetValidatorsKApp().ProcessEconomicsEndOfEpoch(3, validatorInfo)
+	require.Equal(c.t, nil, err)
+
+	expectedValidatorReward := int64(2000)
+
+	// V2: rewards go to pending rewards (NOT to user allowance)
+	assert.Equal(t, int64(0), c.GetAllowance(testReferralAddress), "V2 should NOT add rewards to user allowance")
+	assert.Equal(t, int64(0), c.GetAllowance(userA), "V2 should NOT add rewards to user allowance")
+
+	// V2: rewards are stored in pending rewards trie
+	assert.Equal(t, expectedValidatorReward, c.GetPendingRewards(testReferralAddress)) // 2000 is 0.2% of 1000000
+	assert.Equal(t, rewardsA-expectedValidatorReward, c.GetPendingRewards(userA))      // userA receives 998000
+
+	// Second epoch of rewards
+	rewardsB := int64(100)
+	require.NoError(t, c.AddFeesToPeer(peerAddressA, rewardsB))
+
+	err = c.kappController.GetValidatorsKApp().ProcessEconomicsEndOfEpoch(4, validatorInfo)
+	require.Equal(c.t, nil, err)
+
+	// V2: rewards accumulate in pending rewards
+	assert.Equal(t, expectedValidatorReward, c.GetPendingRewards(testReferralAddress))     // validatorA receives 0 for second epoch because can't get fraction of klv
+	assert.Equal(t, rewardsA+rewardsB-expectedValidatorReward, c.GetPendingRewards(userA)) // userA receives 100 more
+}
+
+func Test_ValidatorRewards_V2_Commission_2000(t *testing.T) {
+	initialBalance := int64(100_000_000_000)
+
+	c := NewController(t)
+
+	// Enable V2 epoch rewards
+	c.UpdateForkController(config.EnableEpochs{
+		EpochRewardsV2: 0,
+	})
+
+	c.AddUser(userA, initialBalance, kdautils.KLVIdentifier)
+	c.AddUser(validatorA, initialBalance, kdautils.KLVIdentifier)
+
+	blk := c.CreateBlockHeader(0, 1, 1)
+
+	freezeContract := transaction.FreezeContract{
+		AssetID: kdautils.KLVIdentifier,
+		Amount:  MinFreezeAmount,
+	}
+
+	// Validator A Self Stake
+	freezeTx, _ := createTransactionMock(&freezeContract, transaction.TXContract_FreezeContractType, validatorA, 0)
+	_, freezeHashTx, err := c.execTx.PreProcessTransaction(freezeTx)
+	require.Nil(c.t, err)
+
+	err = c.execTx.ProcessTransaction(blk, freezeHashTx, freezeTx)
+	require.Equal(c.t, nil, err)
+
+	createValidatorContract := transaction.CreateValidatorContract{
+		OwnerAddress: validatorA,
+		Config: &transaction.ValidatorConfig{
+			BLSPublicKey:        peerAddressA,
+			RewardAddress:       testReferralAddress,
+			CanDelegate:         true,
+			MaxDelegationAmount: 100_000_000_000,
+			Commission:          2000, // 2000 Represents a commission of 20%
+		},
+	}
+
+	createValidatorTx, _ := createTransactionMock(&createValidatorContract, transaction.TXContract_CreateValidatorContractType, validatorA, 0)
+	_, createValidatorTxHash, err := c.execTx.PreProcessTransaction(createValidatorTx)
+	require.Nil(c.t, err)
+
+	err = c.execTx.ProcessTransaction(blk, createValidatorTxHash, createValidatorTx)
+	require.Equal(c.t, nil, err)
+
+	blk = c.CreateBlockHeader(0, 1, 2)
+
+	// User A Freezes and delegate the bucket to Validator A
+	bucketUserA := c.RunFreezeTX(blk, userA, freezeContract.AssetID, freezeContract.Amount)
+	blk = c.CreateBlockHeader(0, 1, 3)
+	c.RunDelegateTX(blk, userA, bucketUserA, validatorA)
+
+	rewardsA := int64(1_000_000) // 1 KLV of reward
+	require.NoError(t, c.AddFeesToPeer(peerAddressA, rewardsA))
+
+	validatorInfo := []*state.ValidatorInfo{{OwnerAddress: validatorA, PublicKey: peerAddressA}}
+	err = c.kappController.GetValidatorsKApp().ProcessEconomicsEndOfEpoch(3, validatorInfo)
+	require.Equal(c.t, nil, err)
+
+	expectedValidatorReward := int64(200000)
+
+	// V2: rewards go to pending rewards (NOT to user allowance)
+	assert.Equal(t, int64(0), c.GetAllowance(testReferralAddress), "V2 should NOT add rewards to user allowance")
+	assert.Equal(t, int64(0), c.GetAllowance(userA), "V2 should NOT add rewards to user allowance")
+
+	// V2: rewards are stored in pending rewards trie
+	assert.Equal(t, expectedValidatorReward, c.GetPendingRewards(testReferralAddress)) // 200000 is 20% of 1000000
+	assert.Equal(t, rewardsA-expectedValidatorReward, c.GetPendingRewards(userA))      // userA receives 800000
 }

--- a/core/process/transaction/txProcessStaking_test.go
+++ b/core/process/transaction/txProcessStaking_test.go
@@ -532,6 +532,14 @@ func (c *Controller) GetAllowance(addr []byte) int64 {
 	return ownerAcc.GetAllowance()
 }
 
+func (c *Controller) GetPendingRewards(addr []byte) int64 {
+	rewards, err := c.kappController.GetValidatorsKApp().GetPendingRewards(addr)
+	if err != nil {
+		return 0
+	}
+	return rewards
+}
+
 func (c *Controller) AddFeesToPeer(addr []byte, amount int64) error {
 	ownerPeer := loadPeerAccount(c.accCacher, addr)
 	ownerPeer.AddToAccumulatedFees(amount)

--- a/docs/node_docs.go
+++ b/docs/node_docs.go
@@ -1914,6 +1914,13 @@ const docTemplatenode = `{
                         }
                     }
                 },
+                "TxResults": {
+                    "description": "Transaction execution result codes for timeout validation",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "hash": {
                     "type": "string"
                 },
@@ -2244,6 +2251,9 @@ const docTemplatenode = `{
                 "claimKFI": {
                     "type": "integer"
                 },
+                "epochRewardsV2": {
+                    "type": "integer"
+                },
                 "fixAuditChanges": {
                     "type": "integer"
                 },
@@ -2429,6 +2439,9 @@ const docTemplatenode = `{
             "type": "object",
             "properties": {
                 "address": {
+                    "type": "string"
+                },
+                "caller": {
                     "type": "string"
                 },
                 "contractId": {

--- a/docs/node_swagger.json
+++ b/docs/node_swagger.json
@@ -1906,6 +1906,13 @@
                         }
                     }
                 },
+                "TxResults": {
+                    "description": "Transaction execution result codes for timeout validation",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "hash": {
                     "type": "string"
                 },
@@ -2236,6 +2243,9 @@
                 "claimKFI": {
                     "type": "integer"
                 },
+                "epochRewardsV2": {
+                    "type": "integer"
+                },
                 "fixAuditChanges": {
                     "type": "integer"
                 },
@@ -2421,6 +2431,9 @@
             "type": "object",
             "properties": {
                 "address": {
+                    "type": "string"
+                },
+                "caller": {
                     "type": "string"
                 },
                 "contractId": {

--- a/docs/node_swagger.yaml
+++ b/docs/node_swagger.yaml
@@ -62,6 +62,11 @@ definitions:
             type: integer
           type: array
         type: array
+      TxResults:
+        description: Transaction execution result codes for timeout validation
+        items:
+          type: integer
+        type: array
       hash:
         type: string
       status:
@@ -280,6 +285,8 @@ definitions:
         type: integer
       claimKFI:
         type: integer
+      epochRewardsV2:
+        type: integer
       fixAuditChanges:
         type: integer
       fixDelegationSameEpoch:
@@ -401,6 +408,8 @@ definitions:
   data.Logs:
     properties:
       address:
+        type: string
+      caller:
         type: string
       contractId:
         type: integer

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -1417,7 +1417,64 @@ func (ei *elasticProcessor) SaveAccounts(
 	return ei.doBulkRequests(accountsIndex, buffSlice.Buffers())
 }
 
-// SaveAccounts will prepare and save information about provided accounts in elasticsearch server
+// convertPermissions converts user account permissions to indexer format.
+func (ei *elasticProcessor) convertPermissions(perms []*state.Permission) []data.Permissions {
+	permissions := make([]data.Permissions, 0, len(perms))
+	for _, p := range perms {
+		keys := make([]data.PermissionKey, 0, len(p.Signers))
+		for _, k := range p.Signers {
+			keys = append(keys, data.PermissionKey{
+				Address: ei.addressPubkeyConverter.Encode(k.Address),
+				Weight:  k.Weight,
+			})
+		}
+		permissions = append(permissions, data.Permissions{
+			ID:             p.ID,
+			Type:           int32(p.Type),
+			PermissionName: p.PermissionName,
+			Threshold:      p.Threshold,
+			Operations:     hex.EncodeToString(p.Operations),
+			Signers:        keys,
+		})
+	}
+	return permissions
+}
+
+// calculateUnfrozenBalance sums the value of all unstaked buckets.
+func calculateUnfrozenBalance(buckets map[string]*kapps.UserBucket) int64 {
+	unfrozenBalance := int64(0)
+	for _, bucket := range buckets {
+		if bucket.UnstakedEpoch != core.DefaultUnstakedEpoch {
+			unfrozenBalance += bucket.Value
+		}
+	}
+	return unfrozenBalance
+}
+
+// getAllowanceWithPendingRewards returns the allowance including V2 pending rewards.
+func (ei *elasticProcessor) getAllowanceWithPendingRewards(userAccount state.UserAccountHandler) int64 {
+	allowance := userAccount.GetAllowance()
+	if check.IfNil(ei.kappsController) {
+		return allowance
+	}
+
+	pendingRewards, err := ei.kappsController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
+	if err == nil && pendingRewards > 0 {
+		allowance += pendingRewards
+	}
+	return allowance
+}
+
+// dispatchAccountEvents sends account events to the event queue if enabled.
+func dispatchAccountEvents(accountsMap map[string]*data.AccountInfo) {
+	if UseEventQueue && len(accountsMap) > 0 {
+		EventQueue <- Event{
+			EvType:  ACCOUNTS,
+			Message: accountsMap,
+		}
+	}
+}
+
 func (ei *elasticProcessor) saveAccounts(
 	blockTimestamp int64,
 	accountsSlice []*data.Account,
@@ -1430,100 +1487,61 @@ func (ei *elasticProcessor) saveAccounts(
 	newAccountsMap := make(map[string]*data.AccountInfo)
 	updateAccountsMap := make(map[string]*data.AccountInfo)
 	historyAccountsMap := make(map[string]*data.AccountInfo)
+
 	for _, userAccount := range accountsSlice {
-		address := ei.addressPubkeyConverter.Encode(userAccount.UserAccount.AddressBytes())
-
-		permissions := make([]data.Permissions, 0)
-		for _, p := range userAccount.UserAccount.GetPermissions() {
-			keys := make([]data.PermissionKey, 0)
-			for _, k := range p.Signers {
-				keys = append(keys, data.PermissionKey{
-					Address: ei.addressPubkeyConverter.Encode(k.Address),
-					Weight:  k.Weight,
-				})
-			}
-			permissions = append(permissions, data.Permissions{
-				ID:             p.ID,
-				Type:           int32(p.Type),
-				PermissionName: p.PermissionName,
-				Threshold:      p.Threshold,
-				Operations:     hex.EncodeToString(p.Operations),
-				Signers:        keys,
-			})
-		}
-
-		userKDA, err := userAccount.UserAccount.GetUserKDA(kdautils.KLVIdentifier, nil, true)
+		acc, err := ei.buildAccountInfo(userAccount, blockTimestamp)
 		if err != nil {
 			return err
 		}
 
-		unfrozenBalance := int64(0)
-		for _, bucket := range userKDA.Buckets {
-			if bucket.UnstakedEpoch != core.DefaultUnstakedEpoch {
-				unfrozenBalance += bucket.Value
-			}
-		}
-
-		// V2 Epoch Rewards: Include pending rewards in allowance
-		allowance := userAccount.UserAccount.GetAllowance()
-		if !check.IfNil(ei.kappsController) {
-			pendingRewards, err := ei.kappsController.GetValidatorsKApp().GetPendingRewards(userAccount.UserAccount.AddressBytes())
-			if err == nil && pendingRewards > 0 {
-				allowance += pendingRewards
-			}
-		}
-
-		acc := &data.AccountInfo{
-			Address:         address,
-			Nonce:           userAccount.UserAccount.GetNonce(),
-			Name:            string(userAccount.UserAccount.GetName()),
-			RootHash:        hex.EncodeToString(userAccount.UserAccount.GetRootHash()),
-			Balance:         userAccount.UserAccount.GetBalance(kdautils.KLVIdentifier, true),
-			FrozenBalance:   userKDA.FrozenBalance,
-			UnfrozenBalance: unfrozenBalance,
-			Allowance:       allowance,
-			Permissions:     permissions,
-			Timestamp:       time.Duration(blockTimestamp * 1000),
-			CodeHash:        hex.EncodeToString(userAccount.UserAccount.GetCodeHash()),
-			CodeMetadata:    hex.EncodeToString(userAccount.UserAccount.GetCodeMetadata()),
-			Foundation:      false,
-		}
-
-		exist := ei.elasticClient.DocExists(accountsIndex, address)
-		if !exist {
-			newAccountsMap[address] = acc
-		} else {
+		address := acc.Address
+		if ei.elasticClient.DocExists(accountsIndex, address) {
 			updateAccountsMap[address] = acc
+		} else {
+			newAccountsMap[address] = acc
 		}
 		historyAccountsMap[address] = acc
 	}
 
-	// Dispatch event
-	if UseEventQueue && len(newAccountsMap) > 0 {
-		EventQueue <- Event{
-			EvType:  ACCOUNTS,
-			Message: newAccountsMap,
-		}
-	}
+	dispatchAccountEvents(newAccountsMap)
+	dispatchAccountEvents(updateAccountsMap)
 
-	if UseEventQueue && len(updateAccountsMap) > 0 {
-		EventQueue <- Event{
-			EvType:  ACCOUNTS,
-			Message: updateAccountsMap,
-		}
-	}
-
-	err := serializeAccounts(newAccountsMap, buffSlice, accountsIndex)
-	if err != nil {
+	if err := serializeAccounts(newAccountsMap, buffSlice, accountsIndex); err != nil {
 		return err
 	}
 
-	err = serializedDataForUpdateAccounts(updateAccountsMap, buffSlice, accountsIndex)
-	if err != nil {
+	if err := serializedDataForUpdateAccounts(updateAccountsMap, buffSlice, accountsIndex); err != nil {
 		return err
 	}
 
 	return ei.saveAccountsHistory(blockTimestamp, historyAccountsMap)
+}
+
+// buildAccountInfo creates an AccountInfo from a user account.
+func (ei *elasticProcessor) buildAccountInfo(userAccount *data.Account, blockTimestamp int64) (*data.AccountInfo, error) {
+	address := ei.addressPubkeyConverter.Encode(userAccount.UserAccount.AddressBytes())
+	permissions := ei.convertPermissions(userAccount.UserAccount.GetPermissions())
+
+	userKDA, err := userAccount.UserAccount.GetUserKDA(kdautils.KLVIdentifier, nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data.AccountInfo{
+		Address:         address,
+		Nonce:           userAccount.UserAccount.GetNonce(),
+		Name:            string(userAccount.UserAccount.GetName()),
+		RootHash:        hex.EncodeToString(userAccount.UserAccount.GetRootHash()),
+		Balance:         userAccount.UserAccount.GetBalance(kdautils.KLVIdentifier, true),
+		FrozenBalance:   userKDA.FrozenBalance,
+		UnfrozenBalance: calculateUnfrozenBalance(userKDA.Buckets),
+		Allowance:       ei.getAllowanceWithPendingRewards(userAccount.UserAccount),
+		Permissions:     permissions,
+		Timestamp:       time.Duration(blockTimestamp * 1000),
+		CodeHash:        hex.EncodeToString(userAccount.UserAccount.GetCodeHash()),
+		CodeMetadata:    hex.EncodeToString(userAccount.UserAccount.GetCodeMetadata()),
+		Foundation:      false,
+	}, nil
 }
 
 func (ei *elasticProcessor) saveAccountsHistory(blockTimestamp int64, accountsInfoMap map[string]*data.AccountInfo) error {

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -1464,6 +1464,15 @@ func (ei *elasticProcessor) saveAccounts(
 			}
 		}
 
+		// V2 Epoch Rewards: Include pending rewards in allowance
+		allowance := userAccount.UserAccount.GetAllowance()
+		if !check.IfNil(ei.kappsController) {
+			pendingRewards, err := ei.kappsController.GetValidatorsKApp().GetPendingRewards(userAccount.UserAccount.AddressBytes())
+			if err == nil && pendingRewards > 0 {
+				allowance += pendingRewards
+			}
+		}
+
 		acc := &data.AccountInfo{
 			Address:         address,
 			Nonce:           userAccount.UserAccount.GetNonce(),
@@ -1472,7 +1481,7 @@ func (ei *elasticProcessor) saveAccounts(
 			Balance:         userAccount.UserAccount.GetBalance(kdautils.KLVIdentifier, true),
 			FrozenBalance:   userKDA.FrozenBalance,
 			UnfrozenBalance: unfrozenBalance,
-			Allowance:       userAccount.UserAccount.GetAllowance(),
+			Allowance:       allowance,
 			Permissions:     permissions,
 			Timestamp:       time.Duration(blockTimestamp * 1000),
 			CodeHash:        hex.EncodeToString(userAccount.UserAccount.GetCodeHash()),

--- a/indexer/elasticProcessor_test.go
+++ b/indexer/elasticProcessor_test.go
@@ -13,13 +13,18 @@ import (
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/kapp"
 	nodeData "github.com/klever-io/klever-go/data"
 	dataBlock "github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/indexer"
+	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/indexer/data"
 	"github.com/klever-io/klever-go/indexer/logsevents"
 	imock "github.com/klever-io/klever-go/indexer/mock"
+	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/kvm/mock/stub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -304,4 +309,476 @@ func TestDoBulkRequestLimit(t *testing.T) {
 		err := esDatabase.SaveTransactions(header, &indexer.Pool{Txs: txsPool})
 		require.Nil(t, err)
 	}
+}
+
+func TestCalculateUnfrozenBalance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		buckets  map[string]*kapps.UserBucket
+		expected int64
+	}{
+		{
+			name:     "nil buckets returns zero",
+			buckets:  nil,
+			expected: 0,
+		},
+		{
+			name:     "empty buckets returns zero",
+			buckets:  map[string]*kapps.UserBucket{},
+			expected: 0,
+		},
+		{
+			name: "all staked buckets returns zero",
+			buckets: map[string]*kapps.UserBucket{
+				"bucket1": {Value: 1000, UnstakedEpoch: core.DefaultUnstakedEpoch},
+				"bucket2": {Value: 2000, UnstakedEpoch: core.DefaultUnstakedEpoch},
+			},
+			expected: 0,
+		},
+		{
+			name: "all unstaked buckets returns sum",
+			buckets: map[string]*kapps.UserBucket{
+				"bucket1": {Value: 1000, UnstakedEpoch: 10},
+				"bucket2": {Value: 2000, UnstakedEpoch: 20},
+			},
+			expected: 3000,
+		},
+		{
+			name: "mixed buckets returns only unstaked sum",
+			buckets: map[string]*kapps.UserBucket{
+				"staked1":   {Value: 5000, UnstakedEpoch: core.DefaultUnstakedEpoch},
+				"unstaked1": {Value: 1000, UnstakedEpoch: 10},
+				"staked2":   {Value: 3000, UnstakedEpoch: core.DefaultUnstakedEpoch},
+				"unstaked2": {Value: 2000, UnstakedEpoch: 20},
+			},
+			expected: 3000,
+		},
+		{
+			name: "bucket with zero unstaked epoch is considered unstaked",
+			buckets: map[string]*kapps.UserBucket{
+				"bucket1": {Value: 500, UnstakedEpoch: 0},
+			},
+			expected: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := calculateUnfrozenBalance(tt.buckets)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetAllowanceWithPendingRewards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil kappsController returns base allowance", func(t *testing.T) {
+		t.Parallel()
+
+		args := createMockElasticProcessorArgs()
+		args.KAppController = nil
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		ep.kappsController = nil
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 1000
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(1000), result)
+	})
+
+	t.Run("with pending rewards adds to allowance", func(t *testing.T) {
+		t.Parallel()
+
+		validatorsKapp := &mock.ValidatorsKAppStub{
+			GetPendingRewardsCalled: func(address []byte) (int64, error) {
+				return 500, nil
+			},
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return validatorsKapp
+			},
+		}
+
+		args := createMockElasticProcessorArgs()
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		ep.kappsController = kappController
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 2000
+			},
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress")
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(2500), result)
+	})
+
+	t.Run("zero pending rewards returns base allowance", func(t *testing.T) {
+		t.Parallel()
+
+		validatorsKapp := &mock.ValidatorsKAppStub{
+			GetPendingRewardsCalled: func(address []byte) (int64, error) {
+				return 0, nil
+			},
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return validatorsKapp
+			},
+		}
+
+		args := createMockElasticProcessorArgs()
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		ep.kappsController = kappController
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 3000
+			},
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress")
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(3000), result)
+	})
+
+	t.Run("error getting pending rewards returns base allowance", func(t *testing.T) {
+		t.Parallel()
+
+		validatorsKapp := &mock.ValidatorsKAppStub{
+			GetPendingRewardsCalled: func(address []byte) (int64, error) {
+				return 0, errors.New("some error")
+			},
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return validatorsKapp
+			},
+		}
+
+		args := createMockElasticProcessorArgs()
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		ep.kappsController = kappController
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 4000
+			},
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress")
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(4000), result)
+	})
+}
+
+func TestConvertPermissions(t *testing.T) {
+	t.Parallel()
+
+	args := createMockElasticProcessorArgs()
+	ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+
+	t.Run("nil permissions returns empty slice", func(t *testing.T) {
+		result := ep.convertPermissions(nil)
+		require.Empty(t, result)
+		require.NotNil(t, result)
+	})
+
+	t.Run("empty permissions returns empty slice", func(t *testing.T) {
+		result := ep.convertPermissions([]*state.Permission{})
+		require.Empty(t, result)
+	})
+
+	t.Run("converts permissions with signers correctly", func(t *testing.T) {
+		perms := []*state.Permission{
+			{
+				ID:             1,
+				Type:           state.Permission_Owner,
+				PermissionName: "TestPermission",
+				Threshold:      2,
+				Operations:     []byte{0x01, 0x02},
+				Signers: []*state.Key{
+					{Address: []byte{0xAA, 0xBB}, Weight: 1},
+					{Address: []byte{0xCC, 0xDD}, Weight: 2},
+				},
+			},
+		}
+
+		result := ep.convertPermissions(perms)
+		require.Len(t, result, 1)
+		require.Equal(t, int32(1), result[0].ID)
+		require.Equal(t, int32(state.Permission_Owner), result[0].Type)
+		require.Equal(t, "TestPermission", result[0].PermissionName)
+		require.Equal(t, int64(2), result[0].Threshold)
+		require.Equal(t, "0102", result[0].Operations)
+		require.Len(t, result[0].Signers, 2)
+		require.Equal(t, int64(1), result[0].Signers[0].Weight)
+		require.Equal(t, int64(2), result[0].Signers[1].Weight)
+	})
+}
+
+func TestDispatchAccountEvents(t *testing.T) {
+	// Not parallel - modifies global EventQueue and UseEventQueue
+
+	t.Run("does not dispatch when UseEventQueue is false", func(t *testing.T) {
+		originalUseEventQueue := UseEventQueue
+		originalEventQueue := EventQueue
+		testQueue := make(chan Event, 1)
+		EventQueue = testQueue
+		UseEventQueue = false
+		defer func() {
+			UseEventQueue = originalUseEventQueue
+			EventQueue = originalEventQueue
+		}()
+
+		accountsMap := map[string]*data.AccountInfo{
+			"addr1": {Address: "addr1"},
+		}
+
+		dispatchAccountEvents(accountsMap)
+
+		// Verify nothing was dispatched
+		select {
+		case <-testQueue:
+			t.Fatal("expected no event to be dispatched when UseEventQueue is false")
+		default:
+			// Success - no event dispatched
+		}
+	})
+
+	t.Run("does not dispatch when accountsMap is empty", func(t *testing.T) {
+		originalUseEventQueue := UseEventQueue
+		originalEventQueue := EventQueue
+		testQueue := make(chan Event, 1)
+		EventQueue = testQueue
+		UseEventQueue = true
+		defer func() {
+			UseEventQueue = originalUseEventQueue
+			EventQueue = originalEventQueue
+		}()
+
+		dispatchAccountEvents(map[string]*data.AccountInfo{})
+
+		// Verify nothing was dispatched
+		select {
+		case <-testQueue:
+			t.Fatal("expected no event to be dispatched when accountsMap is empty")
+		default:
+			// Success - no event dispatched
+		}
+	})
+
+	t.Run("dispatches event with correct type and data when enabled", func(t *testing.T) {
+		originalUseEventQueue := UseEventQueue
+		originalEventQueue := EventQueue
+		testQueue := make(chan Event, 1)
+		EventQueue = testQueue
+		UseEventQueue = true
+		defer func() {
+			UseEventQueue = originalUseEventQueue
+			EventQueue = originalEventQueue
+		}()
+
+		accountsMap := map[string]*data.AccountInfo{
+			"addr1": {Address: "addr1", Balance: 1000},
+			"addr2": {Address: "addr2", Balance: 2000},
+		}
+
+		dispatchAccountEvents(accountsMap)
+
+		// Verify event was dispatched with correct data
+		select {
+		case event := <-testQueue:
+			require.Equal(t, ACCOUNTS, event.EvType)
+			receivedMap, ok := event.Message.(map[string]*data.AccountInfo)
+			require.True(t, ok, "event message should be map[string]*data.AccountInfo")
+			require.Len(t, receivedMap, 2)
+			require.Equal(t, "addr1", receivedMap["addr1"].Address)
+			require.Equal(t, int64(1000), receivedMap["addr1"].Balance)
+			require.Equal(t, "addr2", receivedMap["addr2"].Address)
+			require.Equal(t, int64(2000), receivedMap["addr2"].Balance)
+		default:
+			t.Fatal("expected event to be dispatched")
+		}
+	})
+}
+
+func TestBuildAccountInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("builds account info successfully", func(t *testing.T) {
+		t.Parallel()
+
+		userAccount := &mock.UserAccountHandlerStub{
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress12345678901234567890")
+			},
+			GetNonceCalled: func() uint64 {
+				return 42
+			},
+			GetNameCalled: func() []byte {
+				return []byte("TestAccount")
+			},
+			GetRootHashCalled: func() []byte {
+				return []byte{0x01, 0x02, 0x03}
+			},
+			GetBalanceCalled: func(assetID []byte, cdd bool) int64 {
+				return 10000
+			},
+			GetAllowanceCalled: func() int64 {
+				return 500
+			},
+			GetPermissionsCalled: func() []*state.Permission {
+				return nil
+			},
+			GetCodeHashCalled: func() []byte {
+				return []byte{0x0A, 0x0B}
+			},
+			GetCodeMetadataCalled: func() []byte {
+				return []byte{0x0C, 0x0D}
+			},
+			GetUserKDACalled: func(assetID []byte, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+				return &kapps.UserKDA{
+					FrozenBalance: 2000,
+					Buckets:       map[string]*kapps.UserBucket{},
+				}, nil
+			},
+		}
+
+		args := createMockElasticProcessorArgs()
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		ep.kappsController = nil // nil so getAllowanceWithPendingRewards returns base allowance
+
+		account := &data.Account{
+			UserAccount: userAccount,
+			IsSender:    true,
+		}
+
+		result, err := ep.buildAccountInfo(account, 1234567890)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, uint64(42), result.Nonce)
+		require.Equal(t, "TestAccount", result.Name)
+		require.Equal(t, int64(10000), result.Balance)
+		require.Equal(t, int64(2000), result.FrozenBalance)
+		require.Equal(t, int64(0), result.UnfrozenBalance)
+		require.Equal(t, int64(500), result.Allowance)
+		require.Equal(t, "0a0b", result.CodeHash)
+		require.Equal(t, "0c0d", result.CodeMetadata)
+	})
+
+	t.Run("returns error when GetUserKDA fails", func(t *testing.T) {
+		t.Parallel()
+
+		userAccount := &mock.UserAccountHandlerStub{
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress12345678901234567890")
+			},
+			GetUserKDACalled: func(assetID []byte, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+				return nil, errors.New("KDA not found")
+			},
+		}
+
+		args := createMockElasticProcessorArgs()
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+
+		account := &data.Account{
+			UserAccount: userAccount,
+			IsSender:    true,
+		}
+
+		result, err := ep.buildAccountInfo(account, 1234567890)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.Contains(t, err.Error(), "KDA not found")
+	})
+
+	t.Run("includes pending rewards in allowance", func(t *testing.T) {
+		t.Parallel()
+
+		userAccount := &mock.UserAccountHandlerStub{
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress12345678901234567890")
+			},
+			GetNonceCalled: func() uint64 {
+				return 1
+			},
+			GetNameCalled: func() []byte {
+				return nil
+			},
+			GetRootHashCalled: func() []byte {
+				return nil
+			},
+			GetBalanceCalled: func(assetID []byte, cdd bool) int64 {
+				return 1000
+			},
+			GetAllowanceCalled: func() int64 {
+				return 500
+			},
+			GetPermissionsCalled: func() []*state.Permission {
+				return nil
+			},
+			GetCodeHashCalled: func() []byte {
+				return nil
+			},
+			GetCodeMetadataCalled: func() []byte {
+				return nil
+			},
+			GetUserKDACalled: func(assetID []byte, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+				return &kapps.UserKDA{
+					FrozenBalance: 0,
+					Buckets:       nil,
+				}, nil
+			},
+		}
+
+		validatorsKapp := &mock.ValidatorsKAppStub{
+			GetPendingRewardsCalled: func(address []byte) (int64, error) {
+				return 250, nil
+			},
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return validatorsKapp
+			},
+		}
+
+		args := createMockElasticProcessorArgs()
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		ep.kappsController = kappController
+
+		account := &data.Account{
+			UserAccount: userAccount,
+			IsSender:    true,
+		}
+
+		result, err := ep.buildAccountInfo(account, 1234567890)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// Base allowance (500) + pending rewards (250) = 750
+		require.Equal(t, int64(750), result.Allowance)
+	})
 }

--- a/integrationTest/mock/forkControllerStub.go
+++ b/integrationTest/mock/forkControllerStub.go
@@ -10,6 +10,7 @@ type ForkControllerStub struct {
 	FixDelegationSameEpochCalled  func() bool
 	EnableSmartContractsCalled    func() bool
 	FixAuditChangesCalled         func() bool
+	EpochRewardsV2Called          func() bool
 }
 
 // ProcessorFlowITOPrice -
@@ -83,6 +84,14 @@ func (fc *ForkControllerStub) EnableSmartContracts() bool {
 func (fc *ForkControllerStub) FixAuditChanges() bool {
 	if fc.FixAuditChangesCalled != nil {
 		return fc.FixAuditChangesCalled()
+	}
+
+	return false
+}
+
+func (fc *ForkControllerStub) EpochRewardsV2() bool {
+	if fc.EpochRewardsV2Called != nil {
+		return fc.EpochRewardsV2Called()
 	}
 
 	return false

--- a/integrationTest/processorNode/initProcessorNode.go
+++ b/integrationTest/processorNode/initProcessorNode.go
@@ -280,6 +280,12 @@ func NewBaseProcessorNode(mainConfig config.Config) (*ProcessorNode, error) {
 		EnableSmartContractsCalled: func() bool {
 			return true
 		},
+		FixAuditChangesCalled: func() bool {
+			return true
+		},
+		EpochRewardsV2Called: func() bool {
+			return true
+		},
 	}
 
 	proposalController, err := kapps.NewProposalController(forkControllerStub)

--- a/kvm/scenarioexec/exec.go
+++ b/kvm/scenarioexec/exec.go
@@ -82,6 +82,8 @@ func (ae *VMTestExecutor) InitVM(scenGasSchedule scenjsonmodel.GasSchedule) erro
 		FPRComputeAndKdaFeeFlow: 0,
 		FixDelegationSameEpoch:  0,
 		SmartContracts:          0,
+		FixAuditChanges:         0,
+		EpochRewardsV2:          0,
 	}, epochNotifier)
 
 	err = ae.World.InitBuiltinFunctions(gasSchedule, forkController)

--- a/kvm/testcommon/testHostBuilder.go
+++ b/kvm/testcommon/testHostBuilder.go
@@ -49,6 +49,8 @@ func NewTestHostBuilder(tb testing.TB) *TestHostBuilder {
 		FPRComputeAndKdaFeeFlow: 0,
 		FixDelegationSameEpoch:  0,
 		SmartContracts:          0,
+		FixAuditChanges:         0,
+		EpochRewardsV2:          0,
 	}, epochNotifier)
 
 	return &TestHostBuilder{

--- a/kvm/vmhost/hosttest/execution_benchmark_test.go
+++ b/kvm/vmhost/hosttest/execution_benchmark_test.go
@@ -248,6 +248,8 @@ func prepare(tb testing.TB, ownerAddress []byte) (*worldmock.MockWorld, *worldmo
 		FPRComputeAndKdaFeeFlow: 0,
 		FixDelegationSameEpoch:  0,
 		SmartContracts:          0,
+		FixAuditChanges:         0,
+		EpochRewardsV2:          0,
 	}, epochNotifier)
 
 	protectedKeys := [][]byte{

--- a/node/nodeAccount.go
+++ b/node/nodeAccount.go
@@ -113,7 +113,92 @@ func (n *Node) GetUserKDA(address string, assetId string) (*kapps.UserKDA, error
 	return userAccount.GetUserKDA([]byte(assetId), nil, n.forkController.EnableSmartContracts())
 }
 
-// GetAvailableClaim returns the rewards available for a specific asset in an account
+// loadStakingData loads and unmarshals staking data for a given asset.
+func (n *Node) loadStakingData(assetId string) (*kapps.StakingData, error) {
+	stakingAcnt, err := n.kapps.LoadAccount(kapps.StakingKAppAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	stakingKapp, ok := stakingAcnt.(state.KAppAccountHandler)
+	if !ok {
+		return nil, common.ErrWrongTypeAssertion
+	}
+
+	key := kdautils.ToKDAKey([]byte(assetId), nil)
+	stakedBytes, err := stakingKapp.DataTrieTracker().RetrieveValue(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(stakedBytes) == 0 {
+		return nil, common.ErrStakingNotFound
+	}
+
+	kdaStaking := &kapps.StakingData{}
+	if err = n.internalMarshalizer.Unmarshal(kdaStaking, stakedBytes); err != nil {
+		return nil, err
+	}
+
+	return kdaStaking, nil
+}
+
+// loadKDAData loads and unmarshals KDA data for a given asset.
+func (n *Node) loadKDAData(assetId string) (*kapps.KDAData, error) {
+	kdaAcnt, err := n.kapps.LoadAccount(kapps.KDAKAppAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	kdaKapp, ok := kdaAcnt.(state.KAppAccountHandler)
+	if !ok {
+		return nil, common.ErrWrongTypeAssertion
+	}
+
+	key := kdautils.ToKDAKey([]byte(assetId), nil)
+	kdaBytes, err := kdaKapp.DataTrieTracker().RetrieveValue(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(kdaBytes) == 0 {
+		return nil, common.ErrAssetNotFound
+	}
+
+	kda := &kapps.KDAData{}
+	if err = n.internalMarshalizer.Unmarshal(kda, kdaBytes); err != nil {
+		return nil, err
+	}
+
+	return kda, nil
+}
+
+// getKLVAllowanceWithPending returns the KLV allowance including pending rewards from V2 epoch rewards.
+func (n *Node) getKLVAllowanceWithPending(userAccount state.UserAccountHandler) int64 {
+	allowance := userAccount.GetAllowance()
+
+	if check.IfNil(n.kappController) {
+		return allowance
+	}
+
+	pendingRewards, err := n.kappController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
+	if err == nil && pendingRewards > 0 {
+		allowance += pendingRewards
+	}
+
+	return allowance
+}
+
+// computeRewardsForAsset extracts the computed rewards for the given asset from the rewards map.
+func computeRewardsForAsset(rewards map[string]int64, assetId string) int64 {
+	if len(rewards) == 0 {
+		return 0
+	}
+	// if assetID is KFI, computedRewards must be in KLV stack
+	if assetId == string(kdautils.KFIIdentifier) {
+		assetId = string(kdautils.KLVIdentifier)
+	}
+	return rewards[assetId]
+}
+
 func (n *Node) GetAvailableClaim(address string, assetId string) (int64, map[string]int64, int64, error) {
 	account, err := n.getAccountHandler(address)
 	if err != nil {
@@ -125,54 +210,12 @@ func (n *Node) GetAvailableClaim(address string, assetId string) (int64, map[str
 		return 0, nil, 0, nil
 	}
 
-	currentBlockHeader := n.blkc.GetCurrentBlockHeader()
-
-	stakingAcnt, err := n.kapps.LoadAccount(kapps.StakingKAppAddress)
+	kdaStaking, err := n.loadStakingData(assetId)
 	if err != nil {
 		return 0, nil, 0, err
 	}
 
-	stakingKapp, ok := stakingAcnt.(state.KAppAccountHandler)
-	if !ok {
-		return 0, nil, 0, common.ErrWrongTypeAssertion
-	}
-
-	key := kdautils.ToKDAKey([]byte(assetId), nil)
-
-	stakedBytes, err := stakingKapp.DataTrieTracker().RetrieveValue(key)
-	if err != nil {
-		return 0, nil, 0, err
-	}
-	if len(stakedBytes) == 0 {
-		return 0, nil, 0, common.ErrStakingNotFound
-	}
-
-	kdaStaking := &kapps.StakingData{}
-	err = n.internalMarshalizer.Unmarshal(kdaStaking, stakedBytes)
-	if err != nil {
-		return 0, nil, 0, err
-	}
-
-	kdaAcnt, err := n.kapps.LoadAccount(kapps.KDAKAppAddress)
-	if err != nil {
-		return 0, nil, 0, err
-	}
-
-	kdaKapp, ok := kdaAcnt.(state.KAppAccountHandler)
-	if !ok {
-		return 0, nil, 0, common.ErrWrongTypeAssertion
-	}
-
-	kdaBytes, err := kdaKapp.DataTrieTracker().RetrieveValue(key)
-	if err != nil {
-		return 0, nil, 0, err
-	}
-	if len(kdaBytes) == 0 {
-		return 0, nil, 0, common.ErrAssetNotFound
-	}
-
-	kda := &kapps.KDAData{}
-	err = n.internalMarshalizer.Unmarshal(kda, kdaBytes)
+	_, err = n.loadKDAData(assetId)
 	if err != nil {
 		return 0, nil, 0, err
 	}
@@ -182,6 +225,7 @@ func (n *Node) GetAvailableClaim(address string, assetId string) (int64, map[str
 		return 0, nil, 0, err
 	}
 
+	currentBlockHeader := n.blkc.GetCurrentBlockHeader()
 	rewards, err := userAccount.ComputeAvailableClaim(
 		[]byte(assetId),
 		currentBlockHeader.GetEpoch(),
@@ -196,25 +240,10 @@ func (n *Node) GetAvailableClaim(address string, assetId string) (int64, map[str
 
 	allowance := int64(0)
 	if assetId == "KLV" {
-		allowance = userAccount.GetAllowance()
-
-		// V2 Epoch Rewards: Add pending rewards from KApp data trie
-		if !check.IfNil(n.kappController) {
-			pendingRewards, err := n.kappController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
-			if err == nil && pendingRewards > 0 {
-				allowance += pendingRewards
-			}
-		}
+		allowance = n.getKLVAllowanceWithPending(userAccount)
 	}
 
-	computedRewards := int64(0)
-	if len(rewards) > 0 {
-		// if assetID is KFI, computedRewards must be in KLV stack
-		if assetId == string(kdautils.KFIIdentifier) {
-			assetId = string(kdautils.KLVIdentifier)
-		}
-		computedRewards = rewards[assetId]
-	}
+	computedRewards := computeRewardsForAsset(rewards, assetId)
 
 	return computedRewards, rewards, allowance, nil
 }

--- a/node/nodeAccount.go
+++ b/node/nodeAccount.go
@@ -42,8 +42,12 @@ func (n *Node) GetAccount(address string) (state.UserAccountHandler, error) {
 	// Before fork activation, this returns 0 (no overhead impact on result)
 	if !check.IfNil(n.kappController) {
 		pendingRewards, err := n.kappController.GetValidatorsKApp().GetPendingRewards(account.AddressBytes())
-		if err == nil && pendingRewards > 0 {
-			_ = account.AddToAllowance(pendingRewards)
+		if err != nil {
+			log.Warn("Failed to get pending rewards for account", "address", address, "error", err)
+		} else if pendingRewards > 0 {
+			if err := account.AddToAllowance(pendingRewards); err != nil {
+				log.Warn("Failed to add pending rewards to allowance", "address", address, "error", err)
+			}
 		}
 	}
 
@@ -180,7 +184,9 @@ func (n *Node) getKLVAllowanceWithPending(userAccount state.UserAccountHandler) 
 	}
 
 	pendingRewards, err := n.kappController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
-	if err == nil && pendingRewards > 0 {
+	if err != nil {
+		log.Warn("Failed to get pending rewards for account", "address", userAccount.AddressBytes(), "error", err)
+	} else if pendingRewards > 0 {
 		allowance += pendingRewards
 	}
 

--- a/node/nodeAccount.go
+++ b/node/nodeAccount.go
@@ -38,6 +38,15 @@ func (n *Node) GetAccount(address string) (state.UserAccountHandler, error) {
 		return nil, errors.New("this is not an user account address")
 	}
 
+	// V2 Epoch Rewards: Add pending rewards to allowance for API response
+	// Before fork activation, this returns 0 (no overhead impact on result)
+	if !check.IfNil(n.kappController) {
+		pendingRewards, err := n.kappController.GetValidatorsKApp().GetPendingRewards(account.AddressBytes())
+		if err == nil && pendingRewards > 0 {
+			_ = account.AddToAllowance(pendingRewards)
+		}
+	}
+
 	return account, nil
 }
 
@@ -188,6 +197,14 @@ func (n *Node) GetAvailableClaim(address string, assetId string) (int64, map[str
 	allowance := int64(0)
 	if assetId == "KLV" {
 		allowance = userAccount.GetAllowance()
+
+		// V2 Epoch Rewards: Add pending rewards from KApp data trie
+		if !check.IfNil(n.kappController) {
+			pendingRewards, err := n.kappController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
+			if err == nil && pendingRewards > 0 {
+				allowance += pendingRewards
+			}
+		}
 	}
 
 	computedRewards := int64(0)

--- a/node/nodeAccount_internal_test.go
+++ b/node/nodeAccount_internal_test.go
@@ -1,0 +1,76 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/core/process/kda/kdautils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeRewardsForAsset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rewards  map[string]int64
+		assetId  string
+		expected int64
+	}{
+		{
+			name:     "nil rewards map returns zero",
+			rewards:  nil,
+			assetId:  "KLV",
+			expected: 0,
+		},
+		{
+			name:     "empty rewards map returns zero",
+			rewards:  map[string]int64{},
+			assetId:  "KLV",
+			expected: 0,
+		},
+		{
+			name: "KLV asset returns KLV rewards",
+			rewards: map[string]int64{
+				"KLV": 1000,
+				"BTC": 500,
+			},
+			assetId:  "KLV",
+			expected: 1000,
+		},
+		{
+			name: "KFI asset returns KLV rewards (KFI rewards are in KLV stack)",
+			rewards: map[string]int64{
+				"KLV": 2000,
+				"KFI": 100,
+			},
+			assetId:  string(kdautils.KFIIdentifier),
+			expected: 2000,
+		},
+		{
+			name: "other asset returns its own rewards",
+			rewards: map[string]int64{
+				"KLV":   1000,
+				"TOKEN": 500,
+			},
+			assetId:  "TOKEN",
+			expected: 500,
+		},
+		{
+			name: "missing asset returns zero",
+			rewards: map[string]int64{
+				"KLV": 1000,
+			},
+			assetId:  "MISSING",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := computeRewardsForAsset(tt.rewards, tt.assetId)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/node/nodeAccount_test.go
+++ b/node/nodeAccount_test.go
@@ -6,11 +6,117 @@ import (
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/kapp"
+	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/kvm/mock/stub"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// headerHandlerWithTimestamp extends HeaderHandlerStub to support GetTimestamp
+type headerHandlerWithTimestamp struct {
+	mock.HeaderHandlerStub
+	timestamp int64
+}
+
+func (h *headerHandlerWithTimestamp) GetTimestamp() int64 {
+	return h.timestamp
+}
+
+// Test helpers for reducing boilerplate
+func createBasicUserAcc() *mock.UserAccountHandlerStub {
+	return &mock.UserAccountHandlerStub{
+		AddressBytesCalled: func() []byte { return []byte{0xAA, 0xBB} },
+	}
+}
+
+func createAccDBWithUser(userAcc state.AccountHandler) *mock.AccountsStub {
+	return &mock.AccountsStub{
+		GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+			return userAcc, nil
+		},
+	}
+}
+
+func createKappsDBWithStakingAndKDA(stakingBytes, kdaBytes []byte) *mock.AccountsStub {
+	callCount := 0
+	return &mock.AccountsStub{
+		LoadAccountCalled: func(address []byte) (state.AccountHandler, error) {
+			callCount++
+			returnBytes := stakingBytes
+			if callCount > 1 {
+				returnBytes = kdaBytes
+			}
+			return &mock.KAppAccountHandlerStub{
+				DataTrieTrackerCalled: func() state.DataTrieTracker {
+					return &mock.DataTrieTrackerStub{
+						RetrieveValueCalled: func(key []byte) ([]byte, error) {
+							return returnBytes, nil
+						},
+					}
+				},
+			}, nil
+		},
+	}
+}
+
+func createBlockchainWithHeader(epoch uint32, timestamp int64) *mock.BlockChainMock {
+	return &mock.BlockChainMock{
+		GetCurrentBlockHeaderCalled: func() data.HeaderHandler {
+			return &headerHandlerWithTimestamp{
+				HeaderHandlerStub: mock.HeaderHandlerStub{EpochField: epoch},
+				timestamp:         timestamp,
+			}
+		},
+	}
+}
+
+func createKappsDBWithLoadError(err error) *mock.AccountsStub {
+	return &mock.AccountsStub{
+		LoadAccountCalled: func([]byte) (state.AccountHandler, error) { return nil, err },
+	}
+}
+
+func createKappsDBWithTrieValue(retriever func([]byte) ([]byte, error)) *mock.AccountsStub {
+	return &mock.AccountsStub{
+		LoadAccountCalled: func([]byte) (state.AccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{
+				DataTrieTrackerCalled: func() state.DataTrieTracker {
+					return &mock.DataTrieTrackerStub{RetrieveValueCalled: retriever}
+				},
+			}, nil
+		},
+	}
+}
+
+// createKappsDBSequential returns different results for sequential LoadAccount calls
+func createKappsDBSequential(first, second func() (state.AccountHandler, error)) *mock.AccountsStub {
+	callCount := 0
+	return &mock.AccountsStub{
+		LoadAccountCalled: func([]byte) (state.AccountHandler, error) {
+			callCount++
+			if callCount == 1 {
+				return first()
+			}
+			return second()
+		},
+	}
+}
+
+func kappWithTrieData(data []byte) func() (state.AccountHandler, error) {
+	return func() (state.AccountHandler, error) {
+		return &mock.KAppAccountHandlerStub{
+			DataTrieTrackerCalled: func() state.DataTrieTracker {
+				return &mock.DataTrieTrackerStub{
+					RetrieveValueCalled: func([]byte) ([]byte, error) { return data, nil },
+				}
+			},
+		}, nil
+	}
+}
 
 func TestGetUserKDA(t *testing.T) {
 	t.Parallel()
@@ -28,11 +134,11 @@ func TestGetUserKDA(t *testing.T) {
 			address: "AABC",
 			assetID: "KLV",
 			accSetup: func() *mock.AccountsStub {
-				accDB := &mock.AccountsStub{}
-				accDB.GetExistingAccountCalled = func(address []byte) (state.AccountHandler, error) {
-					return nil, common.ErrAccountNotFound
+				return &mock.AccountsStub{
+					GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+						return nil, common.ErrAccountNotFound
+					},
 				}
-				return accDB
 			},
 			expectedKDA: nil,
 			expectedErr: common.ErrAccountNotFound,
@@ -42,11 +148,11 @@ func TestGetUserKDA(t *testing.T) {
 			address: "AAB",
 			assetID: "KLV",
 			accSetup: func() *mock.AccountsStub {
-				accDB := &mock.AccountsStub{}
-				accDB.GetExistingAccountCalled = func(address []byte) (state.AccountHandler, error) {
-					return nil, common.ErrAccountNotFound
+				return &mock.AccountsStub{
+					GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+						return nil, common.ErrAccountNotFound
+					},
 				}
-				return accDB
 			},
 			expectedKDA: nil,
 			expectedErr: errors.New("invalid address, could not decode from: encoding/hex: odd length hex string"),
@@ -56,25 +162,17 @@ func TestGetUserKDA(t *testing.T) {
 			address: "AABB",
 			assetID: "KLV",
 			accSetup: func() *mock.AccountsStub {
-				accDB := &mock.AccountsStub{}
-				accDB.GetExistingAccountCalled = func(address []byte) (state.AccountHandler, error) {
-					acc := &mock.UserAccountHandlerStub{
-						GetUserKDACalled: func(assetID []byte, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
-							return &kapps.UserKDA{
-								Balance:       1000,
-								FrozenBalance: 0,
-							}, nil
-						},
-					}
-
-					return acc, nil
+				return &mock.AccountsStub{
+					GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+						return &mock.UserAccountHandlerStub{
+							GetUserKDACalled: func(assetID []byte, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+								return &kapps.UserKDA{Balance: 1000, FrozenBalance: 0}, nil
+							},
+						}, nil
+					},
 				}
-				return accDB
 			},
-			expectedKDA: &kapps.UserKDA{
-				Balance:       1000,
-				FrozenBalance: 0,
-			},
+			expectedKDA: &kapps.UserKDA{Balance: 1000, FrozenBalance: 0},
 			expectedErr: nil,
 		},
 		{
@@ -82,11 +180,11 @@ func TestGetUserKDA(t *testing.T) {
 			address: "AABBCC",
 			assetID: "KLV",
 			accSetup: func() *mock.AccountsStub {
-				accDB := &mock.AccountsStub{}
-				accDB.GetExistingAccountCalled = func(address []byte) (state.AccountHandler, error) {
-					return &mock.KAppAccountHandlerStub{}, nil
+				return &mock.AccountsStub{
+					GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+						return &mock.KAppAccountHandlerStub{}, nil
+					},
 				}
-				return accDB
 			},
 			expectedKDA: nil,
 			expectedErr: nil,
@@ -94,18 +192,12 @@ func TestGetUserKDA(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
-			// t.Parallel()
-
-			// Create node with mocks and custom accounts adapter
 			n, err := createNodeWithAccountsAdapter(t, tt.accSetup())
 			require.Nil(t, err)
 
-			// Execute test
 			gotKDA, err := n.GetUserKDA(tt.address, tt.assetID)
 
-			// Verify results
 			if tt.expectedErr != nil {
 				assert.Error(t, err)
 				assert.Equal(t, tt.expectedErr.Error(), err.Error())
@@ -113,6 +205,208 @@ func TestGetUserKDA(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expectedKDA, gotKDA)
+		})
+	}
+}
+
+func TestGetAccount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds pending rewards to allowance when available", func(t *testing.T) {
+		allowanceAfterAdd := int64(1000)
+		userAcc := &mock.UserAccountHandlerStub{
+			AddressBytesCalled:   func() []byte { return []byte{0xAA, 0xBB} },
+			GetAllowanceCalled:   func() int64 { return allowanceAfterAdd },
+			AddToAllowanceCalled: func(value int64) error { allowanceAfterAdd += value; return nil },
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return &mock.ValidatorsKAppStub{
+					GetPendingRewardsCalled: func(address []byte) (int64, error) { return 500, nil },
+				}
+			},
+		}
+
+		n, err := createNodeWithKAppController(t, createAccDBWithUser(userAcc), kappController)
+		require.NoError(t, err)
+
+		account, err := n.GetAccount("AABB")
+		require.NoError(t, err)
+		require.Equal(t, int64(1500), account.GetAllowance())
+	})
+
+	t.Run("returns account even when GetPendingRewards fails", func(t *testing.T) {
+		userAcc := &mock.UserAccountHandlerStub{
+			AddressBytesCalled: func() []byte { return []byte{0xAA, 0xBB} },
+			GetAllowanceCalled: func() int64 { return 1000 },
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return &mock.ValidatorsKAppStub{
+					GetPendingRewardsCalled: func(address []byte) (int64, error) { return 0, errors.New("some error") },
+				}
+			},
+		}
+
+		n, err := createNodeWithKAppController(t, createAccDBWithUser(userAcc), kappController)
+		require.NoError(t, err)
+
+		account, err := n.GetAccount("AABB")
+		require.NoError(t, err)
+		require.Equal(t, int64(1000), account.GetAllowance())
+	})
+
+	t.Run("does not add allowance when pending rewards is zero", func(t *testing.T) {
+		addToAllowanceCalled := false
+		userAcc := &mock.UserAccountHandlerStub{
+			AddressBytesCalled:   func() []byte { return []byte{0xAA, 0xBB} },
+			GetAllowanceCalled:   func() int64 { return 1000 },
+			AddToAllowanceCalled: func(value int64) error { addToAllowanceCalled = true; return nil },
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return &mock.ValidatorsKAppStub{
+					GetPendingRewardsCalled: func(address []byte) (int64, error) { return 0, nil },
+				}
+			},
+		}
+
+		n, err := createNodeWithKAppController(t, createAccDBWithUser(userAcc), kappController)
+		require.NoError(t, err)
+
+		_, err = n.GetAccount("AABB")
+		require.NoError(t, err)
+		require.False(t, addToAllowanceCalled, "AddToAllowance should not be called when pending rewards is 0")
+	})
+}
+
+func TestGetAvailableClaim(t *testing.T) {
+	t.Parallel()
+
+	// Table-driven tests for loadStakingData error cases
+	loadStakingDataErrorTests := []struct {
+		name        string
+		kappsDB     *mock.AccountsStub
+		expectedErr string
+	}{
+		{"staking account not found", createKappsDBWithLoadError(common.ErrAccountNotFound), common.ErrAccountNotFound.Error()},
+		{"wrong type assertion", &mock.AccountsStub{LoadAccountCalled: func([]byte) (state.AccountHandler, error) { return &mock.UserAccountHandlerStub{}, nil }}, common.ErrWrongTypeAssertion.Error()},
+		{"staking not found (empty data)", createKappsDBWithTrieValue(func([]byte) ([]byte, error) { return []byte{}, nil }), common.ErrStakingNotFound.Error()},
+		{"retrieve value error", createKappsDBWithTrieValue(func([]byte) ([]byte, error) { return nil, errors.New("trie error") }), "trie error"},
+	}
+
+	for _, tt := range loadStakingDataErrorTests {
+		t.Run("loadStakingData fails - "+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			n, err := createNodeWithOptions(t, nodeTestOptions{
+				accAdapter:   createAccDBWithUser(createBasicUserAcc()),
+				kappsAdapter: tt.kappsDB,
+				blockchain:   &mock.BlockChainMock{},
+			})
+			require.NoError(t, err)
+
+			_, _, _, err = n.GetAvailableClaim("AABB", "KLV")
+			require.EqualError(t, err, tt.expectedErr)
+		})
+	}
+
+	t.Run("loadKDAData fails", func(t *testing.T) {
+		t.Parallel()
+
+		stakingBytes, _ := (&mock.ProtoMarshalizerMock{}).Marshal(&kapps.StakingData{TotalStaked: 1000})
+		kappsDB := createKappsDBSequential(
+			kappWithTrieData(stakingBytes),
+			func() (state.AccountHandler, error) { return nil, common.ErrAccountNotFound },
+		)
+
+		n, err := createNodeWithOptions(t, nodeTestOptions{
+			accAdapter:   createAccDBWithUser(createBasicUserAcc()),
+			kappsAdapter: kappsDB,
+			blockchain:   &mock.BlockChainMock{},
+		})
+		require.NoError(t, err)
+
+		_, _, _, err = n.GetAvailableClaim("AABB", "KLV")
+		require.ErrorIs(t, err, common.ErrAccountNotFound)
+	})
+
+	t.Run("returns zero values for non-user account", func(t *testing.T) {
+		t.Parallel()
+
+		n, err := createNodeWithOptions(t, nodeTestOptions{
+			accAdapter:   createAccDBWithUser(&mock.KAppAccountHandlerStub{}), // non-user account type
+			kappsAdapter: &mock.AccountsStub{},
+			blockchain:   &mock.BlockChainMock{},
+		})
+		require.NoError(t, err)
+
+		rewards, rewardsMap, allowance, err := n.GetAvailableClaim("AABB", "KLV")
+		require.NoError(t, err)
+		require.Zero(t, rewards)
+		require.Nil(t, rewardsMap)
+		require.Zero(t, allowance)
+	})
+
+	// Success tests - shared marshaler for data setup
+	marshalizer := &mock.ProtoMarshalizerMock{}
+	stakingBytes, _ := marshalizer.Marshal(&kapps.StakingData{TotalStaked: 1000})
+
+	successTests := []struct {
+		name            string
+		assetID         string
+		rewardsMap      map[string]int64
+		expectedRewards int64
+		pendingRewards  int64
+		wantAllowance   int64
+	}{
+		{"KLV with pending rewards", "KLV", map[string]int64{"KLV": 100}, 100, 500, 1500},
+		{"non-KLV asset zero allowance", "MYTOKEN", map[string]int64{"MYTOKEN": 200}, 200, 0, 0},
+	}
+
+	for _, tt := range successTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rewardsMap := tt.rewardsMap // capture for closure
+			userAcc := &mock.UserAccountHandlerStub{
+				AddressBytesCalled: func() []byte { return []byte{0xAA, 0xBB} },
+				GetAllowanceCalled: func() int64 { return 1000 },
+				GetUserKDACalled:   func([]byte, []byte, bool) (*kapps.UserKDA, error) { return &kapps.UserKDA{}, nil },
+				ComputeAvailableClaimCalled: func([]byte, uint32, int64, *kapps.UserKDA, *kapps.StakingData, core.ForkController) (map[string]int64, error) {
+					return rewardsMap, nil
+				},
+			}
+
+			kdaBytes, _ := marshalizer.Marshal(&kapps.KDAData{Name: []byte(tt.assetID)})
+			var kappCtrl kapp.KAppController
+			if tt.pendingRewards > 0 {
+				pending := tt.pendingRewards // capture
+				kappCtrl = &stub.KAppControllerStub{
+					GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+						return &mock.ValidatorsKAppStub{
+							GetPendingRewardsCalled: func([]byte) (int64, error) { return pending, nil },
+						}
+					},
+				}
+			}
+
+			n, err := createNodeWithOptions(t, nodeTestOptions{
+				accAdapter:     createAccDBWithUser(userAcc),
+				kappsAdapter:   createKappsDBWithStakingAndKDA(stakingBytes, kdaBytes),
+				kappController: kappCtrl,
+				blockchain:     createBlockchainWithHeader(10, 1234567890),
+			})
+			require.NoError(t, err)
+
+			rewards, rewardsMap, allowance, err := n.GetAvailableClaim("AABB", tt.assetID)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedRewards, rewards)
+			require.Equal(t, tt.rewardsMap, rewardsMap)
+			require.Equal(t, tt.wantAllowance, allowance)
 		})
 	}
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -254,6 +254,101 @@ func createNodeWithFeeHandler(t *testing.T, feeHandler *mock.FeeHandlerStub) (*n
 	return n, nil
 }
 
+// nodeTestOptions holds optional parameters for creating test nodes.
+type nodeTestOptions struct {
+	accAdapter     *mock.AccountsStub
+	kappsAdapter   *mock.AccountsStub
+	kappController kapp.KAppController
+	blockchain     *mock.BlockChainMock
+}
+
+// createNodeWithOptions creates a node with customizable options for testing.
+// All fields in nodeTestOptions are optional - nil values are skipped.
+func createNodeWithOptions(t *testing.T, opts nodeTestOptions) (*node.Node, error) {
+	uint64Converter := mock.NewNonceHashConverterMock()
+	storerMock := mock.NewStorerMock("", 0)
+
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled: func() retriever.ShardedDataCacherNotifier {
+			return &mock.ShardedDataStub{}
+		},
+	}
+	keyGen := &cryptoMock.KeyGenMock{
+		PublicKeyFromByteArrayMock: func(b []byte) (crypto.PublicKey, error) {
+			return nil, nil
+		},
+	}
+	feeHandler := &mock.FeeHandlerStub{}
+
+	epochNotifier := &mock.EpochNotifierStub{}
+	forkController, _ := fork.NewForkController(config.EnableEpochs{
+		ClaimKFI:              0,
+		ProcessorFlowITOPrice: 0,
+		FixStakingBuckets:     0,
+		KdaFpr:                0,
+	}, epochNotifier)
+
+	proposalController, _ := kapps.NewProposalController(forkController)
+
+	// Build options list with required options
+	options := []node.Option{
+		node.WithDataPool(dataPool),
+		node.WithInternalMarshalizer(getMarshalizer()),
+		node.WithTxSignMarshalizer(getMarshalizer()),
+		node.WithDataStore(&mock.ChainStorerMock{
+			GetCalled: func(unitType retriever.UnitType, key []byte) ([]byte, error) {
+				return storerMock.Get(key)
+			},
+			GetStorerCalled: func(unitType retriever.UnitType) storage.Storer {
+				return storerMock
+			},
+		}),
+		node.WithUint64ByteSliceConverter(uint64Converter),
+		node.WithAddressPubkeyConverter(createMockPubkeyConverter()),
+		node.WithValidatorPubkeyConverter(createMockPubkeyConverter()),
+		node.WithWhiteListHandler(&mock.WhiteListHandlerStub{}),
+		node.WithWhiteListHandlerVerified(&mock.WhiteListHandlerStub{}),
+		node.WithHasher(getHasher()),
+		node.WithTxSignHasher(getHasher()),
+		node.WithKeyGen(createKeyGenMock()),
+		node.WithKeyGenForAccounts(keyGen),
+		node.WithTxFeeHandler(feeHandler),
+		node.WithSingleSigner(&cryptoMock.SignerMock{}),
+		node.WithTxSingleSigner(&disabledSig.DisabledSingleSig{}),
+		node.WithChainID(chainID),
+		node.WithProposalController(proposalController),
+		node.WithForkController(forkController),
+	}
+
+	// Add optional options only if provided
+	if opts.accAdapter != nil {
+		options = append(options, node.WithAccountsAdapter(opts.accAdapter))
+	}
+	if opts.kappsAdapter != nil {
+		options = append(options, node.WithKAppsAdapter(opts.kappsAdapter))
+	}
+	if opts.kappController != nil {
+		options = append(options, node.WithKAppController(opts.kappController))
+	}
+	if opts.blockchain != nil {
+		options = append(options, node.WithBlockChain(opts.blockchain))
+	}
+
+	n, err := node.NewNode(options...)
+	require.Nil(t, err)
+
+	return n, nil
+}
+
+// createNodeWithKAppController is a convenience wrapper for tests that only need
+// accounts adapter and kapp controller.
+func createNodeWithKAppController(t *testing.T, accAdapter *mock.AccountsStub, kappController kapp.KAppController) (*node.Node, error) {
+	return createNodeWithOptions(t, nodeTestOptions{
+		accAdapter:     accAdapter,
+		kappController: kappController,
+	})
+}
+
 func TestCreateTransaction_ShouldWork(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Implement a scalable V2 epoch rewards mechanism that stores pending rewards in the KApp data trie instead of loading individual user accounts during epoch processing. This reduces epoch processing from O(N) user account loads to O(1), significantly improving performance at scale.

## Problem

The V1 epoch rewards distribution requires loading every delegator's user account during epoch processing to update their allowance. With thousands of delegators across many validators, this creates performance bottlenecks during epoch transitions.
Additionally, large data structures (validator buckets, proposal voters) can exceed the MaxLeafSize (786KB) storage limit.

## Solution

Introduce a V2 epoch rewards system that defers reward distribution:
- Store pending rewards in the validators KApp data trie with `PREW` key prefix
- Users claim pending rewards via the existing ClaimAllowance transaction
- Add protective limits for validator buckets (4500 max) and proposal voters (7000 max)
- Gate new functionality behind `EpochRewardsV2` fork flag for safe network upgrade

## Key Changes

**New:**
- `ProcessEconomicsEndOfEpochV2` in `peersUpdate.go` - scalable rewards processing
- Pending rewards storage methods (`GetPendingRewards`, `AddToPendingRewards`, `ClaimPendingRewards`)
- `EpochRewardsV2` fork flag in config and fork controller
- `MaxBucketsPerValidator` (4500) and `MaxVotersPerProposal` (7000) limits
- Comprehensive benchmark and unit tests for V2 rewards

**Updated:**
- `ClaimAllowance` transaction to claim pending V2 rewards
- Node API (`GetAccount`, `GetAvailableClaim`) to include pending rewards in allowance
- Elastic indexer to include pending rewards when indexing accounts
- Integration test fork controller stub with V2 support

## Testing

- [x] All existing tests pass (`make tests`)
- [x] All integration tests pass (`make tests-integration`)
- [x] New tests added for new functionality
- [x] Manual testing performed:
  - V1/V2 behavior parity verified with unit tests
  - Benchmark tests comparing V1 vs V2 performance

## Configuration Changes

```yaml
# config/node/enableEpochs.yaml
enableEpochs:
  epochRewardsV2: 0  # Set to epoch number to enable V2 rewards
```

Breaking Changes

None - V2 is gated behind a fork flag. Existing V1 behavior unchanged until fork activation.
