### PR TITLE
[KLC-2057] Skip checkpoints and snapshots during import-db mode

### DIFF
--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -827,6 +827,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		accCacher,
 		forkController,
 		txLogsProcessor,
+		processingMode,
 	)
 	processComponents, err := factory.ProcessComponentsFactory(processArgs)
 	if err != nil {

--- a/core/process/block/argProcessor.go
+++ b/core/process/block/argProcessor.go
@@ -41,6 +41,7 @@ type ArgBaseProcessor struct {
 	BlockChainHook          process.BlockChainHookHandler
 	HeaderIntegrityVerifier process.HeaderIntegrityVerifier
 	KAppController          kapp.KAppController
+	ProcessingMode          core.NodeProcessingMode
 }
 
 // ArgMetaProcessor holds all dependencies required by the process data factory in order to create

--- a/core/process/block/baseProcess.go
+++ b/core/process/block/baseProcess.go
@@ -61,6 +61,7 @@ type baseProcessor struct {
 	headerIntegrityVerifier      process.HeaderIntegrityVerifier
 	appStatusHandler             core.AppStatusHandler
 	stateCheckpointModulus       uint
+	processingMode               core.NodeProcessingMode
 	txCounter                    *transactionCounter
 
 	tpsBenchmark statistics.TPSBenchmark
@@ -597,8 +598,10 @@ func (bp *baseProcessor) updateStateStorage(
 		return
 	}
 
-	// TODO generate checkpoint on a trigger
-	if bp.stateCheckpointModulus != 0 {
+	// Skip checkpoints during import-db mode to prevent pruning buffer overflow (see KLC-2057)
+	if bp.processingMode == core.ImportDb {
+		log.Trace("skipping checkpoint in import-db mode", "rootHash", rootHash)
+	} else if bp.stateCheckpointModulus != 0 {
 		if finalHeader.GetNonce()%uint64(bp.stateCheckpointModulus) == 0 {
 			log.Debug("trie checkpoint", "rootHash", rootHash)
 			ctx := context.Background()

--- a/core/process/block/baseProcess_test.go
+++ b/core/process/block/baseProcess_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/crypto/hashing"
 	"github.com/klever-io/klever-go/crypto/hashing/blake2b"
+	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -177,3 +179,66 @@ func Test_validateTxRootHash(t *testing.T) {
 		})
 	}
 }
+
+func Test_updateStateStorage_ImportDbMode_SkipsCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	checkpointCalled := false
+	accountsStub := &mock.AccountsStub{
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+		SetStateCheckpointCalled: func(rootHash []byte) {
+			checkpointCalled = true
+		},
+		CancelPruneCalled: func(rootHash []byte, identifier data.TriePruningIdentifier) {},
+		PruneTrieCalled:   func(rootHash []byte, identifier data.TriePruningIdentifier) {},
+	}
+
+	bp := baseProcessor{
+		processingMode:         core.ImportDb,
+		stateCheckpointModulus: 1, // checkpoint every block
+	}
+
+	header := &mock.HeaderHandlerStub{
+		GetNonceCalled: func() uint64 {
+			return 100 // divisible by modulus, would trigger checkpoint
+		},
+	}
+
+	bp.updateStateStorage(header, []byte("rootHash"), []byte("prevRootHash"), accountsStub)
+
+	assert.False(t, checkpointCalled, "SetStateCheckpoint should NOT be called in import-db mode")
+}
+
+func Test_updateStateStorage_NormalMode_CallsCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	checkpointCalled := false
+	accountsStub := &mock.AccountsStub{
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+		SetStateCheckpointCalled: func(rootHash []byte) {
+			checkpointCalled = true
+		},
+		CancelPruneCalled: func(rootHash []byte, identifier data.TriePruningIdentifier) {},
+		PruneTrieCalled:   func(rootHash []byte, identifier data.TriePruningIdentifier) {},
+	}
+
+	bp := baseProcessor{
+		processingMode:         core.Normal,
+		stateCheckpointModulus: 1, // checkpoint every block
+	}
+
+	header := &mock.HeaderHandlerStub{
+		GetNonceCalled: func() uint64 {
+			return 100 // divisible by modulus, should trigger checkpoint
+		},
+	}
+
+	bp.updateStateStorage(header, []byte("rootHash"), []byte("prevRootHash"), accountsStub)
+
+	assert.True(t, checkpointCalled, "SetStateCheckpoint should be called in normal mode")
+}
+

