### PR TITLE
[KLC-962] Add missing index field in PeerAccountToValidatorInfo

### DIFF
--- a/core/bootstrap/process.go
+++ b/core/bootstrap/process.go
@@ -914,6 +914,7 @@ func (e *epochStartBootstrap) PeerAccountToValidatorInfo(peer state.PeerAccountH
 	return &state.ValidatorInfo{
 		OwnerAddress:                    peer.GetOwnerAddress(),
 		PublicKey:                       peer.GetBLSPublicKey(),
+		Index:                           peer.GetIndex(),
 		List:                            peer.GetListString(),
 		TempRating:                      peer.GetTempRating(),
 		Rating:                          peer.GetRating(),

--- a/core/bootstrap/process_test.go
+++ b/core/bootstrap/process_test.go
@@ -11,6 +11,7 @@ import (
 	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
 	cryptoMock "github.com/klever-io/klever-go/crypto/mock"
 	"github.com/klever-io/klever-go/data/retriever"
+	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/sharding"
 	"github.com/klever-io/klever-go/storage"
 	"github.com/klever-io/klever-go/tools/check"
@@ -562,4 +563,68 @@ func TestSyncUserAccountsState(t *testing.T) {
 	rootHash := []byte("rootHash")
 	err = epochStartProvider.syncUserAccountsState(rootHash)
 	assert.Equal(t, common.ErrNilRequestHandler, err)
+}
+
+func TestEpochStartBootstrap_PeerAccountToValidatorInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Correctly maps Index from PeerAccount", func(t *testing.T) {
+		args := createMockEpochStartBootstrapArgs()
+		epochStartBootstrap, err := NewEpochStartBootstrap(args)
+		require.NoError(t, err)
+		require.NotNil(t, epochStartBootstrap)
+
+		// Create a peer account and set its properties
+		peerAcc, err := state.NewPeerAccount([]byte("peerAddress"))
+		require.NoError(t, err)
+
+		expectedIndex := uint32(123)
+		expectedOwnerAddress := []byte("ownerAddress12345678901234567890")
+		expectedBLSPubKey := []byte("blsPublicKey12345678901234567890")
+
+		// Set the Index using SetListAndIndex
+		peerAcc.SetListAndIndex(state.List_eligible, expectedIndex)
+		err = peerAcc.SetOwnerAddress(expectedOwnerAddress)
+		require.NoError(t, err)
+		err = peerAcc.SetBLSPublicKey(expectedBLSPubKey)
+		require.NoError(t, err)
+		peerAcc.SetTempRating(85)
+		peerAcc.SetRating(90)
+		peerAcc.IncreaseLeaderSuccessRate(20)
+		peerAcc.IncreaseValidatorSuccessRate(100)
+
+		// Call PeerAccountToValidatorInfo
+		validatorInfo := epochStartBootstrap.PeerAccountToValidatorInfo(peerAcc)
+
+		// Assert that Index is correctly mapped
+		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should match the value from PeerAccount.GetIndex()")
+		assert.Equal(t, expectedOwnerAddress, validatorInfo.OwnerAddress)
+		assert.Equal(t, expectedBLSPubKey, validatorInfo.PublicKey)
+		assert.Equal(t, "eligible", validatorInfo.List)
+		assert.Equal(t, uint32(85), validatorInfo.TempRating)
+		assert.Equal(t, uint32(90), validatorInfo.Rating)
+		assert.Equal(t, false, validatorInfo.IsPubKeyRevoked)
+	})
+
+	t.Run("Maps Index correctly for revoked validator", func(t *testing.T) {
+		args := createMockEpochStartBootstrapArgs()
+		epochStartBootstrap, err := NewEpochStartBootstrap(args)
+		require.NoError(t, err)
+
+		// Create a real peer account for revoked validator
+		peerAcc, err := state.NewPeerAccount([]byte("revokedPeerAddress"))
+		require.NoError(t, err)
+
+		expectedIndex := uint32(456)
+		peerAcc.SetListAndIndex(state.List_jailed, expectedIndex)
+		peerAcc.SetRevoked()
+		peerAcc.SetTempRating(20)
+
+		validatorInfo := epochStartBootstrap.PeerAccountToValidatorInfo(peerAcc)
+
+		// Assert Index is preserved even for revoked validators
+		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should be preserved for revoked validators")
+		assert.Equal(t, "jailed", validatorInfo.List)
+		assert.Equal(t, true, validatorInfo.IsPubKeyRevoked)
+	})
 }

