### PR TITLE
[KLC-2126] refactor(crypto): review fixes — panic guards, race conditions, naming and tests

### DIFF
--- a/crypto/hashing/fnv/fnv.go
+++ b/crypto/hashing/fnv/fnv.go
@@ -2,13 +2,17 @@ package fnv
 
 import (
 	"hash/fnv"
+	"sync"
 
 	"github.com/klever-io/klever-go/crypto/hashing"
 )
 
 var _ hashing.Hasher = (*Fnv)(nil)
 
-var fnvEmptyHash []byte
+var (
+	fnvEmptyHash []byte
+	fnvOnce      sync.Once
+)
 
 // Fnv is a fnv128a implementation of the hasher interface.
 type Fnv struct {
@@ -16,7 +20,7 @@ type Fnv struct {
 
 // Compute takes a string, and returns the fnv128a hash of that string
 func (f Fnv) Compute(s string) []byte {
-	if len(s) == 0 && len(fnvEmptyHash) != 0 {
+	if len(s) == 0 {
 		return f.EmptyHash()
 	}
 	h := fnv.New128a()
@@ -26,10 +30,13 @@ func (f Fnv) Compute(s string) []byte {
 
 // EmptyHash returns the fnv128a hash of the empty string
 func (f Fnv) EmptyHash() []byte {
-	if len(fnvEmptyHash) == 0 {
-		fnvEmptyHash = f.Compute("")
-	}
-	return fnvEmptyHash
+	fnvOnce.Do(func() {
+		h := fnv.New128a()
+		fnvEmptyHash = h.Sum(nil)
+	})
+	result := make([]byte, len(fnvEmptyHash))
+	copy(result, fnvEmptyHash)
+	return result
 }
 
 // Size returns the size, in number of bytes, of a fnv128a hash

--- a/crypto/hashing/fnv/fnv_test.go
+++ b/crypto/hashing/fnv/fnv_test.go
@@ -1,0 +1,47 @@
+package fnv_test
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/crypto/hashing/fnv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFnv_Compute(t *testing.T) {
+	t.Parallel()
+
+	f := fnv.Fnv{}
+	h1 := f.Compute("test")
+	h2 := f.Compute("test")
+	h3 := f.Compute("other")
+
+	assert.Equal(t, h1, h2)
+	assert.NotEqual(t, h1, h3)
+	assert.Equal(t, f.Size(), len(h1))
+}
+
+func TestFnv_ComputeEmpty(t *testing.T) {
+	t.Parallel()
+
+	f := fnv.Fnv{}
+	h1 := f.Compute("")
+	h2 := f.EmptyHash()
+
+	assert.Equal(t, h1, h2)
+	assert.Equal(t, f.Size(), len(h1))
+}
+
+func TestFnv_Size(t *testing.T) {
+	t.Parallel()
+
+	f := fnv.Fnv{}
+	require.Equal(t, 16, f.Size())
+}
+
+func TestFnv_IsInterfaceNil(t *testing.T) {
+	t.Parallel()
+
+	f := fnv.Fnv{}
+	assert.False(t, f.IsInterfaceNil())
+}

--- a/crypto/hashing/hasher_test.go
+++ b/crypto/hashing/hasher_test.go
@@ -1,6 +1,7 @@
 package hashing_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/klever-io/klever-go/crypto/hashing"
@@ -67,4 +68,72 @@ func testCalculateEmptyHash(t *testing.T, h hashing.Hasher) {
 func testNilReturn(t *testing.T, h hashing.Hasher) {
 	h1 := h.Compute("a")
 	assert.NotNil(t, h1)
+}
+
+func TestKeccak_ConcurrentEmptyHash(t *testing.T) {
+	t.Parallel()
+	testConcurrentEmptyHash(t, keccak.Keccak{})
+}
+
+func TestSha256_ConcurrentEmptyHash(t *testing.T) {
+	t.Parallel()
+	testConcurrentEmptyHash(t, sha256.Sha256{})
+}
+
+func TestFnv_ConcurrentEmptyHash(t *testing.T) {
+	t.Parallel()
+	testConcurrentEmptyHash(t, fnv.Fnv{})
+}
+
+func testConcurrentEmptyHash(t *testing.T, h hashing.Hasher) {
+	expected := h.EmptyHash()
+	goroutines := 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	results := make([][]byte, goroutines)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = h.EmptyHash()
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, result := range results {
+		assert.Equal(t, expected, result, "goroutine %d returned different hash", i)
+	}
+}
+
+func TestKeccak_EmptyHashReturnsCopy(t *testing.T) {
+	t.Parallel()
+	testEmptyHashReturnsCopy(t, keccak.Keccak{})
+}
+
+func TestSha256_EmptyHashReturnsCopy(t *testing.T) {
+	t.Parallel()
+	testEmptyHashReturnsCopy(t, sha256.Sha256{})
+}
+
+func TestFnv_EmptyHashReturnsCopy(t *testing.T) {
+	t.Parallel()
+	testEmptyHashReturnsCopy(t, fnv.Fnv{})
+}
+
+func testEmptyHashReturnsCopy(t *testing.T, h hashing.Hasher) {
+	h1 := h.EmptyHash()
+	original := make([]byte, len(h1))
+	copy(original, h1)
+
+	// mutate the returned slice
+	for i := range h1 {
+		h1[i] = 0xFF
+	}
+
+	// subsequent call should return the correct hash, not the mutated one
+	h2 := h.EmptyHash()
+	assert.Equal(t, original, h2)
+	assert.NotEqual(t, h1, h2)
 }

--- a/crypto/hashing/keccak/keccak.go
+++ b/crypto/hashing/keccak/keccak.go
@@ -1,13 +1,18 @@
 package keccak
 
 import (
+	"sync"
+
 	"github.com/klever-io/klever-go/crypto/hashing"
 	"golang.org/x/crypto/sha3"
 )
 
 var _ hashing.Hasher = (*Keccak)(nil)
 
-var keccakEmptyHash []byte
+var (
+	keccakEmptyHash []byte
+	keccakOnce      sync.Once
+)
 
 // Keccak is a sha3-Keccak implementation of the hasher interface.
 type Keccak struct {
@@ -15,7 +20,7 @@ type Keccak struct {
 
 // Compute takes a string, and returns the sha3-Keccak hash of that string
 func (k Keccak) Compute(s string) []byte {
-	if len(s) == 0 && len(keccakEmptyHash) != 0 {
+	if len(s) == 0 {
 		return k.EmptyHash()
 	}
 	h := sha3.NewLegacyKeccak256()
@@ -25,10 +30,13 @@ func (k Keccak) Compute(s string) []byte {
 
 // EmptyHash returns the sha3-Keccak hash of the empty string
 func (k Keccak) EmptyHash() []byte {
-	if len(keccakEmptyHash) == 0 {
-		keccakEmptyHash = k.Compute("")
-	}
-	return keccakEmptyHash
+	keccakOnce.Do(func() {
+		h := sha3.NewLegacyKeccak256()
+		keccakEmptyHash = h.Sum(nil)
+	})
+	result := make([]byte, len(keccakEmptyHash))
+	copy(result, keccakEmptyHash)
+	return result
 }
 
 // Size returns the size, in number of bytes, of a sha3-Keccak hash

--- a/crypto/hashing/keccak/keccak_test.go
+++ b/crypto/hashing/keccak/keccak_test.go
@@ -1,0 +1,47 @@
+package keccak_test
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/crypto/hashing/keccak"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeccak_Compute(t *testing.T) {
+	t.Parallel()
+
+	k := keccak.Keccak{}
+	h1 := k.Compute("test")
+	h2 := k.Compute("test")
+	h3 := k.Compute("other")
+
+	assert.Equal(t, h1, h2)
+	assert.NotEqual(t, h1, h3)
+	assert.Equal(t, k.Size(), len(h1))
+}
+
+func TestKeccak_ComputeEmpty(t *testing.T) {
+	t.Parallel()
+
+	k := keccak.Keccak{}
+	h1 := k.Compute("")
+	h2 := k.EmptyHash()
+
+	assert.Equal(t, h1, h2)
+	assert.Equal(t, k.Size(), len(h1))
+}
+
+func TestKeccak_Size(t *testing.T) {
+	t.Parallel()
+
+	k := keccak.Keccak{}
+	require.Equal(t, 32, k.Size())
+}
+
+func TestKeccak_IsInterfaceNil(t *testing.T) {
+	t.Parallel()
+
+	k := keccak.Keccak{}
+	assert.False(t, k.IsInterfaceNil())
+}

--- a/crypto/hashing/sha256/sha256.go
+++ b/crypto/hashing/sha256/sha256.go
@@ -2,13 +2,17 @@ package sha256
 
 import (
 	"crypto/sha256"
+	"sync"
 
 	"github.com/klever-io/klever-go/crypto/hashing"
 )
 
 var _ hashing.Hasher = (*Sha256)(nil)
 
-var sha256EmptyHash []byte
+var (
+	sha256EmptyHash []byte
+	sha256Once      sync.Once
+)
 
 // Sha256 is a sha256 implementation of the hasher interface.
 type Sha256 struct {
@@ -16,7 +20,7 @@ type Sha256 struct {
 
 // Compute takes a string, and returns the sha256 hash of that string
 func (sha Sha256) Compute(s string) []byte {
-	if len(s) == 0 && len(sha256EmptyHash) != 0 {
+	if len(s) == 0 {
 		return sha.EmptyHash()
 	}
 	h := sha256.New()
@@ -26,10 +30,13 @@ func (sha Sha256) Compute(s string) []byte {
 
 // EmptyHash returns the sha256 hash of the empty string
 func (sha Sha256) EmptyHash() []byte {
-	if len(sha256EmptyHash) == 0 {
-		sha256EmptyHash = sha.Compute("")
-	}
-	return sha256EmptyHash
+	sha256Once.Do(func() {
+		h := sha256.New()
+		sha256EmptyHash = h.Sum(nil)
+	})
+	result := make([]byte, len(sha256EmptyHash))
+	copy(result, sha256EmptyHash)
+	return result
 }
 
 // Size returns the size, in number of bytes, of a sha256 hash

--- a/crypto/hashing/sha256/sha256_test.go
+++ b/crypto/hashing/sha256/sha256_test.go
@@ -1,0 +1,47 @@
+package sha256_test
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/crypto/hashing/sha256"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSha256_Compute(t *testing.T) {
+	t.Parallel()
+
+	s := sha256.Sha256{}
+	h1 := s.Compute("test")
+	h2 := s.Compute("test")
+	h3 := s.Compute("other")
+
+	assert.Equal(t, h1, h2)
+	assert.NotEqual(t, h1, h3)
+	assert.Equal(t, s.Size(), len(h1))
+}
+
+func TestSha256_ComputeEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := sha256.Sha256{}
+	h1 := s.Compute("")
+	h2 := s.EmptyHash()
+
+	assert.Equal(t, h1, h2)
+	assert.Equal(t, s.Size(), len(h1))
+}
+
+func TestSha256_Size(t *testing.T) {
+	t.Parallel()
+
+	s := sha256.Sha256{}
+	require.Equal(t, 32, s.Size())
+}
+
+func TestSha256_IsInterfaceNil(t *testing.T) {
+	t.Parallel()
+
+	s := sha256.Sha256{}
+	assert.False(t, s.IsInterfaceNil())
+}

--- a/crypto/signing/ed25519/scalar.go
+++ b/crypto/signing/ed25519/scalar.go
@@ -94,7 +94,7 @@ func (es *ed25519Scalar) SetInt64(_ int64) {
 // Zero is not needed for this use case, should be removed if possible
 func (es *ed25519Scalar) Zero() crypto.Scalar {
 	log.Error("ed25519Scalar",
-		"message", "SetInt64 for ed25519Scalar is not implemented, should not be called")
+		"message", "Zero for ed25519Scalar is not implemented, should not be called")
 
 	return nil
 }

--- a/crypto/signing/mcl/multisig/bls.go
+++ b/crypto/signing/mcl/multisig/bls.go
@@ -178,7 +178,7 @@ func (bms *BlsMultiSigner) prepareSignatures(
 
 	var hPk []byte
 	var sPointG1 *mcl.PointG1
-	prepSigs := make([]bls.Sign, 0)
+	prepSigs := make([]bls.Sign, 0, len(signatures))
 
 	for i, sig := range signatures {
 		sigBLS := &bls.Sign{}
@@ -321,7 +321,7 @@ func concatPubKeys(pubKeys []crypto.PublicKey) ([]byte, error) {
 	return result, nil
 }
 
-// hashPublicKeyPoints hashes the concatenation of public keys with the given public key poiint
+// hashPublicKeyPoints hashes the concatenation of public keys with the given public key point
 func hashPublicKeyPoints(hasher hashing.Hasher, pubKeyPoint crypto.Point, concatPubKeys []byte) ([]byte, error) {
 	if check.IfNil(hasher) {
 		return nil, crypto.ErrNilHasher
@@ -359,7 +359,10 @@ func createScalar(suite crypto.Suite, scalarBytes []byte) (crypto.Scalar, error)
 	}
 
 	scalar := suite.CreateScalar()
-	sc, _ := scalar.(*mcl.Scalar)
+	sc, ok := scalar.(*mcl.Scalar)
+	if !ok {
+		return nil, crypto.ErrInvalidScalar
+	}
 
 	err := sc.Scalar.SetString(hex.EncodeToString(scalarBytes), 16)
 	if err != nil {

--- a/crypto/signing/mcl/multisig/bls_test.go
+++ b/crypto/signing/mcl/multisig/bls_test.go
@@ -709,6 +709,29 @@ func Test_ScalarMulPkOK(t *testing.T) {
 	require.NotNil(t, point)
 }
 
+func Test_ScalarMulPkInvalidScalarTypeShouldErr(t *testing.T) {
+	t.Parallel()
+
+	blsSuite := mcl.NewSuiteBLS12()
+	kg := signing.NewKeyGenerator(blsSuite)
+	_, pk := kg.GeneratePair()
+
+	// suite that returns a non-mcl scalar from CreateScalar,
+	// causing the type assertion in createScalar to fail
+	mockSuite := &mock.SuiteMock{
+		CreateScalarStub: func() crypto.Scalar {
+			return &mock.ScalarMock{}
+		},
+	}
+
+	scalarBytes := make([]byte, 32)
+	scalarBytes[0] = 1
+
+	point, err := multisig.ScalarMulPk(mockSuite, scalarBytes, pk.Point())
+	require.Equal(t, crypto.ErrInvalidScalar, err)
+	require.Nil(t, point)
+}
+
 func Test_HashPublicKeyPointsNilHasherShouldErr(t *testing.T) {
 	t.Parallel()
 

--- a/crypto/signing/mcl/pointG1.go
+++ b/crypto/signing/mcl/pointG1.go
@@ -31,7 +31,7 @@ func NewPointG1() *PointG1 {
 // Equal tests if receiver is equal with the Point p given as parameter.
 // Both Points need to be derived from the same Group
 func (po *PointG1) Equal(p crypto.Point) (bool, error) {
-	if p == nil {
+	if check.IfNil(p) {
 		return false, crypto.ErrNilParam
 	}
 

--- a/crypto/signing/mcl/pointG1_test.go
+++ b/crypto/signing/mcl/pointG1_test.go
@@ -64,6 +64,40 @@ func TestPointG1_Equal(t *testing.T) {
 	require.True(t, eq)
 }
 
+func TestPointG1_EqualNilParamShouldErr(t *testing.T) {
+	t.Parallel()
+
+	point := NewPointG1()
+	eq, err := point.Equal(nil)
+
+	assert.Equal(t, crypto.ErrNilParam, err)
+	assert.False(t, eq)
+}
+
+func TestPointG1_EqualNilInterfaceWrappedShouldErr(t *testing.T) {
+	t.Parallel()
+
+	point := NewPointG1()
+	// non-nil interface wrapping a nil concrete pointer —
+	// p == nil would be false, but check.IfNil(p) correctly returns true
+	var nilPoint *PointG1
+	eq, err := point.Equal(nilPoint)
+
+	assert.Equal(t, crypto.ErrNilParam, err)
+	assert.False(t, eq)
+}
+
+func TestPointG1_EqualInvalidParamShouldErr(t *testing.T) {
+	t.Parallel()
+
+	point := NewPointG1()
+	point2 := &mock.PointMock{}
+	eq, err := point.Equal(point2)
+
+	assert.Equal(t, crypto.ErrInvalidParam, err)
+	assert.False(t, eq)
+}
+
 func TestPointG1_CloneNilShouldPanic(t *testing.T) {
 	var p1 *PointG1
 

--- a/crypto/signing/mcl/singlesig/bls.go
+++ b/crypto/signing/mcl/singlesig/bls.go
@@ -93,13 +93,13 @@ func IsPubKeyPointValid(pubKeyPoint *mcl.PointG2) bool {
 	return !pubKeyPoint.IsZero() && pubKeyPoint.IsValidOrder() && pubKeyPoint.IsValid()
 }
 
-// IsSigValidPoint validates that the signature isi a valid point on G1
+// IsSigValidPoint validates that the signature is a valid point on G1
 func IsSigValidPoint(sig *bls.Sign) bool {
 	g1Sig := bls.CastFromSign(sig)
 	return !g1Sig.IsZero() && g1Sig.IsValidOrder() && g1Sig.IsValid()
 }
 
-// IsSecretKeyValid validates  that the scalar is a valid secret key
+// IsSecretKeyValid validates that the scalar is a valid secret key
 func IsSecretKeyValid(scalar *mcl.Scalar) bool {
 	return !scalar.Scalar.IsZero() && scalar.Scalar.IsValid()
 }

--- a/crypto/signing/mcl/singlesig/bls.go
+++ b/crypto/signing/mcl/singlesig/bls.go
@@ -10,7 +10,7 @@ import (
 var _ crypto.SingleSigner = (*BlsSingleSigner)(nil)
 
 const (
-	SIGNATURE_SIZE = 48
+	SignatureSize = 48
 )
 
 // BlsSingleSigner is a SingleSigner implementation that uses a BLS signature scheme
@@ -106,7 +106,7 @@ func IsSecretKeyValid(scalar *mcl.Scalar) bool {
 
 // SignatureSize returns the size of the signature
 func (s *BlsSingleSigner) SignatureSize() int {
-	return SIGNATURE_SIZE
+	return SignatureSize
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/crypto/signing/mcl/suiteBLS12_381.go
+++ b/crypto/signing/mcl/suiteBLS12_381.go
@@ -11,7 +11,7 @@ import (
 	"github.com/klever-io/klever-go/tools/check"
 )
 
-var log = logger.GetOrCreate("process/block")
+var log = logger.GetOrCreate("crypto/signing/mcl")
 
 var _ crypto.Group = (*SuiteBLS12)(nil)
 var _ crypto.Random = (*SuiteBLS12)(nil)

--- a/crypto/signing/multisig/pubkeys.go
+++ b/crypto/signing/multisig/pubkeys.go
@@ -5,7 +5,7 @@ import (
 )
 
 func convertStringsToPubKeys(pubKeys []string, kg crypto.KeyGenerator) ([]crypto.PublicKey, error) {
-	var pk []crypto.PublicKey
+	pk := make([]crypto.PublicKey, 0, len(pubKeys))
 
 	//convert pubKeys
 	for _, pubKeyStr := range pubKeys {


### PR DESCRIPTION
## Summary

- **F017**: Fix potential nil pointer panic in multisig `createScalar` — added type assertion check with proper error return
- **F019/F020**: Fix race condition and shared mutable reference in hash caches (keccak, sha256, fnv) — use `sync.Once` for initialization and return copies from `EmptyHash()`
- **F022**: Fix wrong logger name in `suiteBLS12_381.go` (`"process/block"` → `"crypto/signing/mcl"`)
- **F024**: Fix misleading log message in `ed25519Scalar.Zero()` (`"SetInt64"` → `"Zero"`)
- **F025**: Fix inconsistent nil check in `PointG1.Equal` — use `check.IfNil()` to handle interface-wrapped nil
- **F026**: Rename `SIGNATURE_SIZE` → `SignatureSize` following Go naming conventions
- **F027**: Fix typos in singlesig/bls.go comments
- **F028**: Add per-package test files for keccak, sha256, fnv hashers
- **F029**: Pre-allocate slice in `convertStringsToPubKeys`

15 files changed across `crypto/` module (321 additions, 29 deletions). All tests pass with race detector clean.

## Test plan

- [x] `go test -race ./crypto/...` passes
- [x] New tests: `TestPointG1_EqualNilParamShouldErr`, `TestPointG1_EqualNilInterfaceWrappedShouldErr`, `TestPointG1_EqualInvalidParamShouldErr`
- [x] New test: `Test_ScalarMulPkInvalidScalarTypeShouldErr`
- [x] New tests: `testConcurrentEmptyHash` (50 goroutines), `testEmptyHashReturnsCopy` for all three hashers
- [x] New per-package tests: Compute, ComputeEmpty, Size, IsInterfaceNil for keccak, sha256, fnv
- [x] CI pipeline passes