--- a/core/process/block/baseProcess_test.go
+++ b/core/process/block/baseProcess_test.go
@@ -241,4 +241,3 @@ func Test_updateStateStorage_NormalMode_CallsCheckpoint(t *testing.T) {
 
 	assert.True(t, checkpointCalled, "SetStateCheckpoint should be called in normal mode")
 }
-

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-go/v2"
 	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/core/process/block/bootstrapStorage"
 	"github.com/klever-io/klever-go/data"
@@ -74,6 +75,7 @@ func NewMetaProcessor(arguments ArgMetaProcessor) (*metaProcessor, error) {
 		dataPool:                     arguments.DataPool,
 		blockChain:                   arguments.BlockChain,
 		stateCheckpointModulus:       arguments.StateCheckpointModulus,
+		processingMode:               arguments.ProcessingMode,
 		tpsBenchmark:                 arguments.TpsBenchmark,
 		genesisNonce:                 genesisHdr.GetNonce(),
 		epochNotifier:                arguments.EpochNotifier,
@@ -686,11 +688,17 @@ func (mp *metaProcessor) updateState(lastMetaBlock data.HeaderHandler) {
 	}
 
 	if lastMetaBlock.GetIsEpochStart() {
-		log.Debug("trie snapshot", "rootHash", lastMetaBlock.GetTrieRoot())
-		ctx := context.Background()
-		mp.accountsDB[state.UserAccountsState].SnapshotState(lastMetaBlock.GetTrieRoot(), ctx)
-		mp.accountsDB[state.PeerAccountsState].SnapshotState(lastMetaBlock.GetValidatorsTrieRoot(), ctx)
-		mp.accountsDB[state.KAppAccountsState].SnapshotState(lastMetaBlock.GetKAppsTrieRoot(), ctx)
+		// Skip epoch snapshots during import-db mode to prevent TrieSnapshot directory growth
+		// and memory accumulation from multiple LevelDB instances (see KLC-2057)
+		if mp.processingMode == core.ImportDb {
+			log.Trace("skipping epoch snapshot in import-db mode", "epoch", lastMetaBlock.GetEpoch())
+		} else {
+			log.Debug("trie snapshot", "rootHash", lastMetaBlock.GetTrieRoot())
+			ctx := context.Background()
+			mp.accountsDB[state.UserAccountsState].SnapshotState(lastMetaBlock.GetTrieRoot(), ctx)
+			mp.accountsDB[state.PeerAccountsState].SnapshotState(lastMetaBlock.GetValidatorsTrieRoot(), ctx)
+			mp.accountsDB[state.KAppAccountsState].SnapshotState(lastMetaBlock.GetKAppsTrieRoot(), ctx)
+		}
 	}
 
 	mp.updateStateStorage(

--- a/core/process/block/block_test.go
+++ b/core/process/block/block_test.go
@@ -1588,11 +1588,23 @@ func TestMetaProcessor_UpdateState_ImportDbMode_SkipsEpochSnapshot(t *testing.T)
 			return true
 		},
 	}
+	kappAccountsStub := &mock.AccountsStub{
+		CommitCalled: func() ([]byte, error) {
+			return []byte("kappsRootHash"), nil
+		},
+		SnapshotStateCalled: func(rootHash []byte) {
+			snapshotCallCount++
+		},
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+	}
 
 	arguments := createMockMetaArguments()
 	arguments.ProcessingMode = core.ImportDb
 	arguments.AccountsDB[state.UserAccountsState] = userAccountsStub
 	arguments.AccountsDB[state.PeerAccountsState] = peerAccountsStub