--- a/core/bootstrap/process_test.go
+++ b/core/bootstrap/process_test.go
@@ -565,10 +565,17 @@ func TestSyncUserAccountsState(t *testing.T) {
 	assert.Equal(t, common.ErrNilRequestHandler, err)
 }
 
+func assertValidatorInfoIndexMapping(t *testing.T, info *state.ValidatorInfo, expectedIndex uint32, expectedList string, expectedRevoked bool) {
+	t.Helper()
+	assert.Equal(t, expectedIndex, info.Index, "Index should match PeerAccount.GetIndex()")
+	assert.Equal(t, expectedList, info.List)
+	assert.Equal(t, expectedRevoked, info.IsPubKeyRevoked)
+}
+
 func TestEpochStartBootstrap_PeerAccountToValidatorInfo(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Correctly maps Index from PeerAccount", func(t *testing.T) {
+	t.Run("maps index from peer account", func(t *testing.T) {
 		args := createMockEpochStartBootstrapArgs()
 		epochStartBootstrap, err := NewEpochStartBootstrap(args)
 		require.NoError(t, err)
@@ -596,17 +603,15 @@ func TestEpochStartBootstrap_PeerAccountToValidatorInfo(t *testing.T) {
 		// Call PeerAccountToValidatorInfo
 		validatorInfo := epochStartBootstrap.PeerAccountToValidatorInfo(peerAcc)
 
-		// Assert that Index is correctly mapped
-		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should match the value from PeerAccount.GetIndex()")
+		// Assert that Index and related fields are correctly mapped
+		assertValidatorInfoIndexMapping(t, validatorInfo, expectedIndex, "eligible", false)
 		assert.Equal(t, expectedOwnerAddress, validatorInfo.OwnerAddress)
 		assert.Equal(t, expectedBLSPubKey, validatorInfo.PublicKey)
-		assert.Equal(t, "eligible", validatorInfo.List)
 		assert.Equal(t, uint32(85), validatorInfo.TempRating)
 		assert.Equal(t, uint32(90), validatorInfo.Rating)
-		assert.Equal(t, false, validatorInfo.IsPubKeyRevoked)
 	})
 
-	t.Run("Maps Index correctly for revoked validator", func(t *testing.T) {
+	t.Run("maps index correctly for revoked validator", func(t *testing.T) {
 		args := createMockEpochStartBootstrapArgs()
 		epochStartBootstrap, err := NewEpochStartBootstrap(args)
 		require.NoError(t, err)
@@ -623,8 +628,6 @@ func TestEpochStartBootstrap_PeerAccountToValidatorInfo(t *testing.T) {
 		validatorInfo := epochStartBootstrap.PeerAccountToValidatorInfo(peerAcc)
 
 		// Assert Index is preserved even for revoked validators
-		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should be preserved for revoked validators")
-		assert.Equal(t, "jailed", validatorInfo.List)
-		assert.Equal(t, true, validatorInfo.IsPubKeyRevoked)
+		assertValidatorInfoIndexMapping(t, validatorInfo, expectedIndex, "jailed", true)
 	})
 }

--- a/core/kapp/validators/validators.go
+++ b/core/kapp/validators/validators.go
@@ -1144,6 +1144,7 @@ func (v *validatorsKApp) PeerAccountToValidatorInfo(pubkey []byte, revoked bool,
 	return &state.ValidatorInfo{
 		OwnerAddress:                    peerAcc.GetOwnerAddress(),
 		PublicKey:                       pubkey,
+		Index:                           peerAcc.GetIndex(),
 		List:                            peerAcc.GetListString(),
 		TempRating:                      peerAcc.GetTempRating(),
 		Rating:                          peerAcc.GetRating(),

--- a/core/kapp/validators/validators_test.go
+++ b/core/kapp/validators/validators_test.go
@@ -1175,10 +1175,17 @@ func TestClaimPendingRewards(t *testing.T) {
 	})
 }
 
+func assertValidatorInfoIndexMapping(t *testing.T, info *state.ValidatorInfo, expectedIndex uint32, expectedList string, expectedRevoked bool) {
+	t.Helper()
+	assert.Equal(t, expectedIndex, info.Index, "Index should match PeerAccount.GetIndex()")
+	assert.Equal(t, expectedList, info.List)
+	assert.Equal(t, expectedRevoked, info.IsPubKeyRevoked)
+}
+
 func TestValidatorsKApp_PeerAccountToValidatorInfo(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Correctly maps Index from PeerAccount", func(t *testing.T) {
+	t.Run("maps index from peer account", func(t *testing.T) {
 		args := createMockArgs()
 		v, err := NewValidatorKApp(args)
 		require.NoError(t, err)
@@ -1206,17 +1213,15 @@ func TestValidatorsKApp_PeerAccountToValidatorInfo(t *testing.T) {
 		// Test with revoked = false
 		validatorInfo := v.PeerAccountToValidatorInfo(expectedPubKey, false, peerAcc)
 
-		// Assert that Index is correctly mapped
-		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should match the value from PeerAccount.GetIndex()")
+		// Assert that Index and related fields are correctly mapped
+		assertValidatorInfoIndexMapping(t, validatorInfo, expectedIndex, "eligible", false)
 		assert.Equal(t, expectedOwnerAddress, validatorInfo.OwnerAddress)
 		assert.Equal(t, expectedPubKey, validatorInfo.PublicKey)
-		assert.Equal(t, "eligible", validatorInfo.List)
 		assert.Equal(t, uint32(75), validatorInfo.TempRating)
 		assert.Equal(t, uint32(80), validatorInfo.Rating)
-		assert.Equal(t, false, validatorInfo.IsPubKeyRevoked)
 	})
 
-	t.Run("Maps Index correctly for revoked validator", func(t *testing.T) {
+	t.Run("maps index correctly for revoked validator", func(t *testing.T) {
 		args := createMockArgs()
 		v, err := NewValidatorKApp(args)
 		require.NoError(t, err)
@@ -1233,9 +1238,7 @@ func TestValidatorsKApp_PeerAccountToValidatorInfo(t *testing.T) {
 		validatorInfo := v.PeerAccountToValidatorInfo(expectedPubKey, true, peerAcc)
 
 		// Assert Index is preserved even for revoked validators
-		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should be preserved for revoked validators")
+		assertValidatorInfoIndexMapping(t, validatorInfo, expectedIndex, "leaving", true)
 		assert.Equal(t, expectedPubKey, validatorInfo.PublicKey)
-		assert.Equal(t, "leaving", validatorInfo.List)
-		assert.Equal(t, true, validatorInfo.IsPubKeyRevoked)
 	})
 }

--- a/core/kapp/validators/validators_test.go
+++ b/core/kapp/validators/validators_test.go
@@ -1174,3 +1174,68 @@ func TestClaimPendingRewards(t *testing.T) {
 		assert.Equal(t, int64(0), claimed)
 	})
 }
+
+func TestValidatorsKApp_PeerAccountToValidatorInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Correctly maps Index from PeerAccount", func(t *testing.T) {
+		args := createMockArgs()
+		v, err := NewValidatorKApp(args)
+		require.NoError(t, err)
+		require.NotNil(t, v)
+
+		// Create a peer account and set its properties
+		peerAcc, err := state.NewPeerAccount([]byte("peerAddress"))
+		require.NoError(t, err)
+
+		expectedIndex := uint32(42)
+		expectedOwnerAddress := []byte("ownerAddress12345678901234567890")
+		expectedPubKey := []byte("publicKey123456789012345678901234")
+
+		// Set the Index using SetListAndIndex
+		peerAcc.SetListAndIndex(state.List_eligible, expectedIndex)
+		err = peerAcc.SetOwnerAddress(expectedOwnerAddress)
+		require.NoError(t, err)
+		err = peerAcc.SetBLSPublicKey(expectedPubKey)
+		require.NoError(t, err)
+		peerAcc.SetTempRating(75)
+		peerAcc.SetRating(80)
+		peerAcc.IncreaseLeaderSuccessRate(10)
+		peerAcc.IncreaseValidatorSuccessRate(50)
+
+		// Test with revoked = false
+		validatorInfo := v.PeerAccountToValidatorInfo(expectedPubKey, false, peerAcc)
+
+		// Assert that Index is correctly mapped
+		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should match the value from PeerAccount.GetIndex()")
+		assert.Equal(t, expectedOwnerAddress, validatorInfo.OwnerAddress)
+		assert.Equal(t, expectedPubKey, validatorInfo.PublicKey)
+		assert.Equal(t, "eligible", validatorInfo.List)
+		assert.Equal(t, uint32(75), validatorInfo.TempRating)
+		assert.Equal(t, uint32(80), validatorInfo.Rating)
+		assert.Equal(t, false, validatorInfo.IsPubKeyRevoked)
+	})
+
+	t.Run("Maps Index correctly for revoked validator", func(t *testing.T) {
+		args := createMockArgs()
+		v, err := NewValidatorKApp(args)
+		require.NoError(t, err)
+
+		// Create a peer account for revoked validator
+		peerAcc, err := state.NewPeerAccount([]byte("revokedPeerAddress"))
+		require.NoError(t, err)
+
+		expectedIndex := uint32(99)
+		peerAcc.SetListAndIndex(state.List_leaving, expectedIndex)
+		peerAcc.SetRevoked()
+
+		expectedPubKey := []byte("revokedPubKey123456789012345678")
+		validatorInfo := v.PeerAccountToValidatorInfo(expectedPubKey, true, peerAcc)
+
+		// Assert Index is preserved even for revoked validators
+		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should be preserved for revoked validators")
+		assert.Equal(t, expectedPubKey, validatorInfo.PublicKey)
+		assert.Equal(t, "leaving", validatorInfo.List)
+		assert.Equal(t, true, validatorInfo.IsPubKeyRevoked)
+	})
+}

--- a/core/process/peer/process.go
+++ b/core/process/peer/process.go
@@ -285,6 +285,7 @@ func (vs *validatorStatistics) PeerAccountToValidatorInfo(peer state.PeerAccount
 	return &state.ValidatorInfo{
 		OwnerAddress:                    peer.GetOwnerAddress(),
 		PublicKey:                       peer.GetBLSPublicKey(),
+		Index:                           peer.GetIndex(),
 		List:                            peer.GetListString(),
 		TempRating:                      peer.GetTempRating(),
 		Rating:                          peer.GetRating(),
@@ -307,7 +308,6 @@ func (vs *validatorStatistics) PeerAccountToValidatorInfo(peer state.PeerAccount
 func (vs *validatorStatistics) getValidatorDataFromLeaves(
 	leavesChannel chan data.KeyValueHolder,
 ) ([]*state.ValidatorInfo, error) {
-
 	validators := make([]*state.ValidatorInfo, 0)
 
 	for pa := range leavesChannel {

--- a/core/process/peer/process_test.go
+++ b/core/process/peer/process_test.go
@@ -632,10 +632,17 @@ func TestValidatorStatistics_ProcessRatingsEndOfEpochWithNilValidatorInfos(t *te
 	require.Equal(t, process.ErrNilValidatorInfos, err)
 }
 
+func assertValidatorInfoIndexMapping(t *testing.T, info *state.ValidatorInfo, expectedIndex uint32, expectedList string, expectedRevoked bool) {
+	t.Helper()
+	assert.Equal(t, expectedIndex, info.Index, "Index should match PeerAccount.GetIndex()")
+	assert.Equal(t, expectedList, info.List)
+	assert.Equal(t, expectedRevoked, info.IsPubKeyRevoked)
+}
+
 func TestValidatorStatistics_PeerAccountToValidatorInfo(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Correctly maps Index from PeerAccount", func(t *testing.T) {
+	t.Run("maps index from peer account", func(t *testing.T) {
 		arguments := createMockArguments()
 		validatorStatistics, err := peer.NewValidatorStatisticsProcessor(arguments)
 		require.NoError(t, err)
@@ -663,17 +670,15 @@ func TestValidatorStatistics_PeerAccountToValidatorInfo(t *testing.T) {
 		// Call PeerAccountToValidatorInfo
 		validatorInfo := validatorStatistics.PeerAccountToValidatorInfo(peerAcc)
 
-		// Assert that Index is correctly mapped
-		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should match the value from PeerAccount.GetIndex()")
+		// Assert that Index and related fields are correctly mapped
+		assertValidatorInfoIndexMapping(t, validatorInfo, expectedIndex, "eligible", false)
 		assert.Equal(t, expectedOwnerAddress, validatorInfo.OwnerAddress)
 		assert.Equal(t, expectedBLSPubKey, validatorInfo.PublicKey)
-		assert.Equal(t, "eligible", validatorInfo.List)
 		assert.Equal(t, uint32(65), validatorInfo.TempRating)
 		assert.Equal(t, uint32(70), validatorInfo.Rating)
-		assert.Equal(t, false, validatorInfo.IsPubKeyRevoked)
 	})
 
-	t.Run("Maps Index correctly for revoked validator", func(t *testing.T) {
+	t.Run("maps index correctly for revoked validator", func(t *testing.T) {
 		arguments := createMockArguments()
 		validatorStatistics, err := peer.NewValidatorStatisticsProcessor(arguments)
 		require.NoError(t, err)
@@ -690,8 +695,6 @@ func TestValidatorStatistics_PeerAccountToValidatorInfo(t *testing.T) {
 		validatorInfo := validatorStatistics.PeerAccountToValidatorInfo(peerAcc)
 
 		// Assert Index is preserved even for revoked validators
-		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should be preserved for revoked validators")
-		assert.Equal(t, "leaving", validatorInfo.List)
-		assert.Equal(t, true, validatorInfo.IsPubKeyRevoked)
+		assertValidatorInfoIndexMapping(t, validatorInfo, expectedIndex, "leaving", true)
 	})
 }

--- a/core/process/peer/process_test.go
+++ b/core/process/peer/process_test.go
@@ -631,3 +631,67 @@ func TestValidatorStatistics_ProcessRatingsEndOfEpochWithNilValidatorInfos(t *te
 
 	require.Equal(t, process.ErrNilValidatorInfos, err)
 }
+
+func TestValidatorStatistics_PeerAccountToValidatorInfo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Correctly maps Index from PeerAccount", func(t *testing.T) {
+		arguments := createMockArguments()
+		validatorStatistics, err := peer.NewValidatorStatisticsProcessor(arguments)
+		require.NoError(t, err)
+		require.NotNil(t, validatorStatistics)
+
+		// Create a peer account and set its properties
+		peerAcc, err := state.NewPeerAccount([]byte("peerAddress"))
+		require.NoError(t, err)
+
+		expectedIndex := uint32(777)
+		expectedOwnerAddress := []byte("ownerAddress12345678901234567890")
+		expectedBLSPubKey := []byte("blsPublicKey12345678901234567890")
+
+		// Set the Index using SetListAndIndex
+		peerAcc.SetListAndIndex(state.List_eligible, expectedIndex)
+		err = peerAcc.SetOwnerAddress(expectedOwnerAddress)
+		require.NoError(t, err)
+		err = peerAcc.SetBLSPublicKey(expectedBLSPubKey)
+		require.NoError(t, err)
+		peerAcc.SetTempRating(65)
+		peerAcc.SetRating(70)
+		peerAcc.IncreaseLeaderSuccessRate(15)
+		peerAcc.IncreaseValidatorSuccessRate(75)
+
+		// Call PeerAccountToValidatorInfo
+		validatorInfo := validatorStatistics.PeerAccountToValidatorInfo(peerAcc)
+
+		// Assert that Index is correctly mapped
+		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should match the value from PeerAccount.GetIndex()")
+		assert.Equal(t, expectedOwnerAddress, validatorInfo.OwnerAddress)
+		assert.Equal(t, expectedBLSPubKey, validatorInfo.PublicKey)
+		assert.Equal(t, "eligible", validatorInfo.List)
+		assert.Equal(t, uint32(65), validatorInfo.TempRating)
+		assert.Equal(t, uint32(70), validatorInfo.Rating)
+		assert.Equal(t, false, validatorInfo.IsPubKeyRevoked)
+	})
+
+	t.Run("Maps Index correctly for revoked validator", func(t *testing.T) {
+		arguments := createMockArguments()
+		validatorStatistics, err := peer.NewValidatorStatisticsProcessor(arguments)
+		require.NoError(t, err)
+
+		// Create a peer account for revoked validator
+		peerAcc, err := state.NewPeerAccount([]byte("revokedPeerAddress"))
+		require.NoError(t, err)
+
+		expectedIndex := uint32(888)
+		peerAcc.SetListAndIndex(state.List_leaving, expectedIndex)
+		peerAcc.SetRevoked()
+		peerAcc.SetTempRating(15)
+
+		validatorInfo := validatorStatistics.PeerAccountToValidatorInfo(peerAcc)
+
+		// Assert Index is preserved even for revoked validators
+		assert.Equal(t, expectedIndex, validatorInfo.Index, "Index should be preserved for revoked validators")
+		assert.Equal(t, "leaving", validatorInfo.List)
+		assert.Equal(t, true, validatorInfo.IsPubKeyRevoked)
+	})
+}


### PR DESCRIPTION
This pull request update functions to include the validator index when converting peer accounts to `ValidatorInfo`, ensuring that the index is consistently available across different parts of the codebase.

Enhancements to validator information mapping:

* Added the `Index` field to the `ValidatorInfo` struct in `PeerAccountToValidatorInfo` functions in `core/bootstrap/process.go`, `core/kapp/validators/validators.go`, and `core/process/peer/process.go`, improving access to validator indices throughout the system. [[1]](diffhunk://#diff-6b1d5fa06345e922a623398f82ba5c5e18c3c48ef284d44e02ef53d80ad366ceR917) [[2]](diffhunk://#diff-e27f2a44ee2f77bfa7977883f5c05a2893c579d37bd1e2f8a41d90b9fd5e1d20R1147) [[3]](diffhunk://#diff-84b8c7690aa2e7182abc05771043c4960f1965c452f4b8d92a8c1eaa335ae45bR288)
