### PR TITLE
[KLC-1824] Setting up the environment to release an open repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -645,7 +645,7 @@ We value all contributions! Contributors are:
 
 ## License
 
-By contributing to Klever, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).
+By contributing to Klever, you agree that your contributions will be licensed under the [GNU General Public License v3.0](LICENSE).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thank you for your interest in contributing to the Klever blockchain! We welcome
 - [Commit Message Guidelines](#commit-message-guidelines)
 - [Pull Request Process](#pull-request-process)
 - [Issue Reporting](#issue-reporting)
+- [Use of Automated Tools and AI](#use-of-automated-tools-and-ai)
 - [Community](#community)
 
 ## Code of Conduct
@@ -618,6 +619,51 @@ When requesting features, include:
 - `help wanted`: Extra attention needed
 - `question`: Further information requested
 - `wontfix`: This will not be worked on
+
+## Use of Automated Tools and AI
+
+We encourage contributors to leverage all available tools to maximize productivity, including AI assistants, code generators, and other automated solutions. However, all contributions must reflect meaningful human oversight, judgment, and quality assurance.
+
+### Quality Standards for AI-Assisted Contributions
+
+When using automated tools or AI to assist with contributions:
+
+1. **Review and refine all generated code** before submission. Ensure it meets our coding standards, follows project conventions, and integrates properly with the existing codebase.
+
+2. **Understand what you submit**. You should be able to explain and defend every line of code in your contribution. If you cannot explain why certain code exists or how it works, it requires further review.
+
+3. **Test thoroughly**. Automated tools may generate code that appears correct but contains subtle bugs or security issues. All contributions must pass our test suite and include appropriate new tests.
+
+4. **Provide meaningful context**. Pull request descriptions, commit messages, and comments should reflect genuine understanding of the changes, not generic or templated text.
+
+### Review Effort Consideration
+
+Before submitting a pull request, consider whether the effort you invested exceeds the effort required for us to review it. Contributions that appear to be unreviewed AI output—requiring significant maintainer effort to evaluate, correct, or rewrite—may be closed without detailed feedback.
+
+Our maintainers can use the same tools available to contributors. The value of external contributions lies in the human expertise, domain knowledge, and careful refinement applied to the work.
+
+### Automated and Low-Effort Submissions
+
+Pull requests, issues, or comments that appear to be generated without meaningful human review will be flagged and closed. This includes:
+
+- Code submissions with obvious AI artifacts or inconsistencies
+- Generic descriptions that do not reflect the actual changes
+- Bulk submissions that lack individual attention to quality
+- Comments or discussions that appear templated or contextually inappropriate
+
+Repeated submissions of this nature may result in account restrictions to protect maintainer resources.
+
+### Responsible Use
+
+Automated tools and AI are powerful aids for development. Use them responsibly:
+
+- **Do** use AI to accelerate research, drafting, and iteration
+- **Do** refine and validate all outputs before submission
+- **Do** apply your expertise to improve generated suggestions
+- **Do not** submit unreviewed automated output
+- **Do not** use automation to generate volume over quality
+
+We appreciate contributors who use these tools thoughtfully to deliver high-quality, well-considered contributions.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 
 ## Acknowledgments
 
+This project is derived from [MultiversX](https://github.com/multiversx/mx-chain-go) (formerly Elrond), originally licensed under GPL v3. We acknowledge and thank the MultiversX team for their foundational work.
+
 Built with:
 - [Go](https://golang.org/)
 - [libp2p](https://libp2p.io/)

--- a/README.md
+++ b/README.md
@@ -326,9 +326,3 @@ Built with:
 - [libp2p](https://libp2p.io/)
 - [Wasmer](https://wasmer.io/)
 - [Protocol Buffers](https://protobuf.dev/)
-
----
-
-**Maintained by**: Klever Core Team
-**Status**: Active Development
-**Version**: 1.7.14

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Official Go implementation of the Klever blockchain protocol.
 
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-GPL%20v3-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-1.25+-00ADD8.svg)](https://golang.org/)
 [![Release](https://img.shields.io/github/v/release/klever-io/klever-go)](https://github.com/klever-io/klever-go/releases)
 
@@ -298,7 +298,7 @@ For bug bounty and security audit information, contact: security@klever.org
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU General Public License v3.0 - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -106,18 +106,18 @@ Generate validator and wallet keys for running a node or submitting transactions
 ### Run a Validator Node
 
 ```bash
-./bin/validator --config-path ./config/node
+./bin/validator
 ```
 
-See [Running a Node](#running-a-node) section below for detailed configuration.
+By default, the node looks for configuration files in `./config/node/`. See [Running a Node](#running-a-node) for details.
 
 ### Run a Seed Node
 
 ```bash
-./bin/seednode --config-path ./config/seednode
+./bin/seednode
 ```
 
-See [cmd/seednode/CLI.md](cmd/seednode/CLI.md) for detailed options.
+By default, the seed node looks for configuration in `./config/seednode/`. See [cmd/seednode/CLI.md](cmd/seednode/CLI.md) for detailed options.
 
 ### Use the Operator CLI
 
@@ -145,28 +145,36 @@ For comprehensive node setup and operation instructions, see the official docume
 
 ### Quick Reference
 
-**Validator Node** (participates in consensus):
+**Validator Node**:
 ```bash
-./bin/validator --config-path ./config/node
+./bin/validator
 ```
 
-**Observer Node** (syncs without consensus participation):
-```bash
-./bin/validator --config-path ./config/node --observer
-```
+> **Note:** A node participates in consensus only if its public key is registered and staked in the network. Otherwise, it syncs the blockchain as an observer.
 
 **Seed Node** (bootstrap peer for network discovery):
 ```bash
-./bin/seednode --config-path ./config/seednode
+./bin/seednode
 ```
 
 ### Configuration Files
 
-Configuration files are located in `config/node/`:
-- `config.yaml` - Main node configuration (network, storage, API)
-- `enableEpochs.yaml` - Feature activation schedule
-- `gasScheduleV1.yaml` - Smart contract gas costs
-- `api.yaml` - REST API endpoints
+By default, the node looks for configuration files in `./config/node/`. Each file can be overridden individually:
+
+| File | Flag | Description |
+|------|------|-------------|
+| `config.yaml` | `--config` | Main node configuration (P2P, logging, storage) |
+| `enableEpochs.yaml` | `--config-epochs` | Feature activation schedule by epoch |
+| `gasScheduleV1.yaml` | `--config-gas-schedule` | Smart contract gas costs |
+| `api.yaml` | `--config-api` | REST API endpoint configuration |
+| `external.yaml` | `--config-external` | External integrations (ElasticSearch) |
+| `genesis.json` | `--genesis-file` | Genesis block configuration |
+| `nodesSetup.json` | `--nodes-setup-file` | Initial validator set |
+
+**Example** - Override a specific config:
+```bash
+./bin/validator --config-external /path/to/custom/external.yaml
+```
 
 For detailed configuration options, see the [Node Operations documentation](https://docs.klever.org/node-operations).
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Klever is a high-performance blockchain network designed for decentralized appli
 - [Architecture](#architecture)
 - [Contributing](#contributing)
 - [Security](#security)
+- [Support](#support)
+- [Resources](#resources)
 - [License](#license)
 
 ## Installation
@@ -288,6 +290,15 @@ Quick start:
 **Report security vulnerabilities**: See [SECURITY.md](SECURITY.md)
 
 For bug bounty and security audit information, contact: security@klever.org
+
+## Support
+
+The **[Klever Forum](https://forum.klever.org)** is the official channel for technical support and community feedback. Use it to:
+- Ask technical questions about running nodes or development
+- Discuss ideas and get guidance from the community
+- Engage with the Klever team and other developers
+
+For **bug reports** and **feature requests**, please use [GitHub Issues](https://github.com/klever-io/klever-go/issues).
 
 ## Resources
 

--- a/cmd/connector/CLI.md
+++ b/cmd/connector/CLI.md
@@ -13,14 +13,14 @@ USAGE:
    
    
 GLOBAL OPTIONS:
-   --address value    Address and port number on which the application will try to connect to the klever-go node (default: "127.0.0.1:8080")
-   --log-level value  This flag specifies the logger level (default: "*:INFO ")
-   --log-correlation  Will include log correlation elements
-   --log-logger-name  Will include logger name
-   --interval value   This flag specifies the duration in seconds until new data is fetched from the node (default: 2)
-   --use-wss          Will use wss instead of ws when creating the web socket
-   --help, -h         show help
-   --version, -v      print the version
+   --address, -a value       Address and port number on which the application will try to connect to the klever-go node (default: "127.0.0.1:8080")
+   --log-level value         This flag specifies the logger level (default: "*:INFO")
+   --log-correlation, -c     Will include log correlation elements
+   --log-logger-name, -n     Will include logger name
+   --interval, -i value      This flag specifies the duration in milliseconds until new data is fetched from the node (default: 1000)
+   --use-wss, -w             Will use wss instead of ws when creating the web socket
+   --help, -h                show help
+   --version, -v             print the version
    
 
 ```

--- a/cmd/keygenerator/CLI.md
+++ b/cmd/keygenerator/CLI.md
@@ -15,10 +15,14 @@ AUTHOR:
    KleverIO <contact@klever.org>
    
 GLOBAL OPTIONS:
-   --num-keys value  How many keys should generate. Example: 1 (default: 1)
-   --key-type value  What king of keys should generate. Available options: validator, wallet, both (default: "validator")
-   --help, -h        show help
-   --version, -v     print the version
+   --num-keys, -n value       How many keys should generate. Example: 1 (default: 1)
+   --key-type, -t value       What kind of keys should generate. Available options: validator, wallet, both (default: "validator")
+   --console-out, -c          Boolean option that will enable printing the generated keys directly on the console
+   --no-split, -s             Boolean option that will make each generated key added in the same file
+   --password, -p value       Password encryption for generated file. Example: --password=MY_SECRET
+   --password-file value      Path to a file containing the password for encryption
+   --help, -h                 show help
+   --version, -v              print the version
    
 
 ```

--- a/cmd/keygenerator/main.go
+++ b/cmd/keygenerator/main.go
@@ -104,7 +104,7 @@ func main() {
 	rootCmd.Flags().IntVarP(&argsConfig.numKeys, "num-keys", "n", 1, "How many keys should generate. Example: 1")
 	// keyType defines a flag for setting what keys should generate
 	rootCmd.Flags().StringVarP(&argsConfig.keyType, "key-type", "t", "validator", fmt.Sprintf(
-		"What king of keys should generate. Available options: %s, %s, %s",
+		"What kind of keys should generate. Available options: %s, %s, %s",
 		validatorType,
 		walletType,
 		bothType))

--- a/cmd/seednode/CLI.md
+++ b/cmd/seednode/CLI.md
@@ -15,13 +15,14 @@ AUTHOR:
    The Klever Team <contact@klever.org>
    
 GLOBAL OPTIONS:
-   --port [p2p port]     The [p2p port] number on which the application will start. Can use single values such as `0, 10230, 15670` or range of ports such as `5000-10000` (default: "10000")
-   --p2p-seed value      P2P seed will be used when generating credentials for p2p component. Can be any string. (default: "seed")
-   --log-level level(s)  This flag specifies the logger level(s). It can contain multiple comma-separated value. For example, if set to *:INFO the logs for all packages will have the INFO level. However, if set to *:INFO,api:DEBUG the logs for all packages will have the INFO level, excepting the api package which will receive a DEBUG log level. (default: "*:INFO ")
-   --log-save            Boolean option for enabling log saving. If set, it will automatically save all the logs into a file.
-   --config [path]       The [path] for the main configuration file. This TOML file contain the main configurations such as the marshalizer type (default: "./config/config.toml")
-   --help, -h            show help
-   --version, -v         print the version
+   --port [p2p port]              The [p2p port] number on which the application will start. Can use single values such as `0, 10230, 15670` or range of ports such as `5000-10000` (default: "10000")
+   --p2p-seed value               P2P seed will be used when generating credentials for p2p component. Can be any string. (default: "seed")
+   --log-level level(s)           This flag specifies the logger level(s). It can contain multiple comma-separated value. For example, if set to *:INFO the logs for all packages will have the INFO level. However, if set to *:INFO,api:DEBUG the logs for all packages will have the INFO level, excepting the api package which will receive a DEBUG log level. (default: "*:INFO")
+   --log-save                     Boolean option for enabling log saving. If set, it will automatically save all the logs into a file.
+   --config [path]                The [path] for the main configuration file. This YAML file contains the main configurations such as the marshalizer type (default: "./config/seednode/config.yaml")
+   --rest-api-interface address   The interface address and port to which the REST API will attempt to bind. To bind to all available interfaces, set this flag to :8080. If set to "off" then the API won't be available (default: "localhost:8080")
+   --help, -h                     show help
+   --version, -v                  print the version
    
 
 ```

--- a/kvm/README.md
+++ b/kvm/README.md
@@ -1,3 +1,31 @@
-# wasm-vm
+# KVM - Klever Virtual Machine
 
-WASM-based Virtual Machine for running Klever Custom Contracts.
+WebAssembly-based virtual machine for executing smart contracts on the Klever blockchain.
+
+## Overview
+
+KVM provides a sandboxed execution environment powered by Wasmer 2.x, with gas metering and blockchain context access for smart contracts.
+
+## Directory Structure
+
+- `vmhost/` - VM host implementation and context management
+- `wasmer2/` - Wasmer runtime integration and shared libraries
+- `executor/` - WASM executor abstraction
+- `crypto/` - Cryptographic operations (hashing, signing)
+- `scenarioexec/` - JSON-based scenario testing framework
+- `test/contracts/` - Example smart contracts for testing
+- `mock/` - Mock implementations for unit testing
+
+## Testing
+
+```bash
+# Run KVM tests
+make tests-kvm
+
+# Run specific package
+go test ./kvm/vmhost/...
+```
+
+## Configuration
+
+Gas costs are defined in `config/node/gasScheduleV1.yaml`.

--- a/tools/tracing/CONSENSUS_TRACING.md
+++ b/tools/tracing/CONSENSUS_TRACING.md
@@ -384,21 +384,20 @@ func (c *CustomConsensus) ProcessBlock(block *Block) error {
 }
 ```
 
-### Example 2: Analyzing Slow Consensus
+### Example 2: Analyzing Traces
 
-```go
-// Use the TraceAnalyzer to identify slow operations
-analyzer := tracing.NewTraceAnalyzer()
-analyzer.LoadFromFile("traces_20240829_120000.json")
+Traces are saved as JSON files in the `./traces` directory. You can analyze them using:
 
-// Get slowest operations
-fmt.Println(analyzer.GetSlowOperations(10))
+1. **Zipkin UI** - Import traces at http://localhost:9411 for visual analysis
+2. **Manual inspection** - Trace files contain span data with timing information
+3. **jq queries** - Parse JSON traces to find slow operations:
 
-// Get consensus statistics
-fmt.Println(analyzer.GetConsensusStats())
+```bash
+# Find spans longer than 100ms
+jq '.[] | select(.duration > 100000)' traces_*.json
 
-// View trace tree for specific slot
-fmt.Println(analyzer.GetTraceTree("trace-id-123"))
+# Get all consensus-related spans
+jq '.[] | select(.name | startswith("consensus"))' traces_*.json
 ```
 
 ## Future Enhancements

--- a/tools/tracing/README.md
+++ b/tools/tracing/README.md
@@ -275,7 +275,7 @@ tags := map[string]string{"user": "alice", "action": "create"}
 defer tracing.StartSpanWithTags("user.action", tags)()
 ```
 
-#### `StartSpanf(format string, args ...interface{}) func()`
+#### `StartSpanf(format string, args ...any) func()`
 Starts a span with a formatted name.
 
 ```go
@@ -289,7 +289,7 @@ Adds a tag to the currently active span.
 tracing.AddTag("status", "success")
 ```
 
-#### `AddTagf(key, format string, args ...interface{})`
+#### `AddTagf(key, format string, args ...any)`
 Adds a formatted tag to the currently active span.
 
 ```go
@@ -303,7 +303,7 @@ Adds an annotation (event marker) to the currently active span.
 tracing.AddAnnotation("Cache miss occurred")
 ```
 
-#### `AddAnnotationf(format string, args ...interface{})`
+#### `AddAnnotationf(format string, args ...any)`
 Adds a formatted annotation to the currently active span.
 
 ```go


### PR DESCRIPTION
## Summary

Prepare documentation for public open-source release by fixing inaccuracies, updating license references to GPL v3, and ensuring all CLI documentation matches actual code.

## Problem

Documentation had multiple issues preventing a clean open-source release:
- License incorrectly referenced as Apache 2.0 (must be GPL v3 due to fork origin)
- CLI documentation contained wrong flags, paths, and defaults that would fail for users
- Missing official support channel reference (Klever Forum)
- KVM README was only 3 lines with no useful information
- Several markdown files had outdated or non-existent API references

## Solution

Systematically audited all markdown documentation files against the actual codebase using parallel investigation agents. Fixed all discrepancies between documentation and code, ensuring commands and flags match what's actually implemented.

## Key Changes

- **New:**
  - `README.md`: Added Support section with Klever Forum as official support channel
  - `README.md`: Added configuration flags table with all override options

- **Updated:**
  - `README.md`: License badge and text (Apache 2.0 → GPL v3)
  - `README.md`: Simplified node commands (removed incorrect `--config-path` flag)
  - `README.md`: Added missing config files (external.yaml, genesis.json, nodesSetup.json)
  - `CONTRIBUTING.md`: License reference (Apache 2.0 → GPL v3)
  - `cmd/seednode/CLI.md`: Fixed config path (`./config/config.toml` → `./config/seednode/config.yaml`), format (TOML → YAML), added `--rest-api-interface` flag
  - `cmd/keygenerator/CLI.md`: Fixed typo ("king" → "kind"), added 4 missing flags (`--console-out`, `--no-split`, `--password`, `--password-file`)
  - `cmd/connector/CLI.md`: Fixed interval unit (seconds → milliseconds) and default (2 → 1000)
  - `tools/tracing/README.md`: Fixed type signatures (`...interface{}` → `...any`)
  - `tools/tracing/CONSENSUS_TRACING.md`: Replaced non-existent TraceAnalyzer API with practical alternatives
  - `kvm/README.md`: Rewrote from 3 lines to proper module documentation

- **Removed:**
  - `README.md`: Removed incorrect `--observer` flag documentation (flag doesn't exist)
  - `tools/tracing/CONSENSUS_TRACING.md`: Removed non-existent TraceAnalyzer code examples

## Testing

- [ ] All existing tests pass (`make tests`)
- [ ] New tests added for new functionality
- [x] Manual testing performed:
  - Verified all CLI flags against source code
  - Verified all file paths and config defaults against actual files
  - Verified Makefile targets exist as documented

## Configuration Changes

None - documentation only.

## Breaking Changes

None

## Related Issues

Related to open-source release preparation task

## Checklist

- [x] Code follows project style guidelines (`make goimports`)
- [ ] Tests added/updated and passing
- [x] Documentation updated (README, CLAUDE.md, code comments)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unnecessary files included
- [x] Breaking changes documented above
- [x] Configuration changes documented above