+	arguments.AccountsDB[state.KAppAccountsState] = kappAccountsStub
 
 	// Set up the data pool to return the previous header
 	prevHeader := &block.Block{
@@ -1669,11 +1681,23 @@ func TestMetaProcessor_UpdateState_NormalMode_CallsEpochSnapshot(t *testing.T) {
 			return true
 		},
 	}
+	kappAccountsStub := &mock.AccountsStub{
+		CommitCalled: func() ([]byte, error) {
+			return []byte("kappsRootHash"), nil
+		},
+		SnapshotStateCalled: func(rootHash []byte) {
+			snapshotCallCount++
+		},
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+	}
 
 	arguments := createMockMetaArguments()
 	arguments.ProcessingMode = core.Normal // Normal mode
 	arguments.AccountsDB[state.UserAccountsState] = userAccountsStub
 	arguments.AccountsDB[state.PeerAccountsState] = peerAccountsStub
+	arguments.AccountsDB[state.KAppAccountsState] = kappAccountsStub
 
 	// Set up the data pool to return the previous header
 	prevHeader := &block.Block{
@@ -1718,6 +1742,6 @@ func TestMetaProcessor_UpdateState_NormalMode_CallsEpochSnapshot(t *testing.T) {
 	// Call updateState - in Normal mode, snapshots should be called
 	mpTest.UpdateState(epochStartHeader)
 
-	// Verify SnapshotState WAS called (at least for User and Peer accounts)
-	assert.GreaterOrEqual(t, snapshotCallCount, 2, "SnapshotState should be called in normal mode during epoch start")
+	// Verify SnapshotState WAS called for all 3 account types (User, Peer, KApp)
+	assert.Equal(t, 3, snapshotCallCount, "SnapshotState should be called 3 times in normal mode during epoch start")
 }

--- a/core/process/block/block_test.go
+++ b/core/process/block/block_test.go
@@ -1559,3 +1559,165 @@ func TestMetaProcessor_CreateAndProcessWithInvalidProcess(t *testing.T) {
 	err = mp.ProcessBlock(metaHdr, haveTime)
 	assert.Nil(t, err)
 }
+
+func TestMetaProcessor_UpdateState_ImportDbMode_SkipsEpochSnapshot(t *testing.T) {
+	t.Parallel()
+
+	snapshotCallCount := 0
+
+	// Create mock accounts that track SnapshotState calls
+	userAccountsStub := &mock.AccountsStub{
+		CommitCalled: func() ([]byte, error) {
+			return []byte("rootHash"), nil
+		},
+		SnapshotStateCalled: func(rootHash []byte) {
+			snapshotCallCount++
+		},
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+	}
+	peerAccountsStub := &mock.AccountsStub{
+		CommitCalled: func() ([]byte, error) {
+			return []byte("validatorsRootHash"), nil
+		},
+		SnapshotStateCalled: func(rootHash []byte) {
+			snapshotCallCount++
+		},
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+	}
+
+	arguments := createMockMetaArguments()
+	arguments.ProcessingMode = core.ImportDb
+	arguments.AccountsDB[state.UserAccountsState] = userAccountsStub
+	arguments.AccountsDB[state.PeerAccountsState] = peerAccountsStub
+
+	// Set up the data pool to return the previous header
+	prevHeader := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce:    0,
+			Slot:     0,
+			TrieRoot: []byte("prevRootHash"),
+		},
+	}
+	prevHeaderHash := []byte("prevHeaderHash")
+
+	arguments.DataPool.(*mock.PoolsHolderStub).HeadersCalled = func() retriever.HeadersPool {
+		return &mock.HeadersCacherStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				if bytes.Equal(hash, prevHeaderHash) {
+					return prevHeader, nil
+				}
+				return nil, errors.New("not found")
+			},
+		}
+	}
+
+	mp, err := blproc.NewMetaProcessor(arguments)
+	require.NoError(t, err)
+
+	mpTest := blproc.NewMetaProcessorForTests(mp)
+
+	// Create an epoch start header
+	epochStartHeader := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce:              1,
+			Slot:               1,
+			ParentHash:         prevHeaderHash,
+			TrieRoot:           []byte("newRootHash"),
+			ValidatorsTrieRoot: []byte("validatorsRoot"),
+			KAppsTrieRoot:      []byte("kappsRoot"),
+			IsEpochStart:       true,
+			Epoch:              1,
+		},
+	}
+
+	// Call updateState - in ImportDb mode, snapshots should be skipped
+	mpTest.UpdateState(epochStartHeader)
+
+	// Verify SnapshotState was NOT called
+	assert.Equal(t, 0, snapshotCallCount, "SnapshotState should NOT be called in import-db mode during epoch start")
+}
+
+func TestMetaProcessor_UpdateState_NormalMode_CallsEpochSnapshot(t *testing.T) {
+	t.Parallel()
+
+	snapshotCallCount := 0
+
+	// Create mock accounts that track SnapshotState calls
+	userAccountsStub := &mock.AccountsStub{
+		CommitCalled: func() ([]byte, error) {
+			return []byte("rootHash"), nil
+		},
+		SnapshotStateCalled: func(rootHash []byte) {
+			snapshotCallCount++
+		},
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+	}
+	peerAccountsStub := &mock.AccountsStub{
+		CommitCalled: func() ([]byte, error) {
+			return []byte("validatorsRootHash"), nil
+		},
+		SnapshotStateCalled: func(rootHash []byte) {
+			snapshotCallCount++
+		},
+		IsPruningEnabledCalled: func() bool {
+			return true
+		},
+	}
+
+	arguments := createMockMetaArguments()
+	arguments.ProcessingMode = core.Normal // Normal mode
+	arguments.AccountsDB[state.UserAccountsState] = userAccountsStub
+	arguments.AccountsDB[state.PeerAccountsState] = peerAccountsStub
+
+	// Set up the data pool to return the previous header
+	prevHeader := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce:    0,
+			Slot:     0,
+			TrieRoot: []byte("prevRootHash"),
+		},
+	}
+	prevHeaderHash := []byte("prevHeaderHash")
+
+	arguments.DataPool.(*mock.PoolsHolderStub).HeadersCalled = func() retriever.HeadersPool {
+		return &mock.HeadersCacherStub{
+			GetHeaderByHashCalled: func(hash []byte) (data.HeaderHandler, error) {
+				if bytes.Equal(hash, prevHeaderHash) {
+					return prevHeader, nil
+				}
+				return nil, errors.New("not found")
+			},
+		}
+	}
+
+	mp, err := blproc.NewMetaProcessor(arguments)
+	require.NoError(t, err)
+
+	mpTest := blproc.NewMetaProcessorForTests(mp)
+
+	// Create an epoch start header
+	epochStartHeader := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce:              1,
+			Slot:               1,
+			ParentHash:         prevHeaderHash,
+			TrieRoot:           []byte("newRootHash"),
+			ValidatorsTrieRoot: []byte("validatorsRoot"),
+			KAppsTrieRoot:      []byte("kappsRoot"),
+			IsEpochStart:       true,
+			Epoch:              1,
+		},
+	}
+
+	// Call updateState - in Normal mode, snapshots should be called
+	mpTest.UpdateState(epochStartHeader)
+
+	// Verify SnapshotState WAS called (at least for User and Peer accounts)
+	assert.GreaterOrEqual(t, snapshotCallCount, 2, "SnapshotState should be called in normal mode during epoch start")
+}

