### PR TITLE
[KLC-1891] Fix testnet sync issue with fork-aware proposal parameter validation

### DIFF
--- a/common/mock/proposalControllerStub.go
+++ b/common/mock/proposalControllerStub.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"reflect"
 
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/kapps"
 )
 
@@ -10,7 +11,7 @@ type ProposalControllerStub struct {
 	GetActiveParametersCalled   func() map[int32]*kapps.Parameter
 	GetParameterIntCalled       func(kapps.EnumParameter) int64
 	GetParameterUintCalled      func(kapps.EnumParameter) uint64
-	ParseParamAndValidateCalled func(parameter kapps.EnumParameter, value []byte) (reflect.Value, error)
+	ParseParamAndValidateCalled func(parameter kapps.EnumParameter, value []byte, forks core.ForkController) (reflect.Value, error)
 	UpdateParametersCalled      func(map[int32]*kapps.Parameter)
 	IsInterfaceNilCalled        func() bool
 }
@@ -39,9 +40,9 @@ func (stub *ProposalControllerStub) GetParameterUint(param kapps.EnumParameter) 
 	return 0
 }
 
-func (stub *ProposalControllerStub) ParseParamAndValidate(param kapps.EnumParameter, value []byte) (reflect.Value, error) {
+func (stub *ProposalControllerStub) ParseParamAndValidate(param kapps.EnumParameter, value []byte, fc core.ForkController) (reflect.Value, error) {
 	if stub.ParseParamAndValidateCalled != nil {
-		return stub.ParseParamAndValidateCalled(param, value)
+		return stub.ParseParamAndValidateCalled(param, value, fc)
 	}
 
 	return reflect.Value{}, nil

--- a/core/kapp/proposal/proposal.go
+++ b/core/kapp/proposal/proposal.go
@@ -206,7 +206,7 @@ func (p *proposalKapp) validateNewParameters(params map[int32][]byte, controller
 			return common.ErrInvalidValue
 		}
 
-		if _, err := controller.ParseParamAndValidate(kapps.EnumParameter(parameter), value); err != nil {
+		if _, err := controller.ParseParamAndValidate(kapps.EnumParameter(parameter), value, p.forkController); err != nil {
 			return err
 		}
 	}

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -1247,7 +1247,7 @@ func (mp *metaProcessor) updateApprovedProposalParameters(proposal *kapps.Propos
 }
 
 func (mp *metaProcessor) validateAndApplyParameter(parameter int32, value []byte, controller *kapps.ProposalController) error {
-	_, err := controller.ParseParamAndValidate(kapps.EnumParameter(parameter), value)
+	_, err := controller.ParseParamAndValidate(kapps.EnumParameter(parameter), value, mp.forkController)
 	if err != nil {
 		return err
 	}

--- a/kapps/proposal.go
+++ b/kapps/proposal.go
@@ -3,9 +3,12 @@ package kapps
 import (
 	reflect "reflect"
 
+	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
 )
+
+var log = logger.GetOrCreate("kapps/proposal")
 
 type activeProposalController struct {
 	*ProposalController
@@ -16,7 +19,7 @@ type ActiveProposalController interface {
 	GetActiveParameters() map[int32]*Parameter
 	GetParameterInt(parameter EnumParameter) int64
 	GetParameterUint(parameter EnumParameter) uint64
-	ParseParamAndValidate(parameter EnumParameter, value []byte) (reflect.Value, error)
+	ParseParamAndValidate(parameter EnumParameter, value []byte, fc core.ForkController) (reflect.Value, error)
 	UpdateParameters(map[int32]*Parameter)
 }
 
@@ -250,7 +253,7 @@ func (p *ProposalController) ParseParam(parameter EnumParameter, value []byte) (
 }
 
 // ParseAndValidate parses the value and validates it against the constraints
-func (p *ProposalController) ParseParamAndValidate(parameter EnumParameter, value []byte) (reflect.Value, error) {
+func (p *ProposalController) ParseParamAndValidate(parameter EnumParameter, value []byte, fc core.ForkController) (reflect.Value, error) {
 	param := p.ActiveParameters[int32(parameter)]
 	if param == nil {
 		return reflect.Value{}, common.ErrInvalidParameter
@@ -266,25 +269,34 @@ func (p *ProposalController) ParseParamAndValidate(parameter EnumParameter, valu
 		return reflect.Value{}, err
 	}
 
-	return result, p.validateConstraints(parameter, result)
+	return result, p.validateConstraints(parameter, result, fc)
 }
 
-func (p *ProposalController) validateConstraints(parameter EnumParameter, value reflect.Value) error {
+func (p *ProposalController) validateConstraints(parameter EnumParameter, value reflect.Value, fc core.ForkController) error {
 	switch parameter {
 	case EnumParameter_LeaderValidatorRewardsPercentage:
 		if value.Uint() > uint64(core.HundredPercent) {
+			log.Error("invalid LeaderValidatorRewardsPercentage", "value", value.Uint(), "max", core.HundredPercent)
 			return common.ErrInvalidParameter
 		}
 	case EnumParameter_GasMultiplier:
 		if value.Int() < 1 {
+			log.Error("invalid GasMultiplier", "value", value.Int(), "min", 1)
 			return common.ErrInvalidParameter
 		}
 	case EnumParameter_MaxGasPerBlock:
 		if value.Int() < core.MinGasLimit {
+			log.Error("invalid MaxGasPerBlock", "value", value.Int(), "min", core.MinGasLimit)
 			return common.ErrInvalidParameter
 		}
 	case EnumParameter_MaxGasPerTX:
-		if value.Int() < core.MinGasLimit || value.Int() > core.MaxGasLimitPerTx {
+		maxValue := int64(core.MaxGasLimitPerTx)
+		if !fc.FixAuditChanges() {
+			maxValue = core.MaxGasBandwidthPerBatchPerSender
+		}
+
+		if value.Int() < core.MinGasLimit || value.Int() > maxValue {
+			log.Error("invalid MaxGasPerTX", "value", value.Int(), "min", core.MinGasLimit, "max", maxValue)
 			return common.ErrInvalidParameter
 		}
 	}

--- a/kapps/proposal.go
+++ b/kapps/proposal.go
@@ -252,7 +252,7 @@ func (p *ProposalController) ParseParam(parameter EnumParameter, value []byte) (
 	return parser(value)
 }
 
-// ParseAndValidate parses the value and validates it against the constraints
+// ParseParamAndValidate parses the value and validates it against the constraints
 func (p *ProposalController) ParseParamAndValidate(parameter EnumParameter, value []byte, fc core.ForkController) (reflect.Value, error) {
 	param := p.ActiveParameters[int32(parameter)]
 	if param == nil {

--- a/kapps/proposal_test.go
+++ b/kapps/proposal_test.go
@@ -134,6 +134,7 @@ func TestGetParameterUint(t *testing.T) {
 
 func TestParseParamAndValidate(t *testing.T) {
 	controller := NewProposalControllerForTests()
+	mockForks := mock.NewForkControllerStub()
 
 	tests := []struct {
 		name        string
@@ -158,7 +159,7 @@ func TestParseParamAndValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resultValue, err := controller.ParseParamAndValidate(tt.parameter, tt.value)
+			resultValue, err := controller.ParseParamAndValidate(tt.parameter, tt.value, mockForks)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if _, ok := tt.err.(*strconv.NumError); ok {
@@ -178,6 +179,7 @@ func TestParseParamAndValidate(t *testing.T) {
 
 func TestParseParamAndValidate_InvalidTypes(t *testing.T) {
 	controller := NewProposalControllerForTests()
+	mockForks := mock.NewForkControllerStub()
 
 	// overwriting the parameter with a different type
 	controller.GetActiveParameters()[int32(kapps.EnumParameter_LeaderValidatorRewardsPercentage)] = &kapps.Parameter{
@@ -185,9 +187,154 @@ func TestParseParamAndValidate_InvalidTypes(t *testing.T) {
 		Value: []byte("5000"),
 	}
 
-	_, err := controller.ParseParamAndValidate(kapps.EnumParameter_LeaderValidatorRewardsPercentage, []byte("5000"))
+	_, err := controller.ParseParamAndValidate(kapps.EnumParameter_LeaderValidatorRewardsPercentage, []byte("5000"), mockForks)
 	assert.Error(t, err)
 
+}
+
+func TestParseParamAndValidate_MaxGasPerTX_ForkAware(t *testing.T) {
+	controller := NewProposalControllerForTests()
+
+	t.Run("FixAuditChanges enabled - uses MaxGasLimitPerTx", func(t *testing.T) {
+		mockForks := mock.NewForkControllerStub()
+		mockForks.FixAuditChangesValue = true
+
+		tests := []struct {
+			name    string
+			value   []byte
+			wantErr bool
+		}{
+			{"valid at min limit", []byte("50000"), false},                  // core.MinGasLimit
+			{"valid mid range", []byte("250000000"), false},                 // 250M
+			{"valid at max limit", []byte("500000000"), false},              // core.MaxGasLimitPerTx
+			{"invalid below min", []byte("49999"), true},                    // below MinGasLimit
+			{"invalid above max", []byte("500000001"), true},                // above MaxGasLimitPerTx
+			{"invalid way above max", []byte("10000000000000"), true},       // way above max
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := controller.ParseParamAndValidate(kapps.EnumParameter_MaxGasPerTX, tt.value, mockForks)
+				if tt.wantErr {
+					assert.Error(t, err)
+					assert.Equal(t, common.ErrInvalidParameter, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("FixAuditChanges disabled - uses MaxGasBandwidthPerBatchPerSender", func(t *testing.T) {
+		mockForks := mock.NewForkControllerStub()
+		mockForks.FixAuditChangesValue = false
+
+		tests := []struct {
+			name    string
+			value   []byte
+			wantErr bool
+		}{
+			{"valid at min limit", []byte("50000"), false},                  // core.MinGasLimit
+			{"valid mid range", []byte("25000000"), false},                  // 25M
+			{"valid at old max limit", []byte("50000000"), false},           // core.MaxGasBandwidthPerBatchPerSender
+			{"invalid below min", []byte("49999"), true},                    // below MinGasLimit
+			{"invalid above old max", []byte("50000001"), true},             // above MaxGasBandwidthPerBatchPerSender
+			{"invalid at new max (but above old)", []byte("500000000"), true}, // MaxGasLimitPerTx but invalid pre-fork
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := controller.ParseParamAndValidate(kapps.EnumParameter_MaxGasPerTX, tt.value, mockForks)
+				if tt.wantErr {
+					assert.Error(t, err)
+					assert.Equal(t, common.ErrInvalidParameter, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+}
+
+func TestValidateConstraints_AllParameters(t *testing.T) {
+	controller := NewProposalControllerForTests()
+	mockForks := mock.NewForkControllerStub()
+	mockForks.FixAuditChangesValue = true
+
+	t.Run("LeaderValidatorRewardsPercentage", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			value   []byte
+			wantErr bool
+		}{
+			{"valid zero", []byte("0"), false},
+			{"valid mid range", []byte("5000"), false},
+			{"valid at max (HundredPercent)", []byte("10000"), false},
+			{"invalid above max", []byte("10001"), true},
+			{"invalid way above max", []byte("15000"), true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := controller.ParseParamAndValidate(kapps.EnumParameter_LeaderValidatorRewardsPercentage, tt.value, mockForks)
+				if tt.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("GasMultiplier", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			value   []byte
+			wantErr bool
+		}{
+			{"valid minimum (1)", []byte("1"), false},
+			{"valid higher value", []byte("10"), false},
+			{"valid large value", []byte("1000"), false},
+			{"invalid zero", []byte("0"), true},
+			{"invalid negative", []byte("-1"), true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := controller.ParseParamAndValidate(kapps.EnumParameter_GasMultiplier, tt.value, mockForks)
+				if tt.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("MaxGasPerBlock", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			value   []byte
+			wantErr bool
+		}{
+			{"valid at min limit", []byte("50000"), false},        // core.MinGasLimit
+			{"valid higher value", []byte("1500000000"), false},   // 1.5B
+			{"valid large value", []byte("10000000000"), false},   // 10B
+			{"invalid below min", []byte("49999"), true},
+			{"invalid zero", []byte("0"), true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := controller.ParseParamAndValidate(kapps.EnumParameter_MaxGasPerBlock, tt.value, mockForks)
+				if tt.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
 }
 
 func TestIsInterfaceNil(t *testing.T) {

--- a/kapps/proposal_test.go
+++ b/kapps/proposal_test.go
@@ -204,12 +204,12 @@ func TestParseParamAndValidate_MaxGasPerTX_ForkAware(t *testing.T) {
 			value   []byte
 			wantErr bool
 		}{
-			{"valid at min limit", []byte("50000"), false},                  // core.MinGasLimit
-			{"valid mid range", []byte("250000000"), false},                 // 250M
-			{"valid at max limit", []byte("500000000"), false},              // core.MaxGasLimitPerTx
-			{"invalid below min", []byte("49999"), true},                    // below MinGasLimit
-			{"invalid above max", []byte("500000001"), true},                // above MaxGasLimitPerTx
-			{"invalid way above max", []byte("10000000000000"), true},       // way above max
+			{"valid at min limit", []byte("50000"), false},            // core.MinGasLimit
+			{"valid mid range", []byte("250000000"), false},           // 250M
+			{"valid at max limit", []byte("500000000"), false},        // core.MaxGasLimitPerTx
+			{"invalid below min", []byte("49999"), true},              // below MinGasLimit
+			{"invalid above max", []byte("500000001"), true},          // above MaxGasLimitPerTx
+			{"invalid way above max", []byte("10000000000000"), true}, // way above max
 		}
 
 		for _, tt := range tests {
@@ -234,11 +234,11 @@ func TestParseParamAndValidate_MaxGasPerTX_ForkAware(t *testing.T) {
 			value   []byte
 			wantErr bool
 		}{
-			{"valid at min limit", []byte("50000"), false},                  // core.MinGasLimit
-			{"valid mid range", []byte("25000000"), false},                  // 25M
-			{"valid at old max limit", []byte("50000000"), false},           // core.MaxGasBandwidthPerBatchPerSender
-			{"invalid below min", []byte("49999"), true},                    // below MinGasLimit
-			{"invalid above old max", []byte("50000001"), true},             // above MaxGasBandwidthPerBatchPerSender
+			{"valid at min limit", []byte("50000"), false},                    // core.MinGasLimit
+			{"valid mid range", []byte("25000000"), false},                    // 25M
+			{"valid at old max limit", []byte("50000000"), false},             // core.MaxGasBandwidthPerBatchPerSender
+			{"invalid below min", []byte("49999"), true},                      // below MinGasLimit
+			{"invalid above old max", []byte("50000001"), true},               // above MaxGasBandwidthPerBatchPerSender
 			{"invalid at new max (but above old)", []byte("500000000"), true}, // MaxGasLimitPerTx but invalid pre-fork
 		}
 
@@ -317,9 +317,9 @@ func TestValidateConstraints_AllParameters(t *testing.T) {
 			value   []byte
 			wantErr bool
 		}{
-			{"valid at min limit", []byte("50000"), false},        // core.MinGasLimit
-			{"valid higher value", []byte("1500000000"), false},   // 1.5B
-			{"valid large value", []byte("10000000000"), false},   // 10B
+			{"valid at min limit", []byte("50000"), false},      // core.MinGasLimit
+			{"valid higher value", []byte("1500000000"), false}, // 1.5B
+			{"valid large value", []byte("10000000000"), false}, // 10B
 			{"invalid below min", []byte("49999"), true},
 			{"invalid zero", []byte("0"), true},
 		}


### PR DESCRIPTION
## Summary

  - Add fork-aware validation for `MaxGasPerTX` proposal parameter to fix testnet sync issues
  - Before `FixAuditChanges` fork, `MaxGasPerTX` limit was 50M (`MaxGasBandwidthPerBatchPerSender`), after fork it's 500M (`MaxGasLimitPerTx`)
  - Nodes syncing testnet from scratch were rejecting valid historical proposals due to hardcoded post-fork limits

  ## Changes

  ### Core Fix
  - Add `ForkController` parameter to `ParseParamAndValidate` and `validateConstraints` functions
  - Use `FixAuditChanges()` fork flag to determine correct `MaxGasPerTX` limit based on chain state
  - Add error logging with context for invalid parameter validation failures

  ### Files Modified
  - `kapps/proposal.go` - Fork-aware validation logic
  - `core/process/block/block.go` - Pass forkController to validation
  - `core/kapp/proposal/proposal.go` - Pass forkController to validation
  - `common/mock/proposalControllerStub.go` - Update mock interface

  ### Tests Added
  - `TestParseParamAndValidate_MaxGasPerTX_ForkAware` - Tests both fork states with edge cases
  - `TestValidateConstraints_AllParameters` - Comprehensive validation tests for all constrained parameters

  ## Test plan

  - [x] Unit tests pass for fork-aware MaxGasPerTX validation
  - [x] Unit tests cover all parameter constraint edge cases
  - [ ] Verify testnet node can sync from genesis without proposal validation errors

  ## Notes

  Mainnet is unaffected as the `FixAuditChanges` fork activates on release, so there are no historical proposals with the old limit.