--- a/core/process/block/export_test.go
+++ b/core/process/block/export_test.go
@@ -43,3 +43,13 @@ func (m *MetaProcessorForTests) SetProposalKApp(kdaKapp state.KAppAccountHandler
 func (m *MetaProcessorForTests) GetActiveParameters() map[int32]*kapps.Parameter {
 	return m.proposalController.GetActiveParameters()
 }
+
+// UpdateState exposes the updateState method for testing
+func (m *MetaProcessorForTests) UpdateState(lastMetaBlock data.HeaderHandler) {
+	m.updateState(lastMetaBlock)
+}
+
+// GetAccountsDB returns the accountsDB for testing
+func (m *MetaProcessorForTests) GetAccountsDB() map[state.AccountsDbIdentifier]state.AccountsAdapter {
+	return m.accountsDB
+}

--- a/factory/process.go
+++ b/factory/process.go
@@ -104,6 +104,7 @@ type ProcessComponentsFactoryArgs struct {
 	indexRating               bool
 	accountsCacher            state.AccountsCacher
 	forkController            core.ForkController
+	processingMode            core.NodeProcessingMode
 }
 
 type MetaInterceptorContainerFactoryArgs struct {
@@ -160,6 +161,7 @@ func NewProcessComponentsFactoryArgs(
 	cacher state.AccountsCacher,
 	forkController core.ForkController,
 	txLogProcessor process.TransactionLogProcessor,
+	processingMode core.NodeProcessingMode,
 ) *ProcessComponentsFactoryArgs {
 
 	minSizeInBytes := mainConfig.BlockSizeThrottle.MinSizeInBytes
@@ -214,6 +216,7 @@ func NewProcessComponentsFactoryArgs(
 		accountsCacher:            cacher,
 		forkController:            forkController,
 		txLogsProcessor:           txLogProcessor,
+		processingMode:            processingMode,
 	}
 
 }
@@ -1039,6 +1042,7 @@ func newBlockProcessor(
 		HeaderIntegrityVerifier: headerIntegrityVerifier,
 		KAppController:          processArgs.state.KAppController,
 		BlockChainHook:          virtualMachineFactory.BlockChainHookImpl(),
+		ProcessingMode:          processArgs.processingMode,
 	}
 
 	arguments := block.ArgMetaProcessor{

--- a/factory/process_test.go
+++ b/factory/process_test.go
@@ -203,6 +203,7 @@ func createMockArguments() *factory.ProcessComponentsFactoryArgs {
 		accCacher,
 		forkController,
 		txLogsProcessor,
+		core.Normal,
 	)
 
 }


### PR DESCRIPTION
## Summary

  - Fix high memory consumption (90%+) during import-db mode
  - Skip intermediate checkpoints every 100 blocks in import-db mode
  - Skip epoch snapshots in import-db mode to prevent TrieSnapshot growth

  ## Problem

  During import-db, memory consumption grows to 90%+ on a 16GB machine due to:

  1. **Pruning buffer overflow**: Checkpoints every 100 blocks fill the pruning buffer (100k max). When full, entries are silently dropped, causing eviction waiting list to grow unbounded.

  2. **TrieSnapshot directory growth**: Epoch snapshots create new LevelDB instances rapidly. On restart, `GetSnapshotThatContainsHash()` scans all snapshots, loading index/filter blocks into memory.

  ## Solution

  Add `ProcessingMode` to block processor and skip checkpoints/snapshots when in import-db mode:

  - `SetStateCheckpoint()` - skipped (every 100 blocks)
  - `SnapshotState()` - skipped (at epoch boundaries)

  This is safe because import-db is deterministic and the source DB serves as the recovery point. Snapshots are created when the node switches to normal mode after import completes.

  ## Test plan

  - [x] Build succeeds
  - [x] Unit tests pass
  - [x] Run import-db and verify:
    - [x] No "pruning buffer is full" warnings
    - [x] Memory stays stable (not climbing to 90%+)
    - [x] TrieSnapshot directory doesn't grow excessively