### PR TITLE
[KLC-2088] Web Socket Improvements & query features

### DIFF
--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -728,6 +728,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		AddressPubkeyConverter:   addressPubkeyConverter,
 		ValidatorPubkeyConverter: validatorPubkeyConverter,
 		Indexer:                  esIndexer,
+		KAppController:           stateComponents.KAppController,
 	})
 	if err != nil {
 		return err

--- a/indexer/dataIndexerArgs.go
+++ b/indexer/dataIndexerArgs.go
@@ -53,4 +53,5 @@ type ArgEventsProcessor struct {
 	AddressPubkeyConverter   core.PubkeyConverter
 	ValidatorPubkeyConverter core.PubkeyConverter
 	Indexer                  Indexer
+	KAppController           kapp.KAppController
 }

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -548,11 +548,11 @@ func (ei *elasticProcessor) SaveTransactions(
 	// Dispatch events
 	if UseEventQueue && len(txs) > 0 {
 		trySendEvent(Event{
-			EvType:  USER_TRANSACTION,
+			EvType:  USER_TRANSACTIONS,
 			Message: txs,
 		})
 		trySendEvent(Event{
-			EvType:  TRANSACTION,
+			EvType:  TRANSACTIONS,
 			Message: txs,
 		})
 	}

--- a/indexer/elasticProcessor_test.go
+++ b/indexer/elasticProcessor_test.go
@@ -1406,13 +1406,13 @@ func TestElasticProcessor_SaveTransactions_DispatchesEventsWhenQueueEnabled(t *t
 	require.Nil(t, err)
 
 	userTxEvent := <-testQueue
-	require.Equal(t, USER_TRANSACTION, userTxEvent.EvType)
+	require.Equal(t, USER_TRANSACTIONS, userTxEvent.EvType)
 	txs, ok := userTxEvent.Message.([]*data.Transaction)
 	require.True(t, ok)
 	require.Len(t, txs, 1)
 
 	txEvent := <-testQueue
-	require.Equal(t, TRANSACTION, txEvent.EvType)
+	require.Equal(t, TRANSACTIONS, txEvent.EvType)
 }
 
 func TestBuildAccountInfo(t *testing.T) {

--- a/indexer/events.go
+++ b/indexer/events.go
@@ -19,11 +19,11 @@ type Event struct {
 type EventType string
 
 const (
-	UNKNOWN          EventType = ""
-	USER_TRANSACTION EventType = "user_transaction"
-	ACCOUNTS         EventType = "accounts"
-	BLOCKS           EventType = "blocks"
-	TRANSACTION      EventType = "transaction"
+	UNKNOWN           EventType = ""
+	USER_TRANSACTIONS EventType = "user_transactions"
+	ACCOUNTS          EventType = "accounts"
+	BLOCKS            EventType = "blocks"
+	TRANSACTIONS      EventType = "transactions"
 )
 
 const dropLogIntervalSeconds = 10
@@ -52,14 +52,14 @@ var ErrUnknownEventType = errors.New("unknown event type")
 
 func NewEventTypeStrict(evType string) (EventType, error) {
 	switch evType {
-	case "transaction":
-		return TRANSACTION, nil
+	case "transactions":
+		return TRANSACTIONS, nil
 	case "accounts":
 		return ACCOUNTS, nil
 	case "blocks":
 		return BLOCKS, nil
-	case "user_transaction":
-		return USER_TRANSACTION, nil
+	case "user_transactions":
+		return USER_TRANSACTIONS, nil
 	default:
 		return UNKNOWN, ErrUnknownEventType
 	}
@@ -67,14 +67,14 @@ func NewEventTypeStrict(evType string) (EventType, error) {
 
 func NewEventType(evType string) EventType {
 	switch evType {
-	case "transaction":
-		return TRANSACTION
+	case "transactions":
+		return TRANSACTIONS
 	case "accounts":
 		return ACCOUNTS
 	case "blocks":
 		return BLOCKS
-	case "user_transaction":
-		return USER_TRANSACTION
+	case "user_transactions":
+		return USER_TRANSACTIONS
 	default:
 		return UNKNOWN
 	}

--- a/indexer/events.go
+++ b/indexer/events.go
@@ -52,7 +52,7 @@ var ErrUnknownEventType = errors.New("unknown event type")
 
 func NewEventTypeStrict(evType string) (EventType, error) {
 	switch evType {
-	case "transactions":
+	case "transaction":
 		return TRANSACTION, nil
 	case "accounts":
 		return ACCOUNTS, nil
@@ -67,7 +67,7 @@ func NewEventTypeStrict(evType string) (EventType, error) {
 
 func NewEventType(evType string) EventType {
 	switch evType {
-	case "transactions":
+	case "transaction":
 		return TRANSACTION
 	case "accounts":
 		return ACCOUNTS

--- a/indexer/events.go
+++ b/indexer/events.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"errors"
 	"sync/atomic"
 	"time"
 )
@@ -44,6 +45,23 @@ func trySendEvent(event Event) {
 				log.Warn("event queue full, dropping events", "type", string(event.EvType), "droppedCount", count)
 			}
 		}
+	}
+}
+
+var ErrUnknownEventType = errors.New("unknown event type")
+
+func NewEventTypeStrict(evType string) (EventType, error) {
+	switch evType {
+	case "transactions":
+		return TRANSACTION, nil
+	case "accounts":
+		return ACCOUNTS, nil
+	case "blocks":
+		return BLOCKS, nil
+	case "user_transaction":
+		return USER_TRANSACTION, nil
+	default:
+		return UNKNOWN, ErrUnknownEventType
 	}
 }
 

--- a/indexer/eventsProcessor.go
+++ b/indexer/eventsProcessor.go
@@ -248,7 +248,12 @@ func (ep *eventsProcessor) getAllowanceWithPendingRewards(userAccount dataState.
 		return allowance
 	}
 
-	pendingRewards, err := ep.kappsController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
+	validatorsKApp := ep.kappsController.GetValidatorsKApp()
+	if check.IfNil(validatorsKApp) {
+		return allowance
+	}
+
+	pendingRewards, err := validatorsKApp.GetPendingRewards(userAccount.AddressBytes())
 	if err == nil && pendingRewards > 0 {
 		allowance += pendingRewards
 	}

--- a/indexer/eventsProcessor.go
+++ b/indexer/eventsProcessor.go
@@ -123,11 +123,11 @@ func (ep *eventsProcessor) processTransactionEvents(header nodeData.HeaderHandle
 	}
 
 	trySendEvent(Event{
-		EvType:  USER_TRANSACTION,
+		EvType:  USER_TRANSACTIONS,
 		Message: txs,
 	})
 	trySendEvent(Event{
-		EvType:  TRANSACTION,
+		EvType:  TRANSACTIONS,
 		Message: txs,
 	})
 }

--- a/indexer/eventsProcessor.go
+++ b/indexer/eventsProcessor.go
@@ -16,8 +16,9 @@ import (
 
 type eventsProcessor struct {
 	*txDatabaseProcessor
-	indexer Indexer
-	parser  *dataParser
+	indexer         Indexer
+	parser          *dataParser
+	kappsController kapp.KAppController
 }
 
 func NewEventsProcessor(arguments ArgEventsProcessor) (*eventsProcessor, error) {
@@ -39,6 +40,7 @@ func NewEventsProcessor(arguments ArgEventsProcessor) (*eventsProcessor, error) 
 			hasher:      arguments.Hasher,
 			marshalizer: arguments.Marshalizer,
 		},
+		kappsController: arguments.KAppController,
 	}
 
 	return ep, nil
@@ -201,7 +203,7 @@ func (ep *eventsProcessor) SaveAccounts(blockTimestamp int64, acc []dataState.Us
 				Balance:         userAccount.GetBalance(kdautils.KLVIdentifier, true),
 				FrozenBalance:   userKDA.FrozenBalance,
 				UnfrozenBalance: calculateUnfrozenBalance(userKDA.Buckets),
-				Allowance:       userAccount.GetAllowance(),
+				Allowance:       ep.getAllowanceWithPendingRewards(userAccount),
 				Permissions:     ep.convertPermissions(userAccount.GetPermissions()),
 				Timestamp:       toMilliseconds(blockTimestamp),
 				UpdatedAt:       toMilliseconds(blockTimestamp),
@@ -238,6 +240,19 @@ func (ep *eventsProcessor) convertPermissions(perms []*dataState.Permission) []d
 		})
 	}
 	return permissions
+}
+
+func (ep *eventsProcessor) getAllowanceWithPendingRewards(userAccount dataState.UserAccountHandler) int64 {
+	allowance := userAccount.GetAllowance()
+	if check.IfNil(ep.kappsController) {
+		return allowance
+	}
+
+	pendingRewards, err := ep.kappsController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
+	if err == nil && pendingRewards > 0 {
+		allowance += pendingRewards
+	}
+	return allowance
 }
 
 func (ep *eventsProcessor) IsInterfaceNil() bool {

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/indexer/data"
 	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/kvm/mock/stub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -593,4 +594,159 @@ func TestTrySendEvent_QueueFull(t *testing.T) {
 
 	event := <-fullQueue
 	require.Equal(t, BLOCKS, event.EvType)
+}
+
+func createTestEventsProcessorWithKApp(ctrl kapp.KAppController) *eventsProcessor {
+	ep, _ := NewEventsProcessor(ArgEventsProcessor{
+		Marshalizer:              &mock.MarshalizerMock{},
+		Hasher:                   &mock.HasherMock{},
+		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
+		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
+		Indexer:                  nil,
+		KAppController:           ctrl,
+	})
+	return ep
+}
+
+func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil kappsController returns base allowance", func(t *testing.T) {
+		t.Parallel()
+
+		ep := createTestEventsProcessor()
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 1000
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(1000), result)
+	})
+
+	t.Run("with pending rewards adds to allowance", func(t *testing.T) {
+		t.Parallel()
+
+		validatorsKapp := &mock.ValidatorsKAppStub{
+			GetPendingRewardsCalled: func(address []byte) (int64, error) {
+				return 500, nil
+			},
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return validatorsKapp
+			},
+		}
+
+		ep := createTestEventsProcessorWithKApp(kappController)
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 2000
+			},
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress")
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(2500), result)
+	})
+
+	t.Run("zero pending rewards returns base allowance", func(t *testing.T) {
+		t.Parallel()
+
+		validatorsKapp := &mock.ValidatorsKAppStub{
+			GetPendingRewardsCalled: func(address []byte) (int64, error) {
+				return 0, nil
+			},
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return validatorsKapp
+			},
+		}
+
+		ep := createTestEventsProcessorWithKApp(kappController)
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 3000
+			},
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress")
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(3000), result)
+	})
+
+	t.Run("error getting pending rewards returns base allowance", func(t *testing.T) {
+		t.Parallel()
+
+		validatorsKapp := &mock.ValidatorsKAppStub{
+			GetPendingRewardsCalled: func(address []byte) (int64, error) {
+				return 0, errors.New("some error")
+			},
+		}
+
+		kappController := &stub.KAppControllerStub{
+			GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+				return validatorsKapp
+			},
+		}
+
+		ep := createTestEventsProcessorWithKApp(kappController)
+
+		userAccount := &mock.UserAccountHandlerStub{
+			GetAllowanceCalled: func() int64 {
+				return 4000
+			},
+			AddressBytesCalled: func() []byte {
+				return []byte("testaddress")
+			},
+		}
+
+		result := ep.getAllowanceWithPendingRewards(userAccount)
+		require.Equal(t, int64(4000), result)
+	})
+}
+
+func TestEventsProcessor_SaveAccounts_AllowanceIncludesPendingRewards(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	validatorsKapp := &mock.ValidatorsKAppStub{
+		GetPendingRewardsCalled: func(address []byte) (int64, error) {
+			return 100, nil
+		},
+	}
+
+	kappController := &stub.KAppControllerStub{
+		GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+			return validatorsKapp
+		},
+	}
+
+	ep := createTestEventsProcessorWithKApp(kappController)
+	acc := createTestAccountStub()
+
+	ep.SaveAccounts(100, []state.UserAccountHandler{acc})
+
+	select {
+	case event := <-testQueue:
+		require.Equal(t, ACCOUNTS, event.EvType)
+		accountsMap, ok := event.Message.(map[string]*data.AccountInfo)
+		require.True(t, ok)
+		require.Len(t, accountsMap, 1)
+		for _, info := range accountsMap {
+			require.Equal(t, int64(150), info.Allowance)
+		}
+	default:
+		t.Fatal("expected account event to be dispatched")
+	}
 }

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -280,14 +280,14 @@ func TestEventsProcessor_SaveBlock_DispatchesTransactionEvents(t *testing.T) {
 	require.Equal(t, BLOCKS, blockEvent.EvType)
 
 	userTxEvent := <-testQueue
-	require.Equal(t, USER_TRANSACTION, userTxEvent.EvType)
+	require.Equal(t, USER_TRANSACTIONS, userTxEvent.EvType)
 	txs, ok := userTxEvent.Message.([]*data.Transaction)
 	require.True(t, ok)
 	require.Len(t, txs, 1)
 	require.NotEmpty(t, txs[0].Contracts)
 
 	txEvent := <-testQueue
-	require.Equal(t, TRANSACTION, txEvent.EvType)
+	require.Equal(t, TRANSACTIONS, txEvent.EvType)
 }
 
 func TestEventsProcessor_SaveBlock_SkipsWebsocketWhenIndexerActive(t *testing.T) {
@@ -592,7 +592,7 @@ func TestTrySendEvent_QueueFull(t *testing.T) {
 	EventQueue = fullQueue
 	defer func() { EventQueue = originalEventQueue }()
 
-	trySendEvent(Event{EvType: TRANSACTION, Message: "dropped"})
+	trySendEvent(Event{EvType: TRANSACTIONS, Message: "dropped"})
 
 	event := <-fullQueue
 	require.Equal(t, BLOCKS, event.EvType)

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -63,14 +63,16 @@ func (s *indexerStub) UpdateProposalsAndParameters(proposalIDs []string) {
 	}
 }
 
-func createTestEventsProcessor() *eventsProcessor {
-	ep, _ := NewEventsProcessor(ArgEventsProcessor{
+func createTestEventsProcessor(t *testing.T) *eventsProcessor {
+	t.Helper()
+	ep, err := NewEventsProcessor(ArgEventsProcessor{
 		Marshalizer:              &mock.MarshalizerMock{},
 		Hasher:                   &mock.HasherMock{},
 		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
 		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
 		Indexer:                  nil,
 	})
+	require.NoError(t, err)
 	return ep
 }
 
@@ -185,7 +187,7 @@ func TestEventsProcessor_Enabled(t *testing.T) {
 		UseEventQueue = false
 		defer func() { UseEventQueue = originalUseEventQueue }()
 
-		ep := createTestEventsProcessor()
+		ep := createTestEventsProcessor(t)
 		require.False(t, ep.Enabled())
 	})
 
@@ -194,7 +196,7 @@ func TestEventsProcessor_Enabled(t *testing.T) {
 		UseEventQueue = true
 		defer func() { UseEventQueue = originalUseEventQueue }()
 
-		ep := createTestEventsProcessor()
+		ep := createTestEventsProcessor(t)
 		require.True(t, ep.Enabled())
 	})
 
@@ -210,7 +212,7 @@ func TestEventsProcessor_Enabled(t *testing.T) {
 
 func TestEventsProcessor_SaveBlock_DispatchesWhenEnabled(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 
 	header := &dataBlock.Block{
 		Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100},
@@ -232,7 +234,7 @@ func TestEventsProcessor_SaveBlock_DispatchesWhenEnabled(t *testing.T) {
 
 func TestEventsProcessor_SaveBlock_SkipsWhenDisabled(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, false)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 
 	header := &dataBlock.Block{
 		Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100},
@@ -252,7 +254,7 @@ func TestEventsProcessor_SaveBlock_SkipsWhenDisabled(t *testing.T) {
 
 func TestEventsProcessor_SaveBlock_DispatchesTransactionEvents(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 
 	contract := transaction.TransferContract{
 		ToAddress: []byte("receiver"),
@@ -320,7 +322,7 @@ func TestEventsProcessor_SaveBlock_SkipsWebsocketWhenIndexerActive(t *testing.T)
 
 func TestEventsProcessor_SaveBlock_NilPool(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 
 	header := &dataBlock.Block{
 		Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100},
@@ -343,7 +345,7 @@ func TestEventsProcessor_SaveBlock_NilPool(t *testing.T) {
 
 func TestEventsProcessor_SaveAccounts_DispatchesWhenEnabled(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 	acc := createTestAccountStub()
 
 	ep.SaveAccounts(100, []state.UserAccountHandler{acc})
@@ -368,7 +370,7 @@ func TestEventsProcessor_SaveAccounts_DispatchesWhenEnabled(t *testing.T) {
 
 func TestEventsProcessor_SaveAccounts_SkipsWhenDisabled(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, false)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 	acc := createTestAccountStub()
 
 	ep.SaveAccounts(100, []state.UserAccountHandler{acc})
@@ -406,7 +408,7 @@ func TestEventsProcessor_SaveAccounts_SkipsWebsocketWhenIndexerActive(t *testing
 
 func TestEventsProcessor_SaveAccounts_GetUserKDAError(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 
 	failAcc := &mock.UserAccountHandlerStub{
 		AddressBytesCalled: func() []byte { return []byte("failaddr") },
@@ -430,7 +432,7 @@ func TestEventsProcessor_SaveAccounts_GetUserKDAError(t *testing.T) {
 
 func TestEventsProcessor_SaveAccounts_EmptySlice(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 
 	ep.SaveAccounts(100, []state.UserAccountHandler{})
 
@@ -443,7 +445,7 @@ func TestEventsProcessor_SaveAccounts_EmptySlice(t *testing.T) {
 
 func TestEventsProcessor_SaveAccounts_WithPermissions(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
-	ep := createTestEventsProcessor()
+	ep := createTestEventsProcessor(t)
 
 	acc := createTestAccountStub()
 	acc.GetPermissionsCalled = func() []*state.Permission {
@@ -483,7 +485,7 @@ func TestEventsProcessor_SaveAccounts_WithPermissions(t *testing.T) {
 
 func TestEventsProcessor_RevertIndexedBlock(t *testing.T) {
 	t.Run("nil indexer does nothing", func(t *testing.T) {
-		ep := createTestEventsProcessor()
+		ep := createTestEventsProcessor(t)
 		ep.RevertIndexedBlock(&dataBlock.Block{
 			Header: &dataBlock.BlockHeader{Nonce: 1},
 		})
@@ -509,7 +511,7 @@ func TestEventsProcessor_RevertIndexedBlock(t *testing.T) {
 
 func TestEventsProcessor_SaveValidatorsRating(t *testing.T) {
 	t.Run("nil indexer does nothing", func(t *testing.T) {
-		ep := createTestEventsProcessor()
+		ep := createTestEventsProcessor(t)
 		ep.SaveValidatorsRating(nil)
 	})
 
@@ -531,7 +533,7 @@ func TestEventsProcessor_SaveValidatorsRating(t *testing.T) {
 
 func TestEventsProcessor_SaveEpochInfo(t *testing.T) {
 	t.Run("nil indexer does nothing", func(t *testing.T) {
-		ep := createTestEventsProcessor()
+		ep := createTestEventsProcessor(t)
 		ep.SaveEpochInfo(1, nil)
 	})
 
@@ -553,7 +555,7 @@ func TestEventsProcessor_SaveEpochInfo(t *testing.T) {
 
 func TestEventsProcessor_UpdateProposalsAndParameters(t *testing.T) {
 	t.Run("nil indexer does nothing", func(t *testing.T) {
-		ep := createTestEventsProcessor()
+		ep := createTestEventsProcessor(t)
 		ep.UpdateProposalsAndParameters([]string{"1"})
 	})
 
@@ -579,7 +581,7 @@ func TestEventsProcessor_IsInterfaceNil(t *testing.T) {
 	var ep *eventsProcessor
 	require.True(t, ep.IsInterfaceNil())
 
-	ep = createTestEventsProcessor()
+	ep = createTestEventsProcessor(t)
 	require.False(t, ep.IsInterfaceNil())
 }
 
@@ -596,8 +598,9 @@ func TestTrySendEvent_QueueFull(t *testing.T) {
 	require.Equal(t, BLOCKS, event.EvType)
 }
 
-func createTestEventsProcessorWithKApp(ctrl kapp.KAppController) *eventsProcessor {
-	ep, _ := NewEventsProcessor(ArgEventsProcessor{
+func createTestEventsProcessorWithKApp(t *testing.T, ctrl kapp.KAppController) *eventsProcessor {
+	t.Helper()
+	ep, err := NewEventsProcessor(ArgEventsProcessor{
 		Marshalizer:              &mock.MarshalizerMock{},
 		Hasher:                   &mock.HasherMock{},
 		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
@@ -605,6 +608,7 @@ func createTestEventsProcessorWithKApp(ctrl kapp.KAppController) *eventsProcesso
 		Indexer:                  nil,
 		KAppController:           ctrl,
 	})
+	require.NoError(t, err)
 	return ep
 }
 
@@ -614,7 +618,7 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 	t.Run("nil kappsController returns base allowance", func(t *testing.T) {
 		t.Parallel()
 
-		ep := createTestEventsProcessor()
+		ep := createTestEventsProcessor(t)
 
 		userAccount := &mock.UserAccountHandlerStub{
 			GetAllowanceCalled: func() int64 {
@@ -641,7 +645,7 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		ep := createTestEventsProcessorWithKApp(kappController)
+		ep := createTestEventsProcessorWithKApp(t, kappController)
 
 		userAccount := &mock.UserAccountHandlerStub{
 			GetAllowanceCalled: func() int64 {
@@ -671,7 +675,7 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		ep := createTestEventsProcessorWithKApp(kappController)
+		ep := createTestEventsProcessorWithKApp(t, kappController)
 
 		userAccount := &mock.UserAccountHandlerStub{
 			GetAllowanceCalled: func() int64 {
@@ -701,7 +705,7 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		ep := createTestEventsProcessorWithKApp(kappController)
+		ep := createTestEventsProcessorWithKApp(t, kappController)
 
 		userAccount := &mock.UserAccountHandlerStub{
 			GetAllowanceCalled: func() int64 {
@@ -732,7 +736,7 @@ func TestEventsProcessor_SaveAccounts_AllowanceIncludesPendingRewards(t *testing
 		},
 	}
 
-	ep := createTestEventsProcessorWithKApp(kappController)
+	ep := createTestEventsProcessorWithKApp(t, kappController)
 	acc := createTestAccountStub()
 
 	ep.SaveAccounts(100, []state.UserAccountHandler{acc})

--- a/indexer/events_test.go
+++ b/indexer/events_test.go
@@ -12,7 +12,7 @@ func TestNewEventTypeStrict_ValidTypes(t *testing.T) {
 		input    string
 		expected EventType
 	}{
-		{"transactions", TRANSACTION},
+		{"transaction", TRANSACTION},
 		{"accounts", ACCOUNTS},
 		{"blocks", BLOCKS},
 		{"user_transaction", USER_TRANSACTION},
@@ -37,6 +37,6 @@ func TestNewEventType_BackwardCompatibility(t *testing.T) {
 	result := NewEventType("invalid_type")
 	assert.Equal(t, UNKNOWN, result)
 
-	result = NewEventType("transactions")
+	result = NewEventType("transaction")
 	assert.Equal(t, TRANSACTION, result)
 }

--- a/indexer/events_test.go
+++ b/indexer/events_test.go
@@ -12,10 +12,10 @@ func TestNewEventTypeStrict_ValidTypes(t *testing.T) {
 		input    string
 		expected EventType
 	}{
-		{"transaction", TRANSACTION},
+		{"transactions", TRANSACTIONS},
 		{"accounts", ACCOUNTS},
 		{"blocks", BLOCKS},
-		{"user_transaction", USER_TRANSACTION},
+		{"user_transactions", USER_TRANSACTIONS},
 	}
 
 	for _, tt := range tests {
@@ -37,6 +37,6 @@ func TestNewEventType_BackwardCompatibility(t *testing.T) {
 	result := NewEventType("invalid_type")
 	assert.Equal(t, UNKNOWN, result)
 
-	result = NewEventType("transaction")
-	assert.Equal(t, TRANSACTION, result)
+	result = NewEventType("transactions")
+	assert.Equal(t, TRANSACTIONS, result)
 }

--- a/indexer/events_test.go
+++ b/indexer/events_test.go
@@ -1,0 +1,42 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEventTypeStrict_ValidTypes(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected EventType
+	}{
+		{"transactions", TRANSACTION},
+		{"accounts", ACCOUNTS},
+		{"blocks", BLOCKS},
+		{"user_transaction", USER_TRANSACTION},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := NewEventTypeStrict(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewEventTypeStrict_InvalidType(t *testing.T) {
+	result, err := NewEventTypeStrict("invalid_type")
+	assert.ErrorIs(t, err, ErrUnknownEventType)
+	assert.Equal(t, UNKNOWN, result)
+}
+
+func TestNewEventType_BackwardCompatibility(t *testing.T) {
+	result := NewEventType("invalid_type")
+	assert.Equal(t, UNKNOWN, result)
+
+	result = NewEventType("transactions")
+	assert.Equal(t, TRANSACTION, result)
+}

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -98,63 +98,27 @@ func Start(ctx context.Context, kleverFacade MainAPIHandler, routesConfig config
 	return ws.Run(kleverFacade.RestAPIInterface())
 }
 
+func registerRouteGroup(ws *gin.Engine, name string, routesConfig config.APIRoutesConfig, authHandler gin.HandlerFunc, register func(*wrapper.RouterWrapper)) {
+	group := ws.Group("/" + name)
+	w, err := wrapper.NewRouterWrapper(name, group, routesConfig, authHandler)
+	if err == nil {
+		register(w)
+	}
+}
+
 // RegisterRoutes will register all routes available on the web server
 func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.APIRoutesConfig, kleverFacade middleware.Handler) {
 	authHandler := middleware.NewAuthenticationFunc(routesConfig)
 
-	nodeRoutes := ws.Group("/node")
-	wrappedNodeRouter, err := wrapper.NewRouterWrapper("node", nodeRoutes, routesConfig, authHandler)
-	if err == nil {
-		node.Routes(wrappedNodeRouter)
-	}
-
-	addressRoutes := ws.Group("/address")
-	wrappedAddressRouter, err := wrapper.NewRouterWrapper("address", addressRoutes, routesConfig, authHandler)
-	if err == nil {
-		address.Routes(wrappedAddressRouter)
-	}
-
-	networkRoutes := ws.Group("/network")
-	wrappedNetworkRoutes, err := wrapper.NewRouterWrapper("network", networkRoutes, routesConfig, authHandler)
-	if err == nil {
-		network.Routes(wrappedNetworkRoutes)
-	}
-
-	txRoutes := ws.Group("/transaction")
-	wrappedTransactionRouter, err := wrapper.NewRouterWrapper("transaction", txRoutes, routesConfig, authHandler)
-	if err == nil {
-		transaction.Routes(wrappedTransactionRouter)
-	}
-
-	validatorRoutes := ws.Group("/validator")
-	wrappedValidatorsRouter, err := wrapper.NewRouterWrapper("validator", validatorRoutes, routesConfig, authHandler)
-	if err == nil {
-		valStats.Routes(wrappedValidatorsRouter)
-	}
-
-	blockRoutes := ws.Group("/block")
-	wrappedBlockRouter, err := wrapper.NewRouterWrapper("block", blockRoutes, routesConfig, authHandler)
-	if err == nil {
-		block.Routes(wrappedBlockRouter)
-	}
-
-	assetRoutes := ws.Group("/asset")
-	wrappedAssetRouter, err := wrapper.NewRouterWrapper("asset", assetRoutes, routesConfig, authHandler)
-	if err == nil {
-		asset.Routes(wrappedAssetRouter)
-	}
-
-	marketplaceRoutes := ws.Group("/marketplace")
-	wrappedMarketplaceRouter, err := wrapper.NewRouterWrapper("marketplace", marketplaceRoutes, routesConfig, authHandler)
-	if err == nil {
-		marketplace.Routes(wrappedMarketplaceRouter)
-	}
-
-	vmRoutes := ws.Group("/vm")
-	wrappedVMRouter, err := wrapper.NewRouterWrapper("vm", vmRoutes, routesConfig, authHandler)
-	if err == nil {
-		vm.Routes(wrappedVMRouter)
-	}
+	registerRouteGroup(ws, "node", routesConfig, authHandler, node.Routes)
+	registerRouteGroup(ws, "address", routesConfig, authHandler, address.Routes)
+	registerRouteGroup(ws, "network", routesConfig, authHandler, network.Routes)
+	registerRouteGroup(ws, "transaction", routesConfig, authHandler, transaction.Routes)
+	registerRouteGroup(ws, "validator", routesConfig, authHandler, valStats.Routes)
+	registerRouteGroup(ws, "block", routesConfig, authHandler, block.Routes)
+	registerRouteGroup(ws, "asset", routesConfig, authHandler, asset.Routes)
+	registerRouteGroup(ws, "marketplace", routesConfig, authHandler, marketplace.Routes)
+	registerRouteGroup(ws, "vm", routesConfig, authHandler, vm.Routes)
 
 	apiHandler, ok := kleverFacade.(MainAPIHandler)
 	if ok && apiHandler.PprofEnabled() {

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -172,8 +172,13 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 			postConnUrl, postConnApiKey = apiHandler.WSConnectionURL(), apiHandler.WSConnectionAPIKey()
 		}
 
+		var wsFacade clientSocket.WSFacade
+		if f, ok := kleverFacade.(clientSocket.WSFacade); ok {
+			wsFacade = f
+		}
+
 		indexer.UseEventQueue = true
-		hub := clientSocket.NewHub(postConnUrl, postConnApiKey)
+		hub := clientSocket.NewHub(postConnUrl, postConnApiKey, wsFacade)
 		wsocket.SubscribeTopics(ws, hub)
 		go hub.StartServer(ctx)
 	}

--- a/network/api/websocket/routes.go
+++ b/network/api/websocket/routes.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	gorilla "github.com/gorilla/websocket"
@@ -12,6 +13,11 @@ import (
 )
 
 var log = logger.GetOrCreate("subscribe")
+
+const (
+	subscribeReadTimeout = 30 * time.Second
+	subscribeOp          = "ws.Subscribe"
+)
 
 var upgrader = gorilla.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
@@ -33,13 +39,35 @@ func SubscribeTopics(ws *gin.Engine, hub *websocket.SocketHub) {
 func handleSubscribe(c *gin.Context, hub *websocket.SocketHub) {
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
-		log.Error("ws.Subscribe", "err", err.Error())
+		log.Error(subscribeOp, "err", err.Error())
+		return
+	}
+
+	go processSubscription(conn, hub)
+}
+
+func processSubscription(conn *gorilla.Conn, hub *websocket.SocketHub) {
+	if err := conn.SetReadDeadline(time.Now().Add(subscribeReadTimeout)); err != nil {
+		log.Error(subscribeOp, "err", err.Error())
+		_ = conn.Close()
 		return
 	}
 
 	var req subscribeRequest
-	if err = conn.ReadJSON(&req); err != nil {
-		log.Error("ws.Subscribe", "err", err.Error())
+	if err := conn.ReadJSON(&req); err != nil {
+		log.Error(subscribeOp, "err", err.Error())
+		_ = conn.Close()
+		return
+	}
+
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		log.Error(subscribeOp, "err", err.Error())
+		_ = conn.Close()
+		return
+	}
+
+	if len(req.Types) == 0 {
+		_ = conn.WriteJSON(map[string]string{"error": "subscribed_types must not be empty"})
 		_ = conn.Close()
 		return
 	}
@@ -51,6 +79,7 @@ func handleSubscribe(c *gin.Context, hub *websocket.SocketHub) {
 		return
 	}
 
+	log.Debug(subscribeOp, "types", fmt.Sprintf("%v", parsedTypes), "addresses", fmt.Sprintf("%v", req.Addresses))
 	client := websocket.NewClient(conn, hub)
 	hub.HandleClientInsertion(parsedTypes, req.Addresses, client)
 }

--- a/network/api/websocket/routes.go
+++ b/network/api/websocket/routes.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -12,54 +13,63 @@ import (
 
 var log = logger.GetOrCreate("subscribe")
 
+var upgrader = gorilla.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+type subscribeRequest struct {
+	Addresses []string `json:"addresses"`
+	Types     []string `json:"subcribed_types"`
+}
+
 func SubscribeTopics(ws *gin.Engine, hub *websocket.SocketHub) {
 	ws.GET("/subscribe", func(c *gin.Context) {
-		upgrader := gorilla.Upgrader{
-			CheckOrigin: func(r *http.Request) bool {
-				return true
-			},
-		}
-
-		conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
-		if err != nil {
-			log.Error("ws.Subscribe", "err", err.Error())
-			return
-		}
-
-		var req struct {
-			Addresses []string `json:"addresses"`
-			Types     []string `json:"subcribed_types"`
-		}
-
-		err = conn.ReadJSON(&req)
-		if err != nil {
-			log.Error("ws.Subscribe", "err", err.Error())
-			return
-		}
-
-		var parsedTypes []indexer.EventType
-		for _, evType := range req.Types {
-			parsed, err := indexer.NewEventTypeStrict(evType)
-			if err != nil {
-				_ = conn.WriteJSON(map[string]string{"error": "invalid subscription type: " + evType})
-				_ = conn.Close()
-				return
-			}
-
-			var has bool
-			for _, v := range parsedTypes {
-				if v == parsed {
-					has = true
-					break
-				}
-			}
-
-			if !has {
-				parsedTypes = append(parsedTypes, parsed)
-			}
-		}
-
-		client := websocket.NewClient(conn, hub)
-		hub.HandleClientInsertion(parsedTypes, req.Addresses, client)
+		handleSubscribe(c, hub)
 	})
+}
+
+func handleSubscribe(c *gin.Context, hub *websocket.SocketHub) {
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Error("ws.Subscribe", "err", err.Error())
+		return
+	}
+
+	var req subscribeRequest
+	if err = conn.ReadJSON(&req); err != nil {
+		log.Error("ws.Subscribe", "err", err.Error())
+		_ = conn.Close()
+		return
+	}
+
+	parsedTypes, err := parseEventTypes(req.Types)
+	if err != nil {
+		_ = conn.WriteJSON(map[string]string{"error": err.Error()})
+		_ = conn.Close()
+		return
+	}
+
+	client := websocket.NewClient(conn, hub)
+	hub.HandleClientInsertion(parsedTypes, req.Addresses, client)
+}
+
+func parseEventTypes(types []string) ([]indexer.EventType, error) {
+	var parsed []indexer.EventType
+	seen := make(map[indexer.EventType]struct{})
+
+	for _, evType := range types {
+		et, err := indexer.NewEventTypeStrict(evType)
+		if err != nil {
+			return nil, fmt.Errorf("invalid subscription type: %s", evType)
+		}
+		if _, ok := seen[et]; ok {
+			continue
+		}
+		seen[et] = struct{}{}
+		parsed = append(parsed, et)
+	}
+
+	return parsed, nil
 }

--- a/network/api/websocket/routes.go
+++ b/network/api/websocket/routes.go
@@ -39,7 +39,12 @@ func SubscribeTopics(ws *gin.Engine, hub *websocket.SocketHub) {
 
 		var parsedTypes []indexer.EventType
 		for _, evType := range req.Types {
-			parsed := indexer.NewEventType(evType)
+			parsed, err := indexer.NewEventTypeStrict(evType)
+			if err != nil {
+				_ = conn.WriteJSON(map[string]string{"error": "invalid subscription type: " + evType})
+				_ = conn.Close()
+				return
+			}
 
 			var has bool
 			for _, v := range parsedTypes {

--- a/network/api/websocket/routes.go
+++ b/network/api/websocket/routes.go
@@ -21,7 +21,7 @@ var upgrader = gorilla.Upgrader{
 
 type subscribeRequest struct {
 	Addresses []string `json:"addresses"`
-	Types     []string `json:"subcribed_types"`
+	Types     []string `json:"subscribed_types"`
 }
 
 func SubscribeTopics(ws *gin.Engine, hub *websocket.SocketHub) {

--- a/network/api/websocket/routes_test.go
+++ b/network/api/websocket/routes_test.go
@@ -2,6 +2,8 @@ package websocket_test
 
 import (
 	"context"
+	"encoding/json"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -12,31 +14,163 @@ import (
 	wsocket "github.com/klever-io/klever-go/network/api/websocket"
 	socket "github.com/klever-io/klever-go/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSubscribeTopics(t *testing.T) {
+func startTestServer(t *testing.T, hub *socket.SocketHub) (string, func()) {
+	t.Helper()
 	gin.SetMode(gin.TestMode)
 	ws := gin.New()
 	ws.Use(cors.Default())
-	hub := socket.NewHub("", "", nil)
 	wsocket.SubscribeTopics(ws, hub)
 
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
 	srv := &http.Server{
-		Addr:              ":23456",
 		Handler:           ws,
 		ReadHeaderTimeout: 1 * time.Second,
 	}
 
-	go func() {
-		_ = srv.ListenAndServe()
-	}()
+	go func() { _ = srv.Serve(listener) }()
 
-	socket, _, err := websocket.DefaultDialer.Dial("ws://localhost:23456/subscribe", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, socket)
+	addr := listener.Addr().String()
+	cleanup := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	err = srv.Shutdown(ctx)
+	return addr, cleanup
+}
+
+func TestSubscribeTopics(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	msg := map[string]interface{}{
+		"addresses":       []string{"klv1test"},
+		"subcribed_types": []string{"blocks"},
+	}
+	err = conn.WriteJSON(msg)
 	assert.NoError(t, err)
+}
+
+func TestSubscribeTopics_InvalidType(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	msg := map[string]interface{}{
+		"addresses":       []string{},
+		"subcribed_types": []string{"invalid_type"},
+	}
+	err = conn.WriteJSON(msg)
+	require.NoError(t, err)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp map[string]string
+	err = conn.ReadJSON(&resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp["error"], "invalid subscription type")
+}
+
+func TestSubscribeTopics_ValidTypes(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	msg := map[string]interface{}{
+		"addresses":       []string{"klv1abc"},
+		"subcribed_types": []string{"blocks", "transactions", "accounts", "user_transaction"},
+	}
+	err = conn.WriteJSON(msg)
+	assert.NoError(t, err)
+}
+
+func TestSubscribeTopics_DuplicateTypes(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	msg := map[string]interface{}{
+		"addresses":       []string{"klv1abc"},
+		"subcribed_types": []string{"blocks", "blocks"},
+	}
+	err = conn.WriteJSON(msg)
+	assert.NoError(t, err)
+}
+
+func TestSubscribeTopics_InvalidJSON(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	err = conn.WriteMessage(websocket.TextMessage, []byte(`not valid json`))
+	require.NoError(t, err)
+
+	conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	_, _, err = conn.ReadMessage()
+	assert.Error(t, err)
+}
+
+func TestSubscribeTopics_ThenSendRequest(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	msg := map[string]interface{}{
+		"addresses":       []string{},
+		"subcribed_types": []string{"blocks"},
+	}
+	err = conn.WriteJSON(msg)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	req := socket.WSRequest{
+		ID:     "test-1",
+		Method: "get_transaction",
+		Params: json.RawMessage(`{"hash":"abc"}`),
+	}
+	err = conn.WriteJSON(req)
+	require.NoError(t, err)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp socket.WSResponse
+	err = conn.ReadJSON(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "test-1", resp.ID)
+	assert.Contains(t, resp.Error, "facade unavailable")
 }

--- a/network/api/websocket/routes_test.go
+++ b/network/api/websocket/routes_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
+	"github.com/klever-io/klever-go/indexer"
 	wsocket "github.com/klever-io/klever-go/network/api/websocket"
 	socket "github.com/klever-io/klever-go/websocket"
 	"github.com/stretchr/testify/assert"
@@ -98,7 +99,7 @@ func TestSubscribeTopics_ValidTypes(t *testing.T) {
 
 	msg := map[string]interface{}{
 		"addresses":        []string{"klv1abc"},
-		"subscribed_types": []string{"blocks", "transaction", "accounts", "user_transaction"},
+		"subscribed_types": []string{"blocks", "transactions", "accounts", "user_transactions"},
 	}
 	err = conn.WriteJSON(msg)
 	assert.NoError(t, err)
@@ -122,6 +123,30 @@ func TestSubscribeTopics_DuplicateTypes(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSubscribeTopics_EmptyTypes(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	msg := map[string]interface{}{
+		"addresses":        []string{},
+		"subscribed_types": []string{},
+	}
+	err = conn.WriteJSON(msg)
+	require.NoError(t, err)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp map[string]string
+	err = conn.ReadJSON(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "subscribed_types must not be empty", resp["error"])
+}
+
 func TestSubscribeTopics_InvalidJSON(t *testing.T) {
 	hub := socket.NewHub("", "", nil)
 	addr, cleanup := startTestServer(t, hub)
@@ -138,6 +163,42 @@ func TestSubscribeTopics_InvalidJSON(t *testing.T) {
 	conn.SetReadDeadline(time.Now().Add(1 * time.Second))
 	_, _, err = conn.ReadMessage()
 	assert.Error(t, err)
+}
+
+func TestSubscribeTopics_BlockEventDelivery(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go hub.StartServer(ctx)
+
+	addr, cleanup := startTestServer(t, hub)
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	msg := map[string]interface{}{
+		"addresses":        []string{},
+		"subscribed_types": []string{"blocks"},
+	}
+	err = conn.WriteJSON(msg)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	blockJSON := []byte(`{"nonce":1,"hash":"abc123"}`)
+	indexer.EventQueue <- indexer.Event{
+		EvType:  indexer.BLOCKS,
+		Message: blockJSON,
+	}
+
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var received socket.Send
+	err = conn.ReadJSON(&received)
+	require.NoError(t, err, "expected to receive block event but got nothing")
+	assert.Equal(t, indexer.BLOCKS, received.Type)
 }
 
 func TestSubscribeTopics_ThenSendRequest(t *testing.T) {

--- a/network/api/websocket/routes_test.go
+++ b/network/api/websocket/routes_test.go
@@ -18,7 +18,7 @@ func TestSubscribeTopics(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ws := gin.New()
 	ws.Use(cors.Default())
-	hub := socket.NewHub("", "")
+	hub := socket.NewHub("", "", nil)
 	wsocket.SubscribeTopics(ws, hub)
 
 	srv := &http.Server{

--- a/network/api/websocket/routes_test.go
+++ b/network/api/websocket/routes_test.go
@@ -55,8 +55,8 @@ func TestSubscribeTopics(t *testing.T) {
 	defer conn.Close()
 
 	msg := map[string]interface{}{
-		"addresses":       []string{"klv1test"},
-		"subcribed_types": []string{"blocks"},
+		"addresses":        []string{"klv1test"},
+		"subscribed_types": []string{"blocks"},
 	}
 	err = conn.WriteJSON(msg)
 	assert.NoError(t, err)
@@ -73,8 +73,8 @@ func TestSubscribeTopics_InvalidType(t *testing.T) {
 	defer conn.Close()
 
 	msg := map[string]interface{}{
-		"addresses":       []string{},
-		"subcribed_types": []string{"invalid_type"},
+		"addresses":        []string{},
+		"subscribed_types": []string{"invalid_type"},
 	}
 	err = conn.WriteJSON(msg)
 	require.NoError(t, err)
@@ -97,8 +97,8 @@ func TestSubscribeTopics_ValidTypes(t *testing.T) {
 	defer conn.Close()
 
 	msg := map[string]interface{}{
-		"addresses":       []string{"klv1abc"},
-		"subcribed_types": []string{"blocks", "transactions", "accounts", "user_transaction"},
+		"addresses":        []string{"klv1abc"},
+		"subscribed_types": []string{"blocks", "transaction", "accounts", "user_transaction"},
 	}
 	err = conn.WriteJSON(msg)
 	assert.NoError(t, err)
@@ -115,8 +115,8 @@ func TestSubscribeTopics_DuplicateTypes(t *testing.T) {
 	defer conn.Close()
 
 	msg := map[string]interface{}{
-		"addresses":       []string{"klv1abc"},
-		"subcribed_types": []string{"blocks", "blocks"},
+		"addresses":        []string{"klv1abc"},
+		"subscribed_types": []string{"blocks", "blocks"},
 	}
 	err = conn.WriteJSON(msg)
 	assert.NoError(t, err)
@@ -151,8 +151,8 @@ func TestSubscribeTopics_ThenSendRequest(t *testing.T) {
 	defer conn.Close()
 
 	msg := map[string]interface{}{
-		"addresses":       []string{},
-		"subcribed_types": []string{"blocks"},
+		"addresses":        []string{},
+		"subscribed_types": []string{"blocks"},
 	}
 	err = conn.WriteJSON(msg)
 	require.NoError(t, err)

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -43,6 +43,8 @@ If any type in `subcribed_types` is invalid, the server responds with an error a
 - `accounts` and `user_transaction` are address-specific. You must provide at least one address for them to deliver events.
 - You can combine any types in a single connection.
 
+> **Note:** The handshake field `subcribed_types` is intentionally spelled without the second "b" — this is the legacy field name required by the server. Additionally, the subscription token `transactions` maps to push events where `"type": "transaction"` (singular) in the event payload.
+
 ---
 
 ## Receiving Push Events

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -13,16 +13,16 @@ Immediately after the connection is established, send an initial JSON message to
 ```json
 {
   "addresses": ["klv1abc...", "klv1def..."],
-  "subcribed_types": ["blocks", "transactions", "accounts", "user_transaction"]
+  "subscribed_types": ["blocks", "transaction", "accounts", "user_transaction"]
 }
 ```
 
 | Field | Description |
 |---|---|
 | `addresses` | List of Klever addresses to watch for address-specific events. |
-| `subcribed_types` | List of event types to subscribe to (see Subscription Types below). |
+| `subscribed_types` | List of event types to subscribe to (see Subscription Types below). |
 
-If any type in `subcribed_types` is invalid, the server responds with an error and closes the connection:
+If any type in `subscribed_types` is invalid, the server responds with an error and closes the connection:
 
 ```json
 {"error": "invalid subscription type: bad_type"}
@@ -35,15 +35,14 @@ If any type in `subcribed_types` is invalid, the server responds with an error a
 | Type | Requires Addresses | Description |
 |---|---|---|
 | `blocks` | No | Receive every new block as it is produced. |
-| `transactions` | No | Receive all transactions globally. |
+| `transaction` | No | Receive all transactions globally. |
 | `accounts` | Yes | Receive account state changes for the specified addresses. |
 | `user_transaction` | Yes | Receive transactions where the specified addresses appear as sender or receiver. |
 
-- `blocks` and `transactions` are global subscriptions and do not require any addresses.
+- `blocks` and `transaction` are global subscriptions and do not require any addresses.
 - `accounts` and `user_transaction` are address-specific. You must provide at least one address for them to deliver events.
 - You can combine any types in a single connection.
 
-> **Note:** The handshake field `subcribed_types` is intentionally spelled without the second "b" — this is the legacy field name required by the server. Additionally, the subscription token `transactions` maps to push events where `"type": "transaction"` (singular) in the event payload.
 
 ---
 
@@ -62,7 +61,7 @@ After subscribing, the server pushes events as JSON messages:
 
 | Field | Description |
 |---|---|
-| `type` | The event type (`blocks`, `transaction`, `accounts`, `user_transaction`). |
+| `type` | The event type (`blocks`, `transaction`, `accounts`, `user_transaction`). Matches the subscription type token. |
 | `address` | The relevant address (populated for address-specific events, empty for global). |
 | `hash` | The transaction hash (populated for transaction-related events). |
 | `data` | The event payload (block data, account info, or transaction details). |
@@ -196,7 +195,7 @@ Dynamically add new subscriptions to the current connection without reconnecting
 
 | Param | Required | Description |
 |---|---|---|
-| `types` | Yes | List of event types to add (`blocks`, `transactions`, `accounts`, `user_transaction`). |
+| `types` | Yes | List of event types to add (`blocks`, `transaction`, `accounts`, `user_transaction`). |
 | `addresses` | No | List of addresses to watch (required for `accounts` and `user_transaction`). |
 
 **Response (success):**
@@ -254,7 +253,7 @@ For address-specific types (`accounts`, `user_transaction`), only the specified 
 
 Errors can occur in two contexts:
 
-**During initial handshake:** If you send an invalid subscription type in the initial `subcribed_types` message, the server returns an error and closes the connection immediately.
+**During initial handshake:** If you send an invalid subscription type in the initial `subscribed_types` message, the server returns an error and closes the connection immediately.
 
 **During request/response messaging:** If a request fails (invalid params, unknown method, resource not found), the server returns an error response with the matching `id`. The connection stays open.
 

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -1,0 +1,276 @@
+# Klever Node WebSocket API
+
+## Connecting
+
+Open a WebSocket connection to:
+
+```
+ws://<node-host>:<port>/subscribe
+```
+
+Immediately after the connection is established, send an initial JSON message to declare your subscriptions:
+
+```json
+{
+  "addresses": ["klv1abc...", "klv1def..."],
+  "subcribed_types": ["blocks", "transactions", "accounts", "user_transaction"]
+}
+```
+
+| Field | Description |
+|---|---|
+| `addresses` | List of Klever addresses to watch for address-specific events. |
+| `subcribed_types` | List of event types to subscribe to (see Subscription Types below). |
+
+If any type in `subcribed_types` is invalid, the server responds with an error and closes the connection:
+
+```json
+{"error": "invalid subscription type: bad_type"}
+```
+
+---
+
+## Subscription Types
+
+| Type | Requires Addresses | Description |
+|---|---|---|
+| `blocks` | No | Receive every new block as it is produced. |
+| `transactions` | No | Receive all transactions globally. |
+| `accounts` | Yes | Receive account state changes for the specified addresses. |
+| `user_transaction` | Yes | Receive transactions where the specified addresses appear as sender or receiver. |
+
+- `blocks` and `transactions` are global subscriptions and do not require any addresses.
+- `accounts` and `user_transaction` are address-specific. You must provide at least one address for them to deliver events.
+- You can combine any types in a single connection.
+
+---
+
+## Receiving Push Events
+
+After subscribing, the server pushes events as JSON messages:
+
+```json
+{
+  "type": "blocks",
+  "address": "",
+  "hash": "",
+  "data": { ... }
+}
+```
+
+| Field | Description |
+|---|---|
+| `type` | The event type (`blocks`, `transaction`, `accounts`, `user_transaction`). |
+| `address` | The relevant address (populated for address-specific events, empty for global). |
+| `hash` | The transaction hash (populated for transaction-related events). |
+| `data` | The event payload (block data, account info, or transaction details). |
+
+---
+
+## Request/Response Messaging
+
+After the initial subscription handshake, you can send JSON requests at any time to query data or manage subscriptions dynamically. Every request must include an `id` field (a client-chosen correlation string) and a `method` field.
+
+### Request Format
+
+```json
+{
+  "id": "your-correlation-id",
+  "method": "method_name",
+  "params": { ... }
+}
+```
+
+### Response Format
+
+On success:
+```json
+{
+  "id": "your-correlation-id",
+  "data": { ... }
+}
+```
+
+On error:
+```json
+{
+  "id": "your-correlation-id",
+  "error": "description of what went wrong"
+}
+```
+
+The `id` in the response always matches the `id` from your request, allowing you to correlate responses when sending multiple concurrent requests.
+
+---
+
+## Available Methods
+
+### `get_transaction`
+
+Retrieve a transaction by its hash.
+
+**Request:**
+```json
+{
+  "id": "1",
+  "method": "get_transaction",
+  "params": {
+    "hash": "abc123def456...",
+    "withResults": true
+  }
+}
+```
+
+| Param | Required | Description |
+|---|---|---|
+| `hash` | Yes | The transaction hash to look up. |
+| `withResults` | No | Whether to include execution results. Defaults to `false`. |
+
+**Response (success):**
+```json
+{
+  "id": "1",
+  "data": {
+    "hash": "abc123def456...",
+    "status": "onChain",
+    ...
+  }
+}
+```
+
+---
+
+### `get_block`
+
+Retrieve a block by nonce or hash. Provide one of the two; if both are provided, nonce takes priority.
+
+**Request by nonce:**
+```json
+{
+  "id": "2",
+  "method": "get_block",
+  "params": {
+    "nonce": 12345,
+    "withTxs": true
+  }
+}
+```
+
+**Request by hash:**
+```json
+{
+  "id": "3",
+  "method": "get_block",
+  "params": {
+    "hash": "blockhash123...",
+    "withTxs": false
+  }
+}
+```
+
+| Param | Required | Description |
+|---|---|---|
+| `nonce` | One of `nonce` or `hash` | The block nonce (height). |
+| `hash` | One of `nonce` or `hash` | The block hash. |
+| `withTxs` | No | Whether to include full transaction details in the block. Defaults to `false`. |
+
+---
+
+### `subscribe`
+
+Dynamically add new subscriptions to the current connection without reconnecting. Subscriptions are additive: calling subscribe multiple times merges the new types and addresses with existing ones.
+
+**Request:**
+```json
+{
+  "id": "4",
+  "method": "subscribe",
+  "params": {
+    "types": ["accounts", "blocks"],
+    "addresses": ["klv1newaddress..."]
+  }
+}
+```
+
+| Param | Required | Description |
+|---|---|---|
+| `types` | Yes | List of event types to add (`blocks`, `transactions`, `accounts`, `user_transaction`). |
+| `addresses` | No | List of addresses to watch (required for `accounts` and `user_transaction`). |
+
+**Response (success):**
+```json
+{
+  "id": "4",
+  "data": "subscribed"
+}
+```
+
+**Response (invalid type):**
+```json
+{
+  "id": "4",
+  "error": "invalid subscription type: bad_type"
+}
+```
+
+---
+
+### `unsubscribe`
+
+Remove specific subscriptions from the current connection. Unsubscribe is granular: it only removes the specified types and addresses without affecting other active subscriptions.
+
+**Request:**
+```json
+{
+  "id": "5",
+  "method": "unsubscribe",
+  "params": {
+    "types": ["accounts"],
+    "addresses": ["klv1oldaddress..."]
+  }
+}
+```
+
+| Param | Required | Description |
+|---|---|---|
+| `types` | Yes | List of event types to remove. |
+| `addresses` | No | List of addresses to stop watching (required for `accounts` and `user_transaction`). |
+
+For address-specific types (`accounts`, `user_transaction`), only the specified type is unsubscribed. If an address still has the other type active, it remains subscribed for that type. The address entry is fully removed only when both `accounts` and `user_transaction` are unsubscribed.
+
+**Response (success):**
+```json
+{
+  "id": "5",
+  "data": "unsubscribed"
+}
+```
+
+---
+
+## Error Handling
+
+Errors can occur in two contexts:
+
+**During initial handshake:** If you send an invalid subscription type in the initial `subcribed_types` message, the server returns an error and closes the connection immediately.
+
+**During request/response messaging:** If a request fails (invalid params, unknown method, resource not found), the server returns an error response with the matching `id`. The connection stays open.
+
+Common error responses:
+
+| Error | Cause |
+|---|---|
+| `"invalid json: ..."` | The message could not be parsed as JSON. |
+| `"unknown method: ..."` | The `method` field is not one of the supported methods. |
+| `"missing required param: hash"` | A `get_transaction` request was sent without a `hash`. |
+| `"must provide nonce or hash"` | A `get_block` request was sent without either `nonce` or `hash`. |
+| `"invalid subscription type: ..."` | A `subscribe` or `unsubscribe` request included an unrecognized type. |
+| `"query not supported: facade unavailable"` | The node does not support data queries over WebSocket (non-indexer node). |
+
+---
+
+## Connection Lifecycle
+
+- The server sends periodic ping frames. The client does not need to send pings, but must respond to pings (most WebSocket libraries handle this automatically).
+- To disconnect, close the WebSocket connection normally. The server cleans up all subscriptions for the client automatically.
+- If the server detects a broken connection, it removes the client and all associated subscriptions.

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -13,7 +13,7 @@ Immediately after the connection is established, send an initial JSON message to
 ```json
 {
   "addresses": ["klv1abc...", "klv1def..."],
-  "subscribed_types": ["blocks", "transaction", "accounts", "user_transaction"]
+  "subscribed_types": ["blocks", "transactions", "accounts", "user_transactions"]
 }
 ```
 
@@ -35,12 +35,12 @@ If any type in `subscribed_types` is invalid, the server responds with an error 
 | Type | Requires Addresses | Description |
 |---|---|---|
 | `blocks` | No | Receive every new block as it is produced. |
-| `transaction` | No | Receive all transactions globally. |
+| `transactions` | No | Receive all transactions globally. |
 | `accounts` | Yes | Receive account state changes for the specified addresses. |
-| `user_transaction` | Yes | Receive transactions where the specified addresses appear as sender or receiver. |
+| `user_transactions` | Yes | Receive transactions where the specified addresses appear as sender or receiver. |
 
-- `blocks` and `transaction` are global subscriptions and do not require any addresses.
-- `accounts` and `user_transaction` are address-specific. You must provide at least one address for them to deliver events.
+- `blocks` and `transactions` are global subscriptions and do not require any addresses.
+- `accounts` and `user_transactions` are address-specific. You must provide at least one address for them to deliver events.
 - You can combine any types in a single connection.
 
 
@@ -61,7 +61,7 @@ After subscribing, the server pushes events as JSON messages:
 
 | Field | Description |
 |---|---|
-| `type` | The event type (`blocks`, `transaction`, `accounts`, `user_transaction`). Matches the subscription type token. |
+| `type` | The event type (`blocks`, `transactions`, `accounts`, `user_transactions`). Matches the subscription type token. |
 | `address` | The relevant address (populated for address-specific events, empty for global). |
 | `hash` | The transaction hash (populated for transaction-related events). |
 | `data` | The event payload (block data, account info, or transaction details). |
@@ -195,8 +195,8 @@ Dynamically add new subscriptions to the current connection without reconnecting
 
 | Param | Required | Description |
 |---|---|---|
-| `types` | Yes | List of event types to add (`blocks`, `transaction`, `accounts`, `user_transaction`). |
-| `addresses` | No | List of addresses to watch (required for `accounts` and `user_transaction`). |
+| `types` | Yes | List of event types to add (`blocks`, `transactions`, `accounts`, `user_transactions`). |
+| `addresses` | No | List of addresses to watch (required for `accounts` and `user_transactions`). |
 
 **Response (success):**
 ```json
@@ -235,9 +235,9 @@ Remove specific subscriptions from the current connection. Unsubscribe is granul
 | Param | Required | Description |
 |---|---|---|
 | `types` | Yes | List of event types to remove. |
-| `addresses` | No | List of addresses to stop watching (required for `accounts` and `user_transaction`). |
+| `addresses` | No | List of addresses to stop watching (required for `accounts` and `user_transactions`). |
 
-For address-specific types (`accounts`, `user_transaction`), only the specified type is unsubscribed. If an address still has the other type active, it remains subscribed for that type. The address entry is fully removed only when both `accounts` and `user_transaction` are unsubscribed.
+For address-specific types (`accounts`, `user_transactions`), only the specified type is unsubscribed. If an address still has the other type active, it remains subscribed for that type. The address entry is fully removed only when both `accounts` and `user_transactions` are unsubscribed.
 
 **Response (success):**
 ```json

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -101,7 +101,7 @@ On error:
 }
 ```
 
-The `id` in the response always matches the `id` from your request, allowing you to correlate responses when sending multiple concurrent requests.
+When your request is valid JSON and includes an `id`, the `id` in the response matches the `id` from your request, allowing you to correlate responses when sending multiple concurrent requests. For parse errors where the incoming frame is not valid JSON, the server may return an error without an `id` because it cannot reliably extract it.
 
 ---
 

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -55,7 +55,7 @@ func (c *client) close() {
 	defer c.aliveLock.Unlock()
 	if c.alive {
 		if err := c.conn.Close(); err != nil {
-			log.Error("ws.close", "err", err.Error())
+			log.Warn("ws.close", "err", err.Error())
 		}
 		c.alive = false
 		c.cancel()
@@ -77,7 +77,7 @@ func (c *client) loopIn() {
 		messageType, message, err := c.conn.ReadMessage()
 		if err != nil {
 			if ws.IsUnexpectedCloseError(err, ws.CloseGoingAway, ws.CloseAbnormalClosure) {
-				log.Error("ws.loopIn", "err", err.Error())
+				log.Warn("ws.loopIn", "err", err.Error())
 			}
 			break
 		}
@@ -88,7 +88,7 @@ func (c *client) loopIn() {
 		case ws.PingMessage:
 			err = c.conn.WriteControl(ws.PongMessage, nil, time.Now().Add(pingPeriod))
 			if err != nil {
-				log.Error("ws.loopIn", "err", err.Error())
+				log.Warn("ws.loopIn.pong", "err", err.Error())
 				return
 			}
 		case ws.TextMessage:
@@ -98,10 +98,16 @@ func (c *client) loopIn() {
 				continue
 			}
 			c.sem <- struct{}{}
-			go func() {
+			ctx := c.ctx
+			go func(ctx context.Context, req WSRequest) {
 				defer func() { <-c.sem }()
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 				c.hub.HandleClientRequest(c, req)
-			}()
+			}(ctx, req)
 		}
 	}
 }
@@ -111,11 +117,15 @@ func (c *client) loopOut() {
 		select {
 		case <-c.ctx.Done():
 			return
-		case m := <-c.out:
+		case m, ok := <-c.out:
+			if !ok {
+				return
+			}
 			err := c.conn.WriteJSON(m)
 			if err != nil {
-				log.Error("ws.loopOut", "err", err.Error())
+				log.Warn("ws.loopOut", "err", err.Error())
 				c.close()
+				return
 			}
 		}
 	}

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -17,11 +17,12 @@ type client struct {
 	out       chan interface{}
 	ctx       context.Context
 	cancel    context.CancelFunc
+	sem       chan struct{}
 }
 
 // NewClient create a new client, add into hub and start ping and watch
 func NewClient(conn *ws.Conn, hub *SocketHub) *client {
-	client := &client{conn: conn, hub: hub, out: make(chan interface{}, outChannelSize), alive: true}
+	client := &client{conn: conn, hub: hub, out: make(chan interface{}, outChannelSize), alive: true, sem: make(chan struct{}, maxWorkers)}
 	client.ctx, client.cancel = context.WithCancel(context.Background())
 	go client.loopIn()
 	go client.loopOut()
@@ -96,7 +97,11 @@ func (c *client) loopIn() {
 				c.send(WSResponse{Error: "invalid json: " + err.Error()})
 				continue
 			}
-			go c.hub.HandleClientRequest(c, req)
+			c.sem <- struct{}{}
+			go func() {
+				defer func() { <-c.sem }()
+				c.hub.HandleClientRequest(c, req)
+			}()
 		}
 	}
 }

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -96,7 +96,7 @@ func (c *client) loopIn() {
 				c.send(WSResponse{Error: "invalid json: " + err.Error()})
 				continue
 			}
-			c.hub.HandleClientRequest(c, req)
+			go c.hub.HandleClientRequest(c, req)
 		}
 	}
 }

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -59,7 +60,7 @@ func (c *client) loopIn() {
 	}()
 
 	for {
-		messageType, _, err := c.conn.ReadMessage()
+		messageType, message, err := c.conn.ReadMessage()
 		if err != nil {
 			if ws.IsUnexpectedCloseError(err, ws.CloseGoingAway, ws.CloseAbnormalClosure) {
 				log.Error("ws.loopIn", "err", err.Error())
@@ -76,6 +77,13 @@ func (c *client) loopIn() {
 				log.Error("ws.loopIn", "err", err.Error())
 				return
 			}
+		case ws.TextMessage:
+			var req WSRequest
+			if err := json.Unmarshal(message, &req); err != nil {
+				c.out <- WSResponse{Error: "invalid json: " + err.Error()}
+				continue
+			}
+			c.hub.HandleClientRequest(c, req)
 		}
 	}
 }

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -35,6 +35,19 @@ func (c *client) IsAlive() bool {
 	return c.alive
 }
 
+func (c *client) send(msg interface{}) {
+	c.aliveLock.Lock()
+	defer c.aliveLock.Unlock()
+	if !c.alive {
+		return
+	}
+	select {
+	case c.out <- msg:
+	default:
+		log.Warn("ws.send", "msg", "client output buffer full, dropping message")
+	}
+}
+
 // close call this function to close client connection and remove from hub
 func (c *client) close() {
 	c.aliveLock.Lock()
@@ -80,7 +93,7 @@ func (c *client) loopIn() {
 		case ws.TextMessage:
 			var req WSRequest
 			if err := json.Unmarshal(message, &req); err != nil {
-				c.out <- WSResponse{Error: "invalid json: " + err.Error()}
+				c.send(WSResponse{Error: "invalid json: " + err.Error()})
 				continue
 			}
 			c.hub.HandleClientRequest(c, req)

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -3,9 +3,7 @@ package websocket
 import "time"
 
 const (
-	// Ping interval to check client connection
-	pingPeriod = time.Duration(15) * time.Second
-
-	// chanel of client messages size
+	pingPeriod     = time.Duration(15) * time.Second
 	outChannelSize = 500
+	maxWorkers     = 4
 )

--- a/websocket/interface.go
+++ b/websocket/interface.go
@@ -1,0 +1,9 @@
+package websocket
+
+import "github.com/klever-io/klever-go/data/api"
+
+type WSFacade interface {
+	GetTransaction(hash string, withResults bool) (*api.Transaction, error)
+	GetBlockByHash(hash string, withTxs bool) (*api.Block, error)
+	GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, error)
+}

--- a/websocket/message.go
+++ b/websocket/message.go
@@ -1,0 +1,43 @@
+package websocket
+
+import "encoding/json"
+
+const (
+	MethodGetTransaction = "get_transaction"
+	MethodGetBlock       = "get_block"
+	MethodSubscribe      = "subscribe"
+	MethodUnsubscribe    = "unsubscribe"
+)
+
+type WSRequest struct {
+	ID     string          `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+type WSResponse struct {
+	ID    string      `json:"id"`
+	Data  interface{} `json:"data,omitempty"`
+	Error string      `json:"error,omitempty"`
+}
+
+type GetTransactionParams struct {
+	Hash        string `json:"hash"`
+	WithResults bool   `json:"withResults"`
+}
+
+type GetBlockParams struct {
+	Nonce   *uint64 `json:"nonce,omitempty"`
+	Hash    string  `json:"hash,omitempty"`
+	WithTxs bool    `json:"withTxs"`
+}
+
+type SubscribeParams struct {
+	Addresses []string `json:"addresses"`
+	Types     []string `json:"types"`
+}
+
+type UnsubscribeParams struct {
+	Addresses []string `json:"addresses"`
+	Types     []string `json:"types"`
+}

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -25,14 +25,14 @@ type SocketHub struct {
 	mu                      sync.Mutex
 	postConnectionURL       string
 	postConnectionAPIKey    string
+	facade                  WSFacade
 	blockSubscription       map[*client]struct{}
 	transactionSubscription map[*client]struct{}
 	addressSubscription     map[string]map[*client]userOptions
 	unregister              chan *client
 }
 
-// NewHub create a hub to manage new websocket connection
-func NewHub(postConnectionURL, postConnectionAPIKey string) *SocketHub {
+func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade) *SocketHub {
 	return &SocketHub{
 		unregister:              make(chan *client),
 		addressSubscription:     make(map[string]map[*client]userOptions),
@@ -40,6 +40,7 @@ func NewHub(postConnectionURL, postConnectionAPIKey string) *SocketHub {
 		transactionSubscription: make(map[*client]struct{}),
 		postConnectionURL:       postConnectionURL,
 		postConnectionAPIKey:    postConnectionAPIKey,
+		facade:                  facade,
 	}
 }
 
@@ -331,6 +332,149 @@ func (h *SocketHub) handleClientDelete(c *client) {
 			if cl == c {
 				delete(clients, c)
 			}
+		}
+	}
+}
+
+func (h *SocketHub) HandleClientRequest(c *client, req WSRequest) {
+	switch req.Method {
+	case MethodGetTransaction:
+		h.handleGetTransaction(c, req)
+	case MethodGetBlock:
+		h.handleGetBlock(c, req)
+	case MethodSubscribe:
+		h.handleDynamicSubscribe(c, req)
+	case MethodUnsubscribe:
+		h.handleDynamicUnsubscribe(c, req)
+	default:
+		c.out <- WSResponse{ID: req.ID, Error: "unknown method: " + req.Method}
+	}
+}
+
+func (h *SocketHub) handleGetTransaction(c *client, req WSRequest) {
+	if h.facade == nil {
+		c.out <- WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"}
+		return
+	}
+
+	var params GetTransactionParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		return
+	}
+
+	if params.Hash == "" {
+		c.out <- WSResponse{ID: req.ID, Error: "missing required param: hash"}
+		return
+	}
+
+	tx, err := h.facade.GetTransaction(params.Hash, params.WithResults)
+	if err != nil {
+		c.out <- WSResponse{ID: req.ID, Error: err.Error()}
+		return
+	}
+
+	c.out <- WSResponse{ID: req.ID, Data: tx}
+}
+
+func (h *SocketHub) handleGetBlock(c *client, req WSRequest) {
+	if h.facade == nil {
+		c.out <- WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"}
+		return
+	}
+
+	var params GetBlockParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		return
+	}
+
+	if params.Nonce == nil && params.Hash == "" {
+		c.out <- WSResponse{ID: req.ID, Error: "must provide nonce or hash"}
+		return
+	}
+
+	if params.Nonce != nil {
+		blk, err := h.facade.GetBlockByNonce(*params.Nonce, params.WithTxs)
+		if err != nil {
+			c.out <- WSResponse{ID: req.ID, Error: err.Error()}
+			return
+		}
+		c.out <- WSResponse{ID: req.ID, Data: blk}
+		return
+	}
+
+	blk, err := h.facade.GetBlockByHash(params.Hash, params.WithTxs)
+	if err != nil {
+		c.out <- WSResponse{ID: req.ID, Error: err.Error()}
+		return
+	}
+	c.out <- WSResponse{ID: req.ID, Data: blk}
+}
+
+func (h *SocketHub) handleDynamicSubscribe(c *client, req WSRequest) {
+	var params SubscribeParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		return
+	}
+
+	var eventTypes []indexer.EventType
+	for _, t := range params.Types {
+		parsed, err := indexer.NewEventTypeStrict(t)
+		if err != nil {
+			c.out <- WSResponse{ID: req.ID, Error: "invalid subscription type: " + t}
+			return
+		}
+		eventTypes = append(eventTypes, parsed)
+	}
+
+	h.HandleClientInsertion(eventTypes, params.Addresses, c)
+	c.out <- WSResponse{ID: req.ID, Data: "subscribed"}
+}
+
+func (h *SocketHub) handleDynamicUnsubscribe(c *client, req WSRequest) {
+	var params UnsubscribeParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		return
+	}
+
+	var eventTypes []indexer.EventType
+	for _, t := range params.Types {
+		parsed, err := indexer.NewEventTypeStrict(t)
+		if err != nil {
+			c.out <- WSResponse{ID: req.ID, Error: "invalid subscription type: " + t}
+			return
+		}
+		eventTypes = append(eventTypes, parsed)
+	}
+
+	h.HandleClientRemoval(eventTypes, params.Addresses, c)
+	c.out <- WSResponse{ID: req.ID, Data: "unsubscribed"}
+}
+
+func (h *SocketHub) HandleClientRemoval(eventTypes []indexer.EventType, addresses []string, c *client) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, t := range eventTypes {
+		switch t {
+		case indexer.BLOCKS:
+			delete(h.blockSubscription, c)
+		case indexer.TRANSACTION:
+			delete(h.transactionSubscription, c)
+		}
+	}
+
+	for _, addr := range addresses {
+		clients, ok := h.addressSubscription[addr]
+		if !ok {
+			continue
+		}
+		delete(clients, c)
+		if len(clients) == 0 {
+			delete(h.addressSubscription, addr)
 		}
 	}
 }

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -23,6 +23,8 @@ const (
 	errUnknownMethod    = "unknown method: "
 	errMissingHash      = "missing required param: hash"
 	errMissingNonceHash = "must provide nonce or hash"
+	errTxNotFound       = "transaction not found"
+	errBlockNotFound    = "block not found"
 )
 
 type userOptions struct {
@@ -148,35 +150,44 @@ func (h *SocketHub) handleUserTransactionEvent(event indexer.Event) {
 	for _, tx := range transactions {
 		var wg sync.WaitGroup
 		wg.Add(3)
-		go func() {
-			defer wg.Done()
-			parsed := h.marshalAndPost(event.EvType, tx.Sender, "", tx)
-			if parsed == nil {
-				return
-			}
-			h.notifyAddressSubscribers(tx.Sender, parsed, acceptTx)
-		}()
-		go func(tx *data.Transaction) {
-			defer wg.Done()
-			for _, receipts := range tx.Receipts {
-				to := receipts["to"]
-				if to == nil {
-					continue
-				}
-				address := to.(string)
-				parsed := h.marshalAndPost(event.EvType, address, "", tx)
-				if parsed == nil {
-					return
-				}
-				h.notifyAddressSubscribers(address, parsed, acceptTx)
-			}
-		}(tx)
-		go func() {
-			defer wg.Done()
-			h.marshalAndPost(event.EvType, "", tx.Hash, tx)
-		}()
+		go h.notifyTxSender(&wg, event.EvType, tx, acceptTx)
+		go h.notifyTxReceipts(&wg, event.EvType, tx, acceptTx)
+		go h.postTxHash(&wg, event.EvType, tx)
 		wg.Wait()
 	}
+}
+
+func (h *SocketHub) notifyTxSender(wg *sync.WaitGroup, evType indexer.EventType, tx *data.Transaction, acceptTx func(userOptions) bool) {
+	defer wg.Done()
+	parsed := h.marshalAndPost(evType, tx.Sender, "", tx)
+	if parsed == nil {
+		return
+	}
+	h.notifyAddressSubscribers(tx.Sender, parsed, acceptTx)
+}
+
+func (h *SocketHub) notifyTxReceipts(wg *sync.WaitGroup, evType indexer.EventType, tx *data.Transaction, acceptTx func(userOptions) bool) {
+	defer wg.Done()
+	for _, receipts := range tx.Receipts {
+		to := receipts["to"]
+		if to == nil {
+			continue
+		}
+		address, ok := to.(string)
+		if !ok {
+			continue
+		}
+		parsed := h.marshalAndPost(evType, address, "", tx)
+		if parsed == nil {
+			return
+		}
+		h.notifyAddressSubscribers(address, parsed, acceptTx)
+	}
+}
+
+func (h *SocketHub) postTxHash(wg *sync.WaitGroup, evType indexer.EventType, tx *data.Transaction) {
+	defer wg.Done()
+	h.marshalAndPost(evType, "", tx.Hash, tx)
 }
 
 func (h *SocketHub) handleBroadcastEvent(event indexer.Event, subscription map[*client]struct{}) {
@@ -349,7 +360,8 @@ func (h *SocketHub) handleGetTransaction(c *client, req WSRequest) {
 
 	tx, err := h.facade.GetTransaction(params.Hash, params.WithResults)
 	if err != nil {
-		c.send(WSResponse{ID: req.ID, Error: err.Error()})
+		log.Warn("ws.handleGetTransaction", "hash", params.Hash, "err", err.Error())
+		c.send(WSResponse{ID: req.ID, Error: errTxNotFound})
 		return
 	}
 
@@ -376,7 +388,8 @@ func (h *SocketHub) handleGetBlock(c *client, req WSRequest) {
 	if params.Nonce != nil {
 		blk, err := h.facade.GetBlockByNonce(*params.Nonce, params.WithTxs)
 		if err != nil {
-			c.send(WSResponse{ID: req.ID, Error: err.Error()})
+			log.Warn("ws.handleGetBlock", "nonce", *params.Nonce, "err", err.Error())
+			c.send(WSResponse{ID: req.ID, Error: errBlockNotFound})
 			return
 		}
 		c.send(WSResponse{ID: req.ID, Data: blk})
@@ -385,7 +398,8 @@ func (h *SocketHub) handleGetBlock(c *client, req WSRequest) {
 
 	blk, err := h.facade.GetBlockByHash(params.Hash, params.WithTxs)
 	if err != nil {
-		c.send(WSResponse{ID: req.ID, Error: err.Error()})
+		log.Warn("ws.handleGetBlock", "hash", params.Hash, "err", err.Error())
+		c.send(WSResponse{ID: req.ID, Error: errBlockNotFound})
 		return
 	}
 	c.send(WSResponse{ID: req.ID, Data: blk})

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -78,7 +78,7 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 
 					for c, opts := range clients {
 						if c.IsAlive() && opts.acceptAccount {
-							c.out <- parsed
+							c.send(parsed)
 						}
 					}
 				}
@@ -108,7 +108,7 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 
 						for c, opts := range clients {
 							if c.IsAlive() && opts.acceptTransaction {
-								c.out <- parsed
+								c.send(parsed)
 							}
 						}
 					}()
@@ -141,7 +141,7 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 
 							for c, opts := range clients {
 								if c.IsAlive() && opts.acceptTransaction {
-									c.out <- parsed
+									c.send(parsed)
 								}
 							}
 						}
@@ -179,7 +179,7 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 				clients := h.transactionSubscription
 				for c := range clients {
 					if c.IsAlive() {
-						c.out <- parsed
+						c.send(parsed)
 					}
 				}
 			default:
@@ -198,7 +198,7 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 				clients := h.blockSubscription
 				for c := range clients {
 					if c.IsAlive() {
-						c.out <- parsed
+						c.send(parsed)
 					}
 				}
 			}
@@ -283,10 +283,14 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 		}
 
 		value := h.addressSubscription[address]
-		value[c] = userOptions{
-			acceptAccount:     acceptAccounts,
-			acceptTransaction: acceptTransactions,
+		existing := value[c]
+		if acceptAccounts {
+			existing.acceptAccount = true
 		}
+		if acceptTransactions {
+			existing.acceptTransaction = true
+		}
+		value[c] = existing
 
 		h.addressSubscription[address] = value
 	}
@@ -347,75 +351,75 @@ func (h *SocketHub) HandleClientRequest(c *client, req WSRequest) {
 	case MethodUnsubscribe:
 		h.handleDynamicUnsubscribe(c, req)
 	default:
-		c.out <- WSResponse{ID: req.ID, Error: "unknown method: " + req.Method}
+		c.send(WSResponse{ID: req.ID, Error: "unknown method: " + req.Method})
 	}
 }
 
 func (h *SocketHub) handleGetTransaction(c *client, req WSRequest) {
 	if h.facade == nil {
-		c.out <- WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"}
+		c.send(WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"})
 		return
 	}
 
 	var params GetTransactionParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
 		return
 	}
 
 	if params.Hash == "" {
-		c.out <- WSResponse{ID: req.ID, Error: "missing required param: hash"}
+		c.send(WSResponse{ID: req.ID, Error: "missing required param: hash"})
 		return
 	}
 
 	tx, err := h.facade.GetTransaction(params.Hash, params.WithResults)
 	if err != nil {
-		c.out <- WSResponse{ID: req.ID, Error: err.Error()}
+		c.send(WSResponse{ID: req.ID, Error: err.Error()})
 		return
 	}
 
-	c.out <- WSResponse{ID: req.ID, Data: tx}
+	c.send(WSResponse{ID: req.ID, Data: tx})
 }
 
 func (h *SocketHub) handleGetBlock(c *client, req WSRequest) {
 	if h.facade == nil {
-		c.out <- WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"}
+		c.send(WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"})
 		return
 	}
 
 	var params GetBlockParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
 		return
 	}
 
 	if params.Nonce == nil && params.Hash == "" {
-		c.out <- WSResponse{ID: req.ID, Error: "must provide nonce or hash"}
+		c.send(WSResponse{ID: req.ID, Error: "must provide nonce or hash"})
 		return
 	}
 
 	if params.Nonce != nil {
 		blk, err := h.facade.GetBlockByNonce(*params.Nonce, params.WithTxs)
 		if err != nil {
-			c.out <- WSResponse{ID: req.ID, Error: err.Error()}
+			c.send(WSResponse{ID: req.ID, Error: err.Error()})
 			return
 		}
-		c.out <- WSResponse{ID: req.ID, Data: blk}
+		c.send(WSResponse{ID: req.ID, Data: blk})
 		return
 	}
 
 	blk, err := h.facade.GetBlockByHash(params.Hash, params.WithTxs)
 	if err != nil {
-		c.out <- WSResponse{ID: req.ID, Error: err.Error()}
+		c.send(WSResponse{ID: req.ID, Error: err.Error()})
 		return
 	}
-	c.out <- WSResponse{ID: req.ID, Data: blk}
+	c.send(WSResponse{ID: req.ID, Data: blk})
 }
 
 func (h *SocketHub) handleDynamicSubscribe(c *client, req WSRequest) {
 	var params SubscribeParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
 		return
 	}
 
@@ -423,20 +427,20 @@ func (h *SocketHub) handleDynamicSubscribe(c *client, req WSRequest) {
 	for _, t := range params.Types {
 		parsed, err := indexer.NewEventTypeStrict(t)
 		if err != nil {
-			c.out <- WSResponse{ID: req.ID, Error: "invalid subscription type: " + t}
+			c.send(WSResponse{ID: req.ID, Error: "invalid subscription type: " + t})
 			return
 		}
 		eventTypes = append(eventTypes, parsed)
 	}
 
 	h.HandleClientInsertion(eventTypes, params.Addresses, c)
-	c.out <- WSResponse{ID: req.ID, Data: "subscribed"}
+	c.send(WSResponse{ID: req.ID, Data: "subscribed"})
 }
 
 func (h *SocketHub) handleDynamicUnsubscribe(c *client, req WSRequest) {
 	var params UnsubscribeParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.out <- WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()}
+		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
 		return
 	}
 
@@ -444,26 +448,32 @@ func (h *SocketHub) handleDynamicUnsubscribe(c *client, req WSRequest) {
 	for _, t := range params.Types {
 		parsed, err := indexer.NewEventTypeStrict(t)
 		if err != nil {
-			c.out <- WSResponse{ID: req.ID, Error: "invalid subscription type: " + t}
+			c.send(WSResponse{ID: req.ID, Error: "invalid subscription type: " + t})
 			return
 		}
 		eventTypes = append(eventTypes, parsed)
 	}
 
 	h.HandleClientRemoval(eventTypes, params.Addresses, c)
-	c.out <- WSResponse{ID: req.ID, Data: "unsubscribed"}
+	c.send(WSResponse{ID: req.ID, Data: "unsubscribed"})
 }
 
 func (h *SocketHub) HandleClientRemoval(eventTypes []indexer.EventType, addresses []string, c *client) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	var removeAccounts bool
+	var removeTransactions bool
 	for _, t := range eventTypes {
 		switch t {
 		case indexer.BLOCKS:
 			delete(h.blockSubscription, c)
 		case indexer.TRANSACTION:
 			delete(h.transactionSubscription, c)
+		case indexer.ACCOUNTS:
+			removeAccounts = true
+		case indexer.USER_TRANSACTION:
+			removeTransactions = true
 		}
 	}
 
@@ -472,7 +482,21 @@ func (h *SocketHub) HandleClientRemoval(eventTypes []indexer.EventType, addresse
 		if !ok {
 			continue
 		}
-		delete(clients, c)
+		existing, ok := clients[c]
+		if !ok {
+			continue
+		}
+		if removeAccounts {
+			existing.acceptAccount = false
+		}
+		if removeTransactions {
+			existing.acceptTransaction = false
+		}
+		if !existing.acceptAccount && !existing.acceptTransaction {
+			delete(clients, c)
+		} else {
+			clients[c] = existing
+		}
 		if len(clients) == 0 {
 			delete(h.addressSubscription, addr)
 		}

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -1,6 +1,5 @@
 package websocket
 
-import "C"
 import (
 	"context"
 	"encoding/json"
@@ -118,12 +117,16 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 		case client := <-h.unregister:
 			h.handleClientDelete(client)
 		case event := <-indexer.EventQueue:
+			h.mu.RLock()
+			blockCount, txCount := len(h.blockSubscription), len(h.transactionSubscription)
+			h.mu.RUnlock()
+			log.Debug("ws.EventReceived", "type", string(event.EvType), "blockSubs", blockCount, "txSubs", txCount)
 			switch event.EvType {
 			case indexer.ACCOUNTS:
 				h.handleAccountsEvent(event)
-			case indexer.USER_TRANSACTION:
+			case indexer.USER_TRANSACTIONS:
 				h.handleUserTransactionEvent(event)
-			case indexer.TRANSACTION:
+			case indexer.TRANSACTIONS:
 				h.handleBroadcastEvent(event, h.transactionSubscription)
 			default:
 				h.handleBroadcastEvent(event, h.blockSubscription)
@@ -179,7 +182,7 @@ func (h *SocketHub) notifyTxReceipts(wg *sync.WaitGroup, evType indexer.EventTyp
 		}
 		parsed := h.marshalAndPost(evType, address, "", tx)
 		if parsed == nil {
-			return
+			continue
 		}
 		h.notifyAddressSubscribers(address, parsed, acceptTx)
 	}
@@ -215,7 +218,7 @@ type Send struct {
 	Type    indexer.EventType `json:"type"`
 	Address string            `json:"address"`
 	Hash    string            `json:"hash"`
-	Data    []byte            `json:"data"`
+	Data    json.RawMessage   `json:"data"`
 }
 
 func marshalMessage(evType indexer.EventType, address string, hash string, message interface{}) (*Send, error) {
@@ -260,9 +263,9 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 		switch types {
 		case indexer.BLOCKS:
 			h.blockSubscription[c] = struct{}{}
-		case indexer.TRANSACTION:
+		case indexer.TRANSACTIONS:
 			h.transactionSubscription[c] = struct{}{}
-		case indexer.USER_TRANSACTION:
+		case indexer.USER_TRANSACTIONS:
 			acceptTransactions = true
 		case indexer.ACCOUNTS:
 			acceptAccounts = true
@@ -460,11 +463,11 @@ func (h *SocketHub) HandleClientRemoval(eventTypes []indexer.EventType, addresse
 		switch t {
 		case indexer.BLOCKS:
 			delete(h.blockSubscription, c)
-		case indexer.TRANSACTION:
+		case indexer.TRANSACTIONS:
 			delete(h.transactionSubscription, c)
 		case indexer.ACCOUNTS:
 			removeAccounts = true
-		case indexer.USER_TRANSACTION:
+		case indexer.USER_TRANSACTIONS:
 			removeTransactions = true
 		}
 	}

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -16,13 +16,22 @@ import (
 
 var log = logger.GetOrCreate("websocket")
 
+const (
+	errInvalidParams    = "invalid params: "
+	errInvalidSubType   = "invalid subscription type: "
+	errFacadeUnavail    = "query not supported: facade unavailable"
+	errUnknownMethod    = "unknown method: "
+	errMissingHash      = "missing required param: hash"
+	errMissingNonceHash = "must provide nonce or hash"
+)
+
 type userOptions struct {
 	acceptAccount     bool
 	acceptTransaction bool
 }
 
 type SocketHub struct {
-	mu                      sync.Mutex
+	mu                      sync.RWMutex
 	postConnectionURL       string
 	postConnectionAPIKey    string
 	facade                  WSFacade
@@ -44,7 +53,59 @@ func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade) *So
 	}
 }
 
-// StartServer start the hub to receive clients and send messages
+func (h *SocketHub) asyncPost(parsed *Send) {
+	go func() {
+		if err := h.postWSConnection(parsed); err != nil {
+			log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
+		}
+	}()
+}
+
+func (h *SocketHub) notifyAddressSubscribers(address string, parsed *Send, filterFn func(userOptions) bool) {
+	h.mu.RLock()
+	original, ok := h.addressSubscription[address]
+	if !ok {
+		h.mu.RUnlock()
+		return
+	}
+	snapshot := make(map[*client]userOptions, len(original))
+	for c, opts := range original {
+		snapshot[c] = opts
+	}
+	h.mu.RUnlock()
+
+	for c, opts := range snapshot {
+		if c.IsAlive() && filterFn(opts) {
+			c.send(parsed)
+		}
+	}
+}
+
+func (h *SocketHub) broadcastToSubscription(parsed *Send, subscription map[*client]struct{}) {
+	h.mu.RLock()
+	snapshot := make([]*client, 0, len(subscription))
+	for c := range subscription {
+		snapshot = append(snapshot, c)
+	}
+	h.mu.RUnlock()
+
+	for _, c := range snapshot {
+		if c.IsAlive() {
+			c.send(parsed)
+		}
+	}
+}
+
+func (h *SocketHub) marshalAndPost(evType indexer.EventType, address, hash string, message interface{}) *Send {
+	parsed, err := marshalMessage(evType, address, hash, message)
+	if err != nil {
+		log.Error("ws.EventReceive", "cannot marshal message", err.Error())
+		return nil
+	}
+	h.asyncPost(parsed)
+	return parsed
+}
+
 func (h *SocketHub) StartServer(ctx context.Context) {
 	for {
 		select {
@@ -57,153 +118,73 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 		case event := <-indexer.EventQueue:
 			switch event.EvType {
 			case indexer.ACCOUNTS:
-				accounts := event.Message.(map[string]*data.AccountInfo)
-				for account, info := range accounts {
-					parsed, err := marshalMessage(event.EvType, account, "", info)
-					if err != nil {
-						log.Error("ws.EventReceive", "cannot marshal message", err.Error())
-						continue
-					}
-
-					go func() {
-						if err := h.postWSConnection(parsed); err != nil {
-							log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
-						}
-					}()
-
-					clients, ok := h.addressSubscription[account]
-					if !ok {
-						continue
-					}
-
-					for c, opts := range clients {
-						if c.IsAlive() && opts.acceptAccount {
-							c.send(parsed)
-						}
-					}
-				}
+				h.handleAccountsEvent(event)
 			case indexer.USER_TRANSACTION:
-				transactions := event.Message.([]*data.Transaction)
-				for _, tx := range transactions {
-					var wg sync.WaitGroup
-					wg.Add(3)
-					go func() {
-						defer wg.Done()
-						parsed, err := marshalMessage(event.EvType, tx.Sender, "", tx)
-						if err != nil {
-							log.Error("ws.EventReceive", "cannot marshal message", err.Error())
-							return
-						}
-
-						go func() {
-							if err := h.postWSConnection(parsed); err != nil {
-								log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
-							}
-						}()
-
-						clients, ok := h.addressSubscription[tx.Sender]
-						if !ok {
-							return
-						}
-
-						for c, opts := range clients {
-							if c.IsAlive() && opts.acceptTransaction {
-								c.send(parsed)
-							}
-						}
-					}()
-					go func(tx *data.Transaction) {
-						defer wg.Done()
-						for _, receipts := range tx.Receipts {
-							to := receipts["to"]
-							if to == nil {
-								continue
-							}
-
-							address := to.(string)
-
-							parsed, err := marshalMessage(event.EvType, address, "", tx)
-							if err != nil {
-								log.Error("ws.EventReceive", "cannot marshal message", err.Error())
-								return
-							}
-
-							go func() {
-								if err := h.postWSConnection(parsed); err != nil {
-									log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
-								}
-							}()
-
-							clients, ok := h.addressSubscription[address]
-							if !ok {
-								continue
-							}
-
-							for c, opts := range clients {
-								if c.IsAlive() && opts.acceptTransaction {
-									c.send(parsed)
-								}
-							}
-						}
-					}(tx)
-					go func() {
-						defer wg.Done()
-						parsed, err := marshalMessage(event.EvType, "", tx.Hash, tx)
-						if err != nil {
-							log.Error("ws.EventReceive", "cannot marshal message", err.Error())
-							return
-						}
-
-						go func() {
-							if err := h.postWSConnection(parsed); err != nil {
-								log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
-							}
-						}()
-					}()
-
-					wg.Wait()
-				}
+				h.handleUserTransactionEvent(event)
 			case indexer.TRANSACTION:
-				parsed, err := marshalMessage(event.EvType, "", "", event.Message)
-				if err != nil {
-					log.Error("ws.EventReceive", "cannot marshal message", err.Error())
-					continue
-				}
-
-				go func() {
-					if err := h.postWSConnection(parsed); err != nil {
-						log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
-					}
-				}()
-
-				clients := h.transactionSubscription
-				for c := range clients {
-					if c.IsAlive() {
-						c.send(parsed)
-					}
-				}
+				h.handleBroadcastEvent(event, h.transactionSubscription)
 			default:
-				parsed, err := marshalMessage(event.EvType, "", "", event.Message)
-				if err != nil {
-					log.Error("ws.EventReceive", "cannot marshal message", err.Error())
-					continue
-				}
-
-				go func() {
-					if err := h.postWSConnection(parsed); err != nil {
-						log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
-					}
-				}()
-
-				clients := h.blockSubscription
-				for c := range clients {
-					if c.IsAlive() {
-						c.send(parsed)
-					}
-				}
+				h.handleBroadcastEvent(event, h.blockSubscription)
 			}
 		}
 	}
+}
+
+func (h *SocketHub) handleAccountsEvent(event indexer.Event) {
+	accounts := event.Message.(map[string]*data.AccountInfo)
+	acceptAccount := func(opts userOptions) bool { return opts.acceptAccount }
+	for account, info := range accounts {
+		parsed := h.marshalAndPost(event.EvType, account, "", info)
+		if parsed == nil {
+			continue
+		}
+		h.notifyAddressSubscribers(account, parsed, acceptAccount)
+	}
+}
+
+func (h *SocketHub) handleUserTransactionEvent(event indexer.Event) {
+	transactions := event.Message.([]*data.Transaction)
+	acceptTx := func(opts userOptions) bool { return opts.acceptTransaction }
+	for _, tx := range transactions {
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			parsed := h.marshalAndPost(event.EvType, tx.Sender, "", tx)
+			if parsed == nil {
+				return
+			}
+			h.notifyAddressSubscribers(tx.Sender, parsed, acceptTx)
+		}()
+		go func(tx *data.Transaction) {
+			defer wg.Done()
+			for _, receipts := range tx.Receipts {
+				to := receipts["to"]
+				if to == nil {
+					continue
+				}
+				address := to.(string)
+				parsed := h.marshalAndPost(event.EvType, address, "", tx)
+				if parsed == nil {
+					return
+				}
+				h.notifyAddressSubscribers(address, parsed, acceptTx)
+			}
+		}(tx)
+		go func() {
+			defer wg.Done()
+			h.marshalAndPost(event.EvType, "", tx.Hash, tx)
+		}()
+		wg.Wait()
+	}
+}
+
+func (h *SocketHub) handleBroadcastEvent(event indexer.Event, subscription map[*client]struct{}) {
+	parsed := h.marshalAndPost(event.EvType, "", "", event.Message)
+	if parsed == nil {
+		return
+	}
+	h.broadcastToSubscription(parsed, subscription)
 }
 
 func (h *SocketHub) postWSConnection(message *Send) error {
@@ -296,6 +277,13 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 	}
 }
 
+func closeAndClear(subscription map[*client]struct{}) {
+	for c := range subscription {
+		c.close()
+		delete(subscription, c)
+	}
+}
+
 func (h *SocketHub) deleteAll() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -307,21 +295,8 @@ func (h *SocketHub) deleteAll() {
 		}
 	}
 
-	for client := range h.blockSubscription {
-		if client.alive {
-			client.close()
-		}
-
-		delete(h.blockSubscription, client)
-	}
-
-	for client := range h.transactionSubscription {
-		if client.alive {
-			client.close()
-		}
-
-		delete(h.transactionSubscription, client)
-	}
+	closeAndClear(h.blockSubscription)
+	closeAndClear(h.transactionSubscription)
 }
 
 func (h *SocketHub) handleClientDelete(c *client) {
@@ -351,24 +326,24 @@ func (h *SocketHub) HandleClientRequest(c *client, req WSRequest) {
 	case MethodUnsubscribe:
 		h.handleDynamicUnsubscribe(c, req)
 	default:
-		c.send(WSResponse{ID: req.ID, Error: "unknown method: " + req.Method})
+		c.send(WSResponse{ID: req.ID, Error: errUnknownMethod + req.Method})
 	}
 }
 
 func (h *SocketHub) handleGetTransaction(c *client, req WSRequest) {
 	if h.facade == nil {
-		c.send(WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"})
+		c.send(WSResponse{ID: req.ID, Error: errFacadeUnavail})
 		return
 	}
 
 	var params GetTransactionParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
+		c.send(WSResponse{ID: req.ID, Error: errInvalidParams + err.Error()})
 		return
 	}
 
 	if params.Hash == "" {
-		c.send(WSResponse{ID: req.ID, Error: "missing required param: hash"})
+		c.send(WSResponse{ID: req.ID, Error: errMissingHash})
 		return
 	}
 
@@ -383,18 +358,18 @@ func (h *SocketHub) handleGetTransaction(c *client, req WSRequest) {
 
 func (h *SocketHub) handleGetBlock(c *client, req WSRequest) {
 	if h.facade == nil {
-		c.send(WSResponse{ID: req.ID, Error: "query not supported: facade unavailable"})
+		c.send(WSResponse{ID: req.ID, Error: errFacadeUnavail})
 		return
 	}
 
 	var params GetBlockParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
+		c.send(WSResponse{ID: req.ID, Error: errInvalidParams + err.Error()})
 		return
 	}
 
 	if params.Nonce == nil && params.Hash == "" {
-		c.send(WSResponse{ID: req.ID, Error: "must provide nonce or hash"})
+		c.send(WSResponse{ID: req.ID, Error: errMissingNonceHash})
 		return
 	}
 
@@ -416,21 +391,29 @@ func (h *SocketHub) handleGetBlock(c *client, req WSRequest) {
 	c.send(WSResponse{ID: req.ID, Data: blk})
 }
 
+func parseStrictEventTypes(c *client, reqID string, types []string) ([]indexer.EventType, bool) {
+	var eventTypes []indexer.EventType
+	for _, t := range types {
+		parsed, err := indexer.NewEventTypeStrict(t)
+		if err != nil {
+			c.send(WSResponse{ID: reqID, Error: errInvalidSubType + t})
+			return nil, false
+		}
+		eventTypes = append(eventTypes, parsed)
+	}
+	return eventTypes, true
+}
+
 func (h *SocketHub) handleDynamicSubscribe(c *client, req WSRequest) {
 	var params SubscribeParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
+		c.send(WSResponse{ID: req.ID, Error: errInvalidParams + err.Error()})
 		return
 	}
 
-	var eventTypes []indexer.EventType
-	for _, t := range params.Types {
-		parsed, err := indexer.NewEventTypeStrict(t)
-		if err != nil {
-			c.send(WSResponse{ID: req.ID, Error: "invalid subscription type: " + t})
-			return
-		}
-		eventTypes = append(eventTypes, parsed)
+	eventTypes, ok := parseStrictEventTypes(c, req.ID, params.Types)
+	if !ok {
+		return
 	}
 
 	h.HandleClientInsertion(eventTypes, params.Addresses, c)
@@ -440,18 +423,13 @@ func (h *SocketHub) handleDynamicSubscribe(c *client, req WSRequest) {
 func (h *SocketHub) handleDynamicUnsubscribe(c *client, req WSRequest) {
 	var params UnsubscribeParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
-		c.send(WSResponse{ID: req.ID, Error: "invalid params: " + err.Error()})
+		c.send(WSResponse{ID: req.ID, Error: errInvalidParams + err.Error()})
 		return
 	}
 
-	var eventTypes []indexer.EventType
-	for _, t := range params.Types {
-		parsed, err := indexer.NewEventTypeStrict(t)
-		if err != nil {
-			c.send(WSResponse{ID: req.ID, Error: "invalid subscription type: " + t})
-			return
-		}
-		eventTypes = append(eventTypes, parsed)
+	eventTypes, ok := parseStrictEventTypes(c, req.ID, params.Types)
+	if !ok {
+		return
 	}
 
 	h.HandleClientRemoval(eventTypes, params.Addresses, c)
@@ -478,27 +456,31 @@ func (h *SocketHub) HandleClientRemoval(eventTypes []indexer.EventType, addresse
 	}
 
 	for _, addr := range addresses {
-		clients, ok := h.addressSubscription[addr]
-		if !ok {
-			continue
-		}
-		existing, ok := clients[c]
-		if !ok {
-			continue
-		}
-		if removeAccounts {
-			existing.acceptAccount = false
-		}
-		if removeTransactions {
-			existing.acceptTransaction = false
-		}
-		if !existing.acceptAccount && !existing.acceptTransaction {
-			delete(clients, c)
-		} else {
-			clients[c] = existing
-		}
-		if len(clients) == 0 {
-			delete(h.addressSubscription, addr)
-		}
+		h.removeClientFromAddress(addr, c, removeAccounts, removeTransactions)
+	}
+}
+
+func (h *SocketHub) removeClientFromAddress(addr string, c *client, removeAccounts, removeTransactions bool) {
+	clients, ok := h.addressSubscription[addr]
+	if !ok {
+		return
+	}
+	existing, ok := clients[c]
+	if !ok {
+		return
+	}
+	if removeAccounts {
+		existing.acceptAccount = false
+	}
+	if removeTransactions {
+		existing.acceptTransaction = false
+	}
+	if !existing.acceptAccount && !existing.acceptTransaction {
+		delete(clients, c)
+	} else {
+		clients[c] = existing
+	}
+	if len(clients) == 0 {
+		delete(h.addressSubscription, addr)
 	}
 }

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -1,0 +1,286 @@
+package websocket
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/klever-io/klever-go/data/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFacade struct {
+	getTransactionFn  func(hash string, withResults bool) (*api.Transaction, error)
+	getBlockByHashFn  func(hash string, withTxs bool) (*api.Block, error)
+	getBlockByNonceFn func(nonce uint64, withTxs bool) (*api.Block, error)
+}
+
+func (m *mockFacade) GetTransaction(hash string, withResults bool) (*api.Transaction, error) {
+	if m.getTransactionFn != nil {
+		return m.getTransactionFn(hash, withResults)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockFacade) GetBlockByHash(hash string, withTxs bool) (*api.Block, error) {
+	if m.getBlockByHashFn != nil {
+		return m.getBlockByHashFn(hash, withTxs)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockFacade) GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, error) {
+	if m.getBlockByNonceFn != nil {
+		return m.getBlockByNonceFn(nonce, withTxs)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func newTestHub(facade WSFacade) *SocketHub {
+	return NewHub("", "", facade)
+}
+
+func drainResponse(c *client) WSResponse {
+	msg := <-c.out
+	resp, ok := msg.(WSResponse)
+	if !ok {
+		return WSResponse{}
+	}
+	return resp
+}
+
+func newTestClient(hub *SocketHub) *client {
+	return &client{
+		hub:   hub,
+		out:   make(chan interface{}, 10),
+		alive: true,
+	}
+}
+
+func TestHandleGetTransaction_Success(t *testing.T) {
+	expectedTx := &api.Transaction{Hash: "abc123"}
+	facade := &mockFacade{
+		getTransactionFn: func(hash string, withResults bool) (*api.Transaction, error) {
+			assert.Equal(t, "abc123", hash)
+			assert.True(t, withResults)
+			return expectedTx, nil
+		},
+	}
+
+	hub := newTestHub(facade)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetTransactionParams{Hash: "abc123", WithResults: true})
+	req := WSRequest{ID: "req-1", Method: MethodGetTransaction, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-1", resp.ID)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, expectedTx, resp.Data)
+}
+
+func TestHandleGetTransaction_NilFacade(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetTransactionParams{Hash: "abc123"})
+	req := WSRequest{ID: "req-2", Method: MethodGetTransaction, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-2", resp.ID)
+	assert.Contains(t, resp.Error, "facade unavailable")
+}
+
+func TestHandleGetTransaction_EmptyHash(t *testing.T) {
+	hub := newTestHub(&mockFacade{})
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetTransactionParams{})
+	req := WSRequest{ID: "req-3", Method: MethodGetTransaction, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-3", resp.ID)
+	assert.Contains(t, resp.Error, "missing required param: hash")
+}
+
+func TestHandleGetTransaction_FacadeError(t *testing.T) {
+	facade := &mockFacade{
+		getTransactionFn: func(hash string, withResults bool) (*api.Transaction, error) {
+			return nil, errors.New("not found")
+		},
+	}
+
+	hub := newTestHub(facade)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetTransactionParams{Hash: "abc123"})
+	req := WSRequest{ID: "req-4", Method: MethodGetTransaction, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-4", resp.ID)
+	assert.Equal(t, "not found", resp.Error)
+}
+
+func TestHandleGetBlock_ByNonce(t *testing.T) {
+	expectedBlock := &api.Block{Hash: "block123"}
+	nonce := uint64(42)
+	facade := &mockFacade{
+		getBlockByNonceFn: func(n uint64, withTxs bool) (*api.Block, error) {
+			assert.Equal(t, uint64(42), n)
+			assert.True(t, withTxs)
+			return expectedBlock, nil
+		},
+	}
+
+	hub := newTestHub(facade)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetBlockParams{Nonce: &nonce, WithTxs: true})
+	req := WSRequest{ID: "req-5", Method: MethodGetBlock, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-5", resp.ID)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, expectedBlock, resp.Data)
+}
+
+func TestHandleGetBlock_ByHash(t *testing.T) {
+	expectedBlock := &api.Block{Hash: "block456"}
+	facade := &mockFacade{
+		getBlockByHashFn: func(hash string, withTxs bool) (*api.Block, error) {
+			assert.Equal(t, "block456", hash)
+			return expectedBlock, nil
+		},
+	}
+
+	hub := newTestHub(facade)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetBlockParams{Hash: "block456"})
+	req := WSRequest{ID: "req-6", Method: MethodGetBlock, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-6", resp.ID)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, expectedBlock, resp.Data)
+}
+
+func TestHandleGetBlock_NoParams(t *testing.T) {
+	hub := newTestHub(&mockFacade{})
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetBlockParams{})
+	req := WSRequest{ID: "req-7", Method: MethodGetBlock, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-7", resp.ID)
+	assert.Contains(t, resp.Error, "must provide nonce or hash")
+}
+
+func TestHandleGetBlock_NilFacade(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	nonce := uint64(1)
+	params, _ := json.Marshal(GetBlockParams{Nonce: &nonce})
+	req := WSRequest{ID: "req-8", Method: MethodGetBlock, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-8", resp.ID)
+	assert.Contains(t, resp.Error, "facade unavailable")
+}
+
+func TestHandleDynamicSubscribe_Success(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(SubscribeParams{
+		Types:     []string{"blocks", "transactions"},
+		Addresses: []string{"klv1abc"},
+	})
+	req := WSRequest{ID: "req-9", Method: MethodSubscribe, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-9", resp.ID)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, "subscribed", resp.Data)
+
+	hub.mu.Lock()
+	_, ok := hub.blockSubscription[c]
+	hub.mu.Unlock()
+	require.True(t, ok)
+}
+
+func TestHandleDynamicSubscribe_InvalidType(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(SubscribeParams{
+		Types: []string{"invalid_type"},
+	})
+	req := WSRequest{ID: "req-10", Method: MethodSubscribe, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-10", resp.ID)
+	assert.Contains(t, resp.Error, "invalid subscription type")
+}
+
+func TestHandleDynamicUnsubscribe_Success(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	hub.mu.Lock()
+	hub.blockSubscription[c] = struct{}{}
+	hub.mu.Unlock()
+
+	params, _ := json.Marshal(UnsubscribeParams{
+		Types: []string{"blocks"},
+	})
+	req := WSRequest{ID: "req-11", Method: MethodUnsubscribe, Params: params}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-11", resp.ID)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, "unsubscribed", resp.Data)
+
+	hub.mu.Lock()
+	_, ok := hub.blockSubscription[c]
+	hub.mu.Unlock()
+	require.False(t, ok)
+}
+
+func TestHandleClientRequest_UnknownMethod(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	req := WSRequest{ID: "req-12", Method: "nonexistent", Params: json.RawMessage(`{}`)}
+
+	hub.HandleClientRequest(c, req)
+	resp := drainResponse(c)
+
+	assert.Equal(t, "req-12", resp.ID)
+	assert.Contains(t, resp.Error, "unknown method")
+}

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -60,12 +60,17 @@ func newTestClient(hub *SocketHub) *client {
 
 func sendRequest(hub *SocketHub, c *client, req WSRequest) WSResponse {
 	hub.HandleClientRequest(c, req)
-	msg := <-c.out
-	resp, ok := msg.(WSResponse)
-	if !ok {
-		return WSResponse{}
+
+	select {
+	case msg := <-c.out:
+		resp, ok := msg.(WSResponse)
+		if !ok {
+			return WSResponse{}
+		}
+		return resp
+	case <-time.After(2 * time.Second):
+		panic("timeout waiting for response in sendRequest")
 	}
-	return resp
 }
 
 func killClient(c *client) {
@@ -302,7 +307,7 @@ func TestHandleDynamicSubscribe_Success(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	params, _ := json.Marshal(SubscribeParams{Types: []string{"blocks", "transaction"}, Addresses: []string{"klv1abc"}})
+	params, _ := json.Marshal(SubscribeParams{Types: []string{"blocks", "transactions"}, Addresses: []string{"klv1abc"}})
 	resp := sendRequest(hub, c, WSRequest{ID: "req-9", Method: MethodSubscribe, Params: params})
 
 	assert.Equal(t, "req-9", resp.ID)
@@ -386,7 +391,7 @@ func TestDynamicSubscribe_MergesFlags(t *testing.T) {
 	params1, _ := json.Marshal(SubscribeParams{Types: []string{"accounts"}, Addresses: []string{"klv1abc"}})
 	sendRequest(hub, c, WSRequest{ID: "s1", Method: MethodSubscribe, Params: params1})
 
-	params2, _ := json.Marshal(SubscribeParams{Types: []string{"user_transaction"}, Addresses: []string{"klv1abc"}})
+	params2, _ := json.Marshal(SubscribeParams{Types: []string{"user_transactions"}, Addresses: []string{"klv1abc"}})
 	sendRequest(hub, c, WSRequest{ID: "s2", Method: MethodSubscribe, Params: params2})
 
 	hub.mu.Lock()
@@ -474,7 +479,7 @@ func TestMarshalMessage_Blocks(t *testing.T) {
 	msg, err := marshalMessage("blocks", "", "hash1", blockData)
 	require.NoError(t, err)
 	assert.Equal(t, indexer.BLOCKS, msg.Type)
-	assert.Equal(t, blockData, msg.Data)
+	assert.Equal(t, json.RawMessage(blockData), msg.Data)
 	assert.Equal(t, "hash1", msg.Hash)
 }
 
@@ -486,9 +491,9 @@ func TestMarshalMessage_BlocksInvalidType(t *testing.T) {
 
 func TestMarshalMessage_NonBlocks(t *testing.T) {
 	payload := map[string]string{"key": "value"}
-	msg, err := marshalMessage("transaction", "addr1", "hash1", payload)
+	msg, err := marshalMessage("transactions", "addr1", "hash1", payload)
 	require.NoError(t, err)
-	assert.Equal(t, indexer.EventType("transaction"), msg.Type)
+	assert.Equal(t, indexer.EventType("transactions"), msg.Type)
 	assert.Equal(t, "addr1", msg.Address)
 	assert.Equal(t, "hash1", msg.Hash)
 	assert.NotEmpty(t, msg.Data)
@@ -498,7 +503,7 @@ func TestHandleClientInsertion_BlocksAndTransactions(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	hub.HandleClientInsertion([]indexer.EventType{indexer.BLOCKS, indexer.TRANSACTION}, nil, c)
+	hub.HandleClientInsertion([]indexer.EventType{indexer.BLOCKS, indexer.TRANSACTIONS}, nil, c)
 
 	hub.mu.Lock()
 	_, hasBlock := hub.blockSubscription[c]
@@ -513,7 +518,7 @@ func TestHandleClientInsertion_AddressTypes(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS, indexer.USER_TRANSACTION}, []string{"klv1test"}, c)
+	hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS, indexer.USER_TRANSACTIONS}, []string{"klv1test"}, c)
 
 	hub.mu.Lock()
 	opts := hub.addressSubscription["klv1test"][c]
@@ -532,7 +537,7 @@ func TestHandleClientRemoval_BlocksAndTransactions(t *testing.T) {
 	hub.transactionSubscription[c] = struct{}{}
 	hub.mu.Unlock()
 
-	hub.HandleClientRemoval([]indexer.EventType{indexer.BLOCKS, indexer.TRANSACTION}, nil, c)
+	hub.HandleClientRemoval([]indexer.EventType{indexer.BLOCKS, indexer.TRANSACTIONS}, nil, c)
 
 	hub.mu.Lock()
 	_, hasBlock := hub.blockSubscription[c]
@@ -727,10 +732,10 @@ func TestStartServer_TransactionEvent(t *testing.T) {
 	env.hub.transactionSubscription[c] = struct{}{}
 	env.hub.mu.Unlock()
 
-	env.queue <- indexer.Event{EvType: indexer.TRANSACTION, Message: map[string]string{"hash": "abc"}}
+	env.queue <- indexer.Event{EvType: indexer.TRANSACTIONS, Message: map[string]string{"hash": "abc"}}
 
 	s := awaitSend(t, c)
-	assert.Equal(t, indexer.TRANSACTION, s.Type)
+	assert.Equal(t, indexer.TRANSACTIONS, s.Type)
 
 	env.teardown(c)
 }
@@ -776,7 +781,7 @@ func TestStartServer_UserTransactionEvent(t *testing.T) {
 	env.hub.mu.Unlock()
 
 	env.queue <- indexer.Event{
-		EvType: indexer.USER_TRANSACTION,
+		EvType: indexer.USER_TRANSACTIONS,
 		Message: []*data.Transaction{{
 			Hash: "tx1", Sender: "klv1sender",
 			Receipts: []map[string]interface{}{{"to": "klv1receiver"}},
@@ -784,7 +789,7 @@ func TestStartServer_UserTransactionEvent(t *testing.T) {
 	}
 
 	s := awaitSend(t, c)
-	assert.Equal(t, indexer.USER_TRANSACTION, s.Type)
+	assert.Equal(t, indexer.USER_TRANSACTIONS, s.Type)
 
 	env.teardown(c)
 }
@@ -798,7 +803,7 @@ func TestStartServer_UserTransaction_NoReceiptTo(t *testing.T) {
 	env.hub.mu.Unlock()
 
 	env.queue <- indexer.Event{
-		EvType: indexer.USER_TRANSACTION,
+		EvType: indexer.USER_TRANSACTIONS,
 		Message: []*data.Transaction{{
 			Hash: "tx-no-to", Sender: "klv1sender",
 			Receipts: []map[string]interface{}{{"amount": "100"}},
@@ -806,7 +811,7 @@ func TestStartServer_UserTransaction_NoReceiptTo(t *testing.T) {
 	}
 
 	s := awaitSend(t, c)
-	assert.Equal(t, indexer.USER_TRANSACTION, s.Type)
+	assert.Equal(t, indexer.USER_TRANSACTIONS, s.Type)
 
 	env.teardown(c)
 }

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -94,10 +93,16 @@ func startServerEnv(t *testing.T, facade WSFacade) *serverEnv {
 		hub.StartServer(ctx)
 		close(done)
 	}()
-	return &serverEnv{
+	env := &serverEnv{
 		hub: hub, queue: testQueue, cancel: cancel, done: done,
 		restoreFn: func() { indexer.EventQueue = origQueue },
 	}
+	t.Cleanup(func() {
+		cancel()
+		<-done
+		indexer.EventQueue = origQueue
+	})
+	return env
 }
 
 func (e *serverEnv) teardown(clients ...*client) {
@@ -167,7 +172,7 @@ func TestHandleGetTransaction_EmptyHash(t *testing.T) {
 func TestHandleGetTransaction_FacadeError(t *testing.T) {
 	facade := &mockFacade{
 		getTransactionFn: func(hash string, withResults bool) (*api.Transaction, error) {
-			return nil, errors.New("not found")
+			return nil, errors.New("db connection refused")
 		},
 	}
 	hub := newTestHub(facade)
@@ -177,7 +182,7 @@ func TestHandleGetTransaction_FacadeError(t *testing.T) {
 	resp := sendRequest(hub, c, WSRequest{ID: "req-4", Method: MethodGetTransaction, Params: params})
 
 	assert.Equal(t, "req-4", resp.ID)
-	assert.Equal(t, "not found", resp.Error)
+	assert.Equal(t, errTxNotFound, resp.Error)
 }
 
 func TestHandleGetTransaction_InvalidJSON(t *testing.T) {
@@ -263,7 +268,7 @@ func TestHandleGetBlock_ByNonce_FacadeError(t *testing.T) {
 	nonce := uint64(99)
 	facade := &mockFacade{
 		getBlockByNonceFn: func(n uint64, withTxs bool) (*api.Block, error) {
-			return nil, errors.New("block not found")
+			return nil, errors.New("storage error")
 		},
 	}
 	hub := newTestHub(facade)
@@ -273,13 +278,13 @@ func TestHandleGetBlock_ByNonce_FacadeError(t *testing.T) {
 	resp := sendRequest(hub, c, WSRequest{ID: "be", Method: MethodGetBlock, Params: params})
 
 	assert.Equal(t, "be", resp.ID)
-	assert.Equal(t, "block not found", resp.Error)
+	assert.Equal(t, errBlockNotFound, resp.Error)
 }
 
 func TestHandleGetBlock_ByHash_FacadeError(t *testing.T) {
 	facade := &mockFacade{
 		getBlockByHashFn: func(hash string, withTxs bool) (*api.Block, error) {
-			return nil, errors.New("hash not found")
+			return nil, errors.New("storage error")
 		},
 	}
 	hub := newTestHub(facade)
@@ -289,7 +294,7 @@ func TestHandleGetBlock_ByHash_FacadeError(t *testing.T) {
 	resp := sendRequest(hub, c, WSRequest{ID: "bhe", Method: MethodGetBlock, Params: params})
 
 	assert.Equal(t, "bhe", resp.ID)
-	assert.Equal(t, "hash not found", resp.Error)
+	assert.Equal(t, errBlockNotFound, resp.Error)
 }
 
 func TestHandleDynamicSubscribe_Success(t *testing.T) {
@@ -659,14 +664,11 @@ func TestPostWSConnection_EmptyConfig(t *testing.T) {
 }
 
 func TestPostWSConnection_WithServer(t *testing.T) {
-	var received []byte
-	var mu sync.Mutex
+	receivedCh := make(chan []byte, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		defer mu.Unlock()
 		buf := make([]byte, 4096)
 		n, _ := r.Body.Read(buf)
-		received = buf[:n]
+		receivedCh <- buf[:n]
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -675,10 +677,12 @@ func TestPostWSConnection_WithServer(t *testing.T) {
 	err := hub.postWSConnection(&Send{Type: indexer.BLOCKS, Data: []byte(`{}`)})
 	assert.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-	mu.Lock()
-	assert.NotEmpty(t, received)
-	mu.Unlock()
+	select {
+	case received := <-receivedCh:
+		assert.NotEmpty(t, received)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for POST request")
+	}
 }
 
 func TestStartServer_ContextCancel(t *testing.T) {

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -284,3 +284,74 @@ func TestHandleClientRequest_UnknownMethod(t *testing.T) {
 	assert.Equal(t, "req-12", resp.ID)
 	assert.Contains(t, resp.Error, "unknown method")
 }
+
+func TestDynamicSubscribe_MergesFlags(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	params1, _ := json.Marshal(SubscribeParams{
+		Types:     []string{"accounts"},
+		Addresses: []string{"klv1abc"},
+	})
+	hub.HandleClientRequest(c, WSRequest{ID: "s1", Method: MethodSubscribe, Params: params1})
+	drainResponse(c)
+
+	params2, _ := json.Marshal(SubscribeParams{
+		Types:     []string{"user_transaction"},
+		Addresses: []string{"klv1abc"},
+	})
+	hub.HandleClientRequest(c, WSRequest{ID: "s2", Method: MethodSubscribe, Params: params2})
+	drainResponse(c)
+
+	hub.mu.Lock()
+	opts := hub.addressSubscription["klv1abc"][c]
+	hub.mu.Unlock()
+
+	assert.True(t, opts.acceptAccount)
+	assert.True(t, opts.acceptTransaction)
+}
+
+func TestDynamicUnsubscribe_PartialFlags(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	hub.mu.Lock()
+	hub.addressSubscription["klv1abc"] = map[*client]userOptions{
+		c: {acceptAccount: true, acceptTransaction: true},
+	}
+	hub.mu.Unlock()
+
+	params, _ := json.Marshal(UnsubscribeParams{
+		Types:     []string{"accounts"},
+		Addresses: []string{"klv1abc"},
+	})
+	hub.HandleClientRequest(c, WSRequest{ID: "u1", Method: MethodUnsubscribe, Params: params})
+	drainResponse(c)
+
+	hub.mu.Lock()
+	opts, ok := hub.addressSubscription["klv1abc"][c]
+	hub.mu.Unlock()
+
+	require.True(t, ok)
+	assert.False(t, opts.acceptAccount)
+	assert.True(t, opts.acceptTransaction)
+}
+
+func TestSend_DoesNotPanicOnClosedClient(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	c.aliveLock.Lock()
+	c.alive = false
+	c.aliveLock.Unlock()
+
+	assert.NotPanics(t, func() {
+		c.send(WSResponse{ID: "x", Error: "test"})
+	})
+
+	select {
+	case <-c.out:
+		t.Fatal("expected no message on closed client")
+	default:
+	}
+}

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -301,7 +301,7 @@ func TestHandleDynamicSubscribe_Success(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	params, _ := json.Marshal(SubscribeParams{Types: []string{"blocks", "transactions"}, Addresses: []string{"klv1abc"}})
+	params, _ := json.Marshal(SubscribeParams{Types: []string{"blocks", "transaction"}, Addresses: []string{"klv1abc"}})
 	resp := sendRequest(hub, c, WSRequest{ID: "req-9", Method: MethodSubscribe, Params: params})
 
 	assert.Equal(t, "req-9", resp.ID)

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -1,11 +1,20 @@
 package websocket
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	ws "github.com/gorilla/websocket"
 	"github.com/klever-io/klever-go/data/api"
+	indexer "github.com/klever-io/klever-go/indexer"
+	"github.com/klever-io/klever-go/indexer/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +50,16 @@ func newTestHub(facade WSFacade) *SocketHub {
 	return NewHub("", "", facade)
 }
 
-func drainResponse(c *client) WSResponse {
+func newTestClient(hub *SocketHub) *client {
+	return &client{
+		hub:   hub,
+		out:   make(chan interface{}, 10),
+		alive: true,
+	}
+}
+
+func sendRequest(hub *SocketHub, c *client, req WSRequest) WSResponse {
+	hub.HandleClientRequest(c, req)
 	msg := <-c.out
 	resp, ok := msg.(WSResponse)
 	if !ok {
@@ -50,11 +68,57 @@ func drainResponse(c *client) WSResponse {
 	return resp
 }
 
-func newTestClient(hub *SocketHub) *client {
-	return &client{
-		hub:   hub,
-		out:   make(chan interface{}, 10),
-		alive: true,
+func killClient(c *client) {
+	c.aliveLock.Lock()
+	c.alive = false
+	c.aliveLock.Unlock()
+}
+
+type serverEnv struct {
+	hub       *SocketHub
+	queue     chan indexer.Event
+	cancel    context.CancelFunc
+	done      <-chan struct{}
+	restoreFn func()
+}
+
+func startServerEnv(t *testing.T, facade WSFacade) *serverEnv {
+	t.Helper()
+	hub := newTestHub(facade)
+	origQueue := indexer.EventQueue
+	testQueue := make(chan indexer.Event, 10)
+	indexer.EventQueue = testQueue
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		hub.StartServer(ctx)
+		close(done)
+	}()
+	return &serverEnv{
+		hub: hub, queue: testQueue, cancel: cancel, done: done,
+		restoreFn: func() { indexer.EventQueue = origQueue },
+	}
+}
+
+func (e *serverEnv) teardown(clients ...*client) {
+	for _, c := range clients {
+		killClient(c)
+	}
+	e.cancel()
+	<-e.done
+	e.restoreFn()
+}
+
+func awaitSend(t *testing.T, c *client) *Send {
+	t.Helper()
+	select {
+	case msg := <-c.out:
+		s, ok := msg.(*Send)
+		require.True(t, ok)
+		return s
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+		return nil
 	}
 }
 
@@ -67,15 +131,11 @@ func TestHandleGetTransaction_Success(t *testing.T) {
 			return expectedTx, nil
 		},
 	}
-
 	hub := newTestHub(facade)
 	c := newTestClient(hub)
 
 	params, _ := json.Marshal(GetTransactionParams{Hash: "abc123", WithResults: true})
-	req := WSRequest{ID: "req-1", Method: MethodGetTransaction, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-1", Method: MethodGetTransaction, Params: params})
 
 	assert.Equal(t, "req-1", resp.ID)
 	assert.Empty(t, resp.Error)
@@ -87,10 +147,7 @@ func TestHandleGetTransaction_NilFacade(t *testing.T) {
 	c := newTestClient(hub)
 
 	params, _ := json.Marshal(GetTransactionParams{Hash: "abc123"})
-	req := WSRequest{ID: "req-2", Method: MethodGetTransaction, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-2", Method: MethodGetTransaction, Params: params})
 
 	assert.Equal(t, "req-2", resp.ID)
 	assert.Contains(t, resp.Error, "facade unavailable")
@@ -101,10 +158,7 @@ func TestHandleGetTransaction_EmptyHash(t *testing.T) {
 	c := newTestClient(hub)
 
 	params, _ := json.Marshal(GetTransactionParams{})
-	req := WSRequest{ID: "req-3", Method: MethodGetTransaction, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-3", Method: MethodGetTransaction, Params: params})
 
 	assert.Equal(t, "req-3", resp.ID)
 	assert.Contains(t, resp.Error, "missing required param: hash")
@@ -116,18 +170,22 @@ func TestHandleGetTransaction_FacadeError(t *testing.T) {
 			return nil, errors.New("not found")
 		},
 	}
-
 	hub := newTestHub(facade)
 	c := newTestClient(hub)
 
 	params, _ := json.Marshal(GetTransactionParams{Hash: "abc123"})
-	req := WSRequest{ID: "req-4", Method: MethodGetTransaction, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-4", Method: MethodGetTransaction, Params: params})
 
 	assert.Equal(t, "req-4", resp.ID)
 	assert.Equal(t, "not found", resp.Error)
+}
+
+func TestHandleGetTransaction_InvalidJSON(t *testing.T) {
+	hub := newTestHub(&mockFacade{})
+	c := newTestClient(hub)
+	resp := sendRequest(hub, c, WSRequest{ID: "bad", Method: MethodGetTransaction, Params: json.RawMessage(`invalid`)})
+	assert.Equal(t, "bad", resp.ID)
+	assert.Contains(t, resp.Error, "invalid params")
 }
 
 func TestHandleGetBlock_ByNonce(t *testing.T) {
@@ -140,15 +198,11 @@ func TestHandleGetBlock_ByNonce(t *testing.T) {
 			return expectedBlock, nil
 		},
 	}
-
 	hub := newTestHub(facade)
 	c := newTestClient(hub)
 
 	params, _ := json.Marshal(GetBlockParams{Nonce: &nonce, WithTxs: true})
-	req := WSRequest{ID: "req-5", Method: MethodGetBlock, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-5", Method: MethodGetBlock, Params: params})
 
 	assert.Equal(t, "req-5", resp.ID)
 	assert.Empty(t, resp.Error)
@@ -163,15 +217,11 @@ func TestHandleGetBlock_ByHash(t *testing.T) {
 			return expectedBlock, nil
 		},
 	}
-
 	hub := newTestHub(facade)
 	c := newTestClient(hub)
 
 	params, _ := json.Marshal(GetBlockParams{Hash: "block456"})
-	req := WSRequest{ID: "req-6", Method: MethodGetBlock, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-6", Method: MethodGetBlock, Params: params})
 
 	assert.Equal(t, "req-6", resp.ID)
 	assert.Empty(t, resp.Error)
@@ -183,10 +233,7 @@ func TestHandleGetBlock_NoParams(t *testing.T) {
 	c := newTestClient(hub)
 
 	params, _ := json.Marshal(GetBlockParams{})
-	req := WSRequest{ID: "req-7", Method: MethodGetBlock, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-7", Method: MethodGetBlock, Params: params})
 
 	assert.Equal(t, "req-7", resp.ID)
 	assert.Contains(t, resp.Error, "must provide nonce or hash")
@@ -198,27 +245,59 @@ func TestHandleGetBlock_NilFacade(t *testing.T) {
 
 	nonce := uint64(1)
 	params, _ := json.Marshal(GetBlockParams{Nonce: &nonce})
-	req := WSRequest{ID: "req-8", Method: MethodGetBlock, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-8", Method: MethodGetBlock, Params: params})
 
 	assert.Equal(t, "req-8", resp.ID)
 	assert.Contains(t, resp.Error, "facade unavailable")
+}
+
+func TestHandleGetBlock_InvalidJSON(t *testing.T) {
+	hub := newTestHub(&mockFacade{})
+	c := newTestClient(hub)
+	resp := sendRequest(hub, c, WSRequest{ID: "bad2", Method: MethodGetBlock, Params: json.RawMessage(`not json`)})
+	assert.Equal(t, "bad2", resp.ID)
+	assert.Contains(t, resp.Error, "invalid params")
+}
+
+func TestHandleGetBlock_ByNonce_FacadeError(t *testing.T) {
+	nonce := uint64(99)
+	facade := &mockFacade{
+		getBlockByNonceFn: func(n uint64, withTxs bool) (*api.Block, error) {
+			return nil, errors.New("block not found")
+		},
+	}
+	hub := newTestHub(facade)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetBlockParams{Nonce: &nonce})
+	resp := sendRequest(hub, c, WSRequest{ID: "be", Method: MethodGetBlock, Params: params})
+
+	assert.Equal(t, "be", resp.ID)
+	assert.Equal(t, "block not found", resp.Error)
+}
+
+func TestHandleGetBlock_ByHash_FacadeError(t *testing.T) {
+	facade := &mockFacade{
+		getBlockByHashFn: func(hash string, withTxs bool) (*api.Block, error) {
+			return nil, errors.New("hash not found")
+		},
+	}
+	hub := newTestHub(facade)
+	c := newTestClient(hub)
+
+	params, _ := json.Marshal(GetBlockParams{Hash: "abc"})
+	resp := sendRequest(hub, c, WSRequest{ID: "bhe", Method: MethodGetBlock, Params: params})
+
+	assert.Equal(t, "bhe", resp.ID)
+	assert.Equal(t, "hash not found", resp.Error)
 }
 
 func TestHandleDynamicSubscribe_Success(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	params, _ := json.Marshal(SubscribeParams{
-		Types:     []string{"blocks", "transactions"},
-		Addresses: []string{"klv1abc"},
-	})
-	req := WSRequest{ID: "req-9", Method: MethodSubscribe, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	params, _ := json.Marshal(SubscribeParams{Types: []string{"blocks", "transactions"}, Addresses: []string{"klv1abc"}})
+	resp := sendRequest(hub, c, WSRequest{ID: "req-9", Method: MethodSubscribe, Params: params})
 
 	assert.Equal(t, "req-9", resp.ID)
 	assert.Empty(t, resp.Error)
@@ -234,16 +313,18 @@ func TestHandleDynamicSubscribe_InvalidType(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	params, _ := json.Marshal(SubscribeParams{
-		Types: []string{"invalid_type"},
-	})
-	req := WSRequest{ID: "req-10", Method: MethodSubscribe, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	params, _ := json.Marshal(SubscribeParams{Types: []string{"invalid_type"}})
+	resp := sendRequest(hub, c, WSRequest{ID: "req-10", Method: MethodSubscribe, Params: params})
 
 	assert.Equal(t, "req-10", resp.ID)
 	assert.Contains(t, resp.Error, "invalid subscription type")
+}
+
+func TestHandleDynamicSubscribe_InvalidJSON(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+	resp := sendRequest(hub, c, WSRequest{ID: "sj", Method: MethodSubscribe, Params: json.RawMessage(`bad`)})
+	assert.Contains(t, resp.Error, "invalid params")
 }
 
 func TestHandleDynamicUnsubscribe_Success(t *testing.T) {
@@ -254,13 +335,8 @@ func TestHandleDynamicUnsubscribe_Success(t *testing.T) {
 	hub.blockSubscription[c] = struct{}{}
 	hub.mu.Unlock()
 
-	params, _ := json.Marshal(UnsubscribeParams{
-		Types: []string{"blocks"},
-	})
-	req := WSRequest{ID: "req-11", Method: MethodUnsubscribe, Params: params}
-
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	params, _ := json.Marshal(UnsubscribeParams{Types: []string{"blocks"}})
+	resp := sendRequest(hub, c, WSRequest{ID: "req-11", Method: MethodUnsubscribe, Params: params})
 
 	assert.Equal(t, "req-11", resp.ID)
 	assert.Empty(t, resp.Error)
@@ -272,15 +348,27 @@ func TestHandleDynamicUnsubscribe_Success(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestHandleClientRequest_UnknownMethod(t *testing.T) {
+func TestHandleDynamicUnsubscribe_InvalidJSON(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+	resp := sendRequest(hub, c, WSRequest{ID: "uj", Method: MethodUnsubscribe, Params: json.RawMessage(`bad`)})
+	assert.Contains(t, resp.Error, "invalid params")
+}
+
+func TestHandleDynamicUnsubscribe_InvalidType(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	req := WSRequest{ID: "req-12", Method: "nonexistent", Params: json.RawMessage(`{}`)}
+	params, _ := json.Marshal(UnsubscribeParams{Types: []string{"bogus"}})
+	resp := sendRequest(hub, c, WSRequest{ID: "ut", Method: MethodUnsubscribe, Params: params})
 
-	hub.HandleClientRequest(c, req)
-	resp := drainResponse(c)
+	assert.Contains(t, resp.Error, "invalid subscription type")
+}
 
+func TestHandleClientRequest_UnknownMethod(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+	resp := sendRequest(hub, c, WSRequest{ID: "req-12", Method: "nonexistent", Params: json.RawMessage(`{}`)})
 	assert.Equal(t, "req-12", resp.ID)
 	assert.Contains(t, resp.Error, "unknown method")
 }
@@ -289,19 +377,11 @@ func TestDynamicSubscribe_MergesFlags(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
 
-	params1, _ := json.Marshal(SubscribeParams{
-		Types:     []string{"accounts"},
-		Addresses: []string{"klv1abc"},
-	})
-	hub.HandleClientRequest(c, WSRequest{ID: "s1", Method: MethodSubscribe, Params: params1})
-	drainResponse(c)
+	params1, _ := json.Marshal(SubscribeParams{Types: []string{"accounts"}, Addresses: []string{"klv1abc"}})
+	sendRequest(hub, c, WSRequest{ID: "s1", Method: MethodSubscribe, Params: params1})
 
-	params2, _ := json.Marshal(SubscribeParams{
-		Types:     []string{"user_transaction"},
-		Addresses: []string{"klv1abc"},
-	})
-	hub.HandleClientRequest(c, WSRequest{ID: "s2", Method: MethodSubscribe, Params: params2})
-	drainResponse(c)
+	params2, _ := json.Marshal(SubscribeParams{Types: []string{"user_transaction"}, Addresses: []string{"klv1abc"}})
+	sendRequest(hub, c, WSRequest{ID: "s2", Method: MethodSubscribe, Params: params2})
 
 	hub.mu.Lock()
 	opts := hub.addressSubscription["klv1abc"][c]
@@ -321,12 +401,8 @@ func TestDynamicUnsubscribe_PartialFlags(t *testing.T) {
 	}
 	hub.mu.Unlock()
 
-	params, _ := json.Marshal(UnsubscribeParams{
-		Types:     []string{"accounts"},
-		Addresses: []string{"klv1abc"},
-	})
-	hub.HandleClientRequest(c, WSRequest{ID: "u1", Method: MethodUnsubscribe, Params: params})
-	drainResponse(c)
+	params, _ := json.Marshal(UnsubscribeParams{Types: []string{"accounts"}, Addresses: []string{"klv1abc"}})
+	sendRequest(hub, c, WSRequest{ID: "u1", Method: MethodUnsubscribe, Params: params})
 
 	hub.mu.Lock()
 	opts, ok := hub.addressSubscription["klv1abc"][c]
@@ -340,10 +416,7 @@ func TestDynamicUnsubscribe_PartialFlags(t *testing.T) {
 func TestSend_DoesNotPanicOnClosedClient(t *testing.T) {
 	hub := newTestHub(nil)
 	c := newTestClient(hub)
-
-	c.aliveLock.Lock()
-	c.alive = false
-	c.aliveLock.Unlock()
+	killClient(c)
 
 	assert.NotPanics(t, func() {
 		c.send(WSResponse{ID: "x", Error: "test"})
@@ -354,4 +427,474 @@ func TestSend_DoesNotPanicOnClosedClient(t *testing.T) {
 		t.Fatal("expected no message on closed client")
 	default:
 	}
+}
+
+func TestSend_BufferFull(t *testing.T) {
+	hub := newTestHub(nil)
+	c := &client{hub: hub, out: make(chan interface{}, 1), alive: true}
+
+	c.send("first")
+	c.send("second")
+
+	msg := <-c.out
+	assert.Equal(t, "first", msg)
+
+	select {
+	case <-c.out:
+		t.Fatal("expected no second message in buffer")
+	default:
+	}
+}
+
+func TestNewHub(t *testing.T) {
+	hub := NewHub("http://example.com", "api-key", nil)
+	assert.NotNil(t, hub)
+	assert.Equal(t, "http://example.com", hub.postConnectionURL)
+	assert.Equal(t, "api-key", hub.postConnectionAPIKey)
+	assert.Nil(t, hub.facade)
+	assert.NotNil(t, hub.blockSubscription)
+	assert.NotNil(t, hub.transactionSubscription)
+	assert.NotNil(t, hub.addressSubscription)
+}
+
+func TestNewHub_WithFacade(t *testing.T) {
+	f := &mockFacade{}
+	hub := NewHub("", "", f)
+	assert.Equal(t, f, hub.facade)
+}
+
+func TestMarshalMessage_Blocks(t *testing.T) {
+	blockData := []byte(`{"nonce":1}`)
+	msg, err := marshalMessage("blocks", "", "hash1", blockData)
+	require.NoError(t, err)
+	assert.Equal(t, indexer.BLOCKS, msg.Type)
+	assert.Equal(t, blockData, msg.Data)
+	assert.Equal(t, "hash1", msg.Hash)
+}
+
+func TestMarshalMessage_BlocksInvalidType(t *testing.T) {
+	msg, err := marshalMessage("blocks", "", "", "not bytes")
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+}
+
+func TestMarshalMessage_NonBlocks(t *testing.T) {
+	payload := map[string]string{"key": "value"}
+	msg, err := marshalMessage("transaction", "addr1", "hash1", payload)
+	require.NoError(t, err)
+	assert.Equal(t, indexer.EventType("transaction"), msg.Type)
+	assert.Equal(t, "addr1", msg.Address)
+	assert.Equal(t, "hash1", msg.Hash)
+	assert.NotEmpty(t, msg.Data)
+}
+
+func TestHandleClientInsertion_BlocksAndTransactions(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	hub.HandleClientInsertion([]indexer.EventType{indexer.BLOCKS, indexer.TRANSACTION}, nil, c)
+
+	hub.mu.Lock()
+	_, hasBlock := hub.blockSubscription[c]
+	_, hasTx := hub.transactionSubscription[c]
+	hub.mu.Unlock()
+
+	assert.True(t, hasBlock)
+	assert.True(t, hasTx)
+}
+
+func TestHandleClientInsertion_AddressTypes(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS, indexer.USER_TRANSACTION}, []string{"klv1test"}, c)
+
+	hub.mu.Lock()
+	opts := hub.addressSubscription["klv1test"][c]
+	hub.mu.Unlock()
+
+	assert.True(t, opts.acceptAccount)
+	assert.True(t, opts.acceptTransaction)
+}
+
+func TestHandleClientRemoval_BlocksAndTransactions(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	hub.mu.Lock()
+	hub.blockSubscription[c] = struct{}{}
+	hub.transactionSubscription[c] = struct{}{}
+	hub.mu.Unlock()
+
+	hub.HandleClientRemoval([]indexer.EventType{indexer.BLOCKS, indexer.TRANSACTION}, nil, c)
+
+	hub.mu.Lock()
+	_, hasBlock := hub.blockSubscription[c]
+	_, hasTx := hub.transactionSubscription[c]
+	hub.mu.Unlock()
+
+	assert.False(t, hasBlock)
+	assert.False(t, hasTx)
+}
+
+func TestHandleClientRemoval_FullUnsubscribeRemovesEntry(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	hub.mu.Lock()
+	hub.addressSubscription["klv1x"] = map[*client]userOptions{c: {acceptAccount: true, acceptTransaction: false}}
+	hub.mu.Unlock()
+
+	hub.HandleClientRemoval([]indexer.EventType{indexer.ACCOUNTS}, []string{"klv1x"}, c)
+
+	hub.mu.Lock()
+	_, exists := hub.addressSubscription["klv1x"]
+	hub.mu.Unlock()
+
+	assert.False(t, exists)
+}
+
+func TestHandleClientRemoval_UnknownAddressNoOp(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	assert.NotPanics(t, func() {
+		hub.HandleClientRemoval([]indexer.EventType{indexer.ACCOUNTS}, []string{"klv1nonexistent"}, c)
+	})
+}
+
+func TestHandleClientRemoval_ClientNotInAddressMap(t *testing.T) {
+	hub := newTestHub(nil)
+	c1 := newTestClient(hub)
+	c2 := newTestClient(hub)
+
+	hub.mu.Lock()
+	hub.addressSubscription["klv1a"] = map[*client]userOptions{c1: {acceptAccount: true}}
+	hub.mu.Unlock()
+
+	hub.HandleClientRemoval([]indexer.EventType{indexer.ACCOUNTS}, []string{"klv1a"}, c2)
+
+	hub.mu.Lock()
+	opts, ok := hub.addressSubscription["klv1a"][c1]
+	hub.mu.Unlock()
+	assert.True(t, ok)
+	assert.True(t, opts.acceptAccount)
+}
+
+func TestHandleClientDelete(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+	killClient(c)
+
+	hub.mu.Lock()
+	hub.blockSubscription[c] = struct{}{}
+	hub.transactionSubscription[c] = struct{}{}
+	hub.addressSubscription["klv1a"] = map[*client]userOptions{c: {acceptAccount: true}}
+	hub.mu.Unlock()
+
+	hub.handleClientDelete(c)
+
+	hub.mu.Lock()
+	_, hasBlock := hub.blockSubscription[c]
+	_, hasTx := hub.transactionSubscription[c]
+	_, hasAddr := hub.addressSubscription["klv1a"][c]
+	hub.mu.Unlock()
+
+	assert.False(t, hasBlock)
+	assert.False(t, hasTx)
+	assert.False(t, hasAddr)
+}
+
+func TestRemoveClient(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	go func() {
+		removed := <-hub.unregister
+		assert.Equal(t, c, removed)
+	}()
+
+	hub.RemoveClient(c)
+}
+
+func TestIsAlive(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	assert.True(t, c.IsAlive())
+	killClient(c)
+	assert.False(t, c.IsAlive())
+}
+
+func TestDeleteAll(t *testing.T) {
+	hub := newTestHub(nil)
+	c1 := newTestClient(hub)
+	c2 := newTestClient(hub)
+	c3 := newTestClient(hub)
+	killClient(c1)
+	killClient(c2)
+	killClient(c3)
+
+	hub.mu.Lock()
+	hub.blockSubscription[c1] = struct{}{}
+	hub.transactionSubscription[c2] = struct{}{}
+	hub.addressSubscription["klv1a"] = map[*client]userOptions{c3: {acceptAccount: true}}
+	hub.mu.Unlock()
+
+	hub.deleteAll()
+
+	hub.mu.Lock()
+	assert.Empty(t, hub.blockSubscription)
+	assert.Empty(t, hub.transactionSubscription)
+	_, hasC3 := hub.addressSubscription["klv1a"][c3]
+	hub.mu.Unlock()
+	assert.False(t, hasC3)
+}
+
+func TestPostWSConnection_EmptyConfig(t *testing.T) {
+	hub := newTestHub(nil)
+	msg := &Send{Type: indexer.BLOCKS, Data: []byte(`{}`)}
+	err := hub.postWSConnection(msg)
+	assert.NoError(t, err)
+}
+
+func TestPostWSConnection_WithServer(t *testing.T) {
+	var received []byte
+	var mu sync.Mutex
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		received = buf[:n]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	hub := NewHub(ts.URL, "test-key", nil)
+	err := hub.postWSConnection(&Send{Type: indexer.BLOCKS, Data: []byte(`{}`)})
+	assert.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	assert.NotEmpty(t, received)
+	mu.Unlock()
+}
+
+func TestStartServer_ContextCancel(t *testing.T) {
+	env := startServerEnv(t, nil)
+	c := newTestClient(env.hub)
+	killClient(c)
+
+	env.hub.mu.Lock()
+	env.hub.blockSubscription[c] = struct{}{}
+	env.hub.mu.Unlock()
+
+	env.teardown()
+
+	env.hub.mu.Lock()
+	_, has := env.hub.blockSubscription[c]
+	env.hub.mu.Unlock()
+	assert.False(t, has)
+}
+
+func TestStartServer_BlocksEvent(t *testing.T) {
+	env := startServerEnv(t, nil)
+	c := newTestClient(env.hub)
+
+	env.hub.mu.Lock()
+	env.hub.blockSubscription[c] = struct{}{}
+	env.hub.mu.Unlock()
+
+	env.queue <- indexer.Event{EvType: indexer.BLOCKS, Message: []byte(`{"nonce":1}`)}
+
+	s := awaitSend(t, c)
+	assert.Equal(t, indexer.BLOCKS, s.Type)
+
+	env.teardown(c)
+}
+
+func TestStartServer_TransactionEvent(t *testing.T) {
+	env := startServerEnv(t, nil)
+	c := newTestClient(env.hub)
+
+	env.hub.mu.Lock()
+	env.hub.transactionSubscription[c] = struct{}{}
+	env.hub.mu.Unlock()
+
+	env.queue <- indexer.Event{EvType: indexer.TRANSACTION, Message: map[string]string{"hash": "abc"}}
+
+	s := awaitSend(t, c)
+	assert.Equal(t, indexer.TRANSACTION, s.Type)
+
+	env.teardown(c)
+}
+
+func TestStartServer_AccountsEvent(t *testing.T) {
+	env := startServerEnv(t, nil)
+	c := newTestClient(env.hub)
+
+	env.hub.mu.Lock()
+	env.hub.addressSubscription["klv1test"] = map[*client]userOptions{c: {acceptAccount: true}}
+	env.hub.mu.Unlock()
+
+	env.queue <- indexer.Event{
+		EvType:  indexer.ACCOUNTS,
+		Message: map[string]*data.AccountInfo{"klv1test": {Address: "klv1test", Balance: 100}},
+	}
+
+	s := awaitSend(t, c)
+	assert.Equal(t, indexer.ACCOUNTS, s.Type)
+	assert.Equal(t, "klv1test", s.Address)
+
+	env.teardown(c)
+}
+
+func TestStartServer_AccountsEvent_NoSubscribers(t *testing.T) {
+	env := startServerEnv(t, nil)
+
+	env.queue <- indexer.Event{
+		EvType:  indexer.ACCOUNTS,
+		Message: map[string]*data.AccountInfo{"klv1nobody": {Address: "klv1nobody"}},
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	env.teardown()
+}
+
+func TestStartServer_UserTransactionEvent(t *testing.T) {
+	env := startServerEnv(t, nil)
+	c := newTestClient(env.hub)
+
+	env.hub.mu.Lock()
+	env.hub.addressSubscription["klv1sender"] = map[*client]userOptions{c: {acceptTransaction: true}}
+	env.hub.mu.Unlock()
+
+	env.queue <- indexer.Event{
+		EvType: indexer.USER_TRANSACTION,
+		Message: []*data.Transaction{{
+			Hash: "tx1", Sender: "klv1sender",
+			Receipts: []map[string]interface{}{{"to": "klv1receiver"}},
+		}},
+	}
+
+	s := awaitSend(t, c)
+	assert.Equal(t, indexer.USER_TRANSACTION, s.Type)
+
+	env.teardown(c)
+}
+
+func TestStartServer_UserTransaction_NoReceiptTo(t *testing.T) {
+	env := startServerEnv(t, nil)
+	c := newTestClient(env.hub)
+
+	env.hub.mu.Lock()
+	env.hub.addressSubscription["klv1sender"] = map[*client]userOptions{c: {acceptTransaction: true}}
+	env.hub.mu.Unlock()
+
+	env.queue <- indexer.Event{
+		EvType: indexer.USER_TRANSACTION,
+		Message: []*data.Transaction{{
+			Hash: "tx-no-to", Sender: "klv1sender",
+			Receipts: []map[string]interface{}{{"amount": "100"}},
+		}},
+	}
+
+	s := awaitSend(t, c)
+	assert.Equal(t, indexer.USER_TRANSACTION, s.Type)
+
+	env.teardown(c)
+}
+
+func TestStartServer_UnregisterClient(t *testing.T) {
+	env := startServerEnv(t, nil)
+	c := newTestClient(env.hub)
+	killClient(c)
+
+	env.hub.mu.Lock()
+	env.hub.blockSubscription[c] = struct{}{}
+	env.hub.mu.Unlock()
+
+	env.hub.unregister <- c
+	time.Sleep(100 * time.Millisecond)
+
+	env.hub.mu.Lock()
+	_, has := env.hub.blockSubscription[c]
+	env.hub.mu.Unlock()
+	assert.False(t, has)
+
+	env.teardown()
+}
+
+func setupTestWSServer(t *testing.T, hub *SocketHub) (*ws.Conn, func()) {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := ws.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		NewClient(conn, hub)
+	}))
+
+	url := "ws" + strings.TrimPrefix(s.URL, "http")
+	conn, _, err := ws.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	return conn, func() {
+		conn.Close()
+		s.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestNewClient_LoopIn_TextMessage(t *testing.T) {
+	facade := &mockFacade{
+		getTransactionFn: func(hash string, withResults bool) (*api.Transaction, error) {
+			return &api.Transaction{Hash: hash}, nil
+		},
+	}
+	hub := newTestHub(facade)
+	conn, cleanup := setupTestWSServer(t, hub)
+	defer cleanup()
+
+	err := conn.WriteJSON(WSRequest{ID: "live-1", Method: MethodGetTransaction, Params: json.RawMessage(`{"hash":"live_hash"}`)})
+	require.NoError(t, err)
+
+	var resp WSResponse
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	err = conn.ReadJSON(&resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, "live-1", resp.ID)
+	assert.Empty(t, resp.Error)
+}
+
+func TestNewClient_LoopIn_InvalidJSON(t *testing.T) {
+	hub := newTestHub(nil)
+	conn, cleanup := setupTestWSServer(t, hub)
+	defer cleanup()
+
+	err := conn.WriteMessage(ws.TextMessage, []byte(`not valid json`))
+	require.NoError(t, err)
+
+	var resp WSResponse
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	err = conn.ReadJSON(&resp)
+	require.NoError(t, err)
+
+	assert.Contains(t, resp.Error, "invalid json")
+}
+
+func TestNewClient_LoopIn_ConnectionClose(t *testing.T) {
+	hub := newTestHub(nil)
+	conn, cleanup := setupTestWSServer(t, hub)
+
+	err := conn.WriteMessage(ws.CloseMessage, ws.FormatCloseMessage(ws.CloseNormalClosure, "bye"))
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	cleanup()
 }

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -54,6 +54,7 @@ func newTestClient(hub *SocketHub) *client {
 		hub:   hub,
 		out:   make(chan interface{}, 10),
 		alive: true,
+		sem:   make(chan struct{}, maxWorkers),
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds bidirectional JSON messaging to the WebSocket API, enabling clients to query transactions/blocks, dynamically manage subscriptions, and receive validation errors on invalid subscribe attempts.

## Problem
The indexer's WebSocket only supported a one-way pub/sub model: clients connect, subscribe to channels, and receive pushes. There was no error feedback on invalid subscriptions (silently mapped to UNKNOWN), no way to query data (transactions, blocks) over the WS connection, and no way to dynamically modify subscriptions after the initial handshake. This forced dependent services (Wallet, DEX, Bots) to rely on REST polling for on-demand queries, duplicating work and adding latency.

## Solution
Introduces a request/response envelope protocol on top of the existing WS connection. Push messages continue unchanged using the existing `Send` struct. New client-initiated requests use `{"id", "method", "params"}` and receive `{"id", "data"}` or `{"id", "error"}` responses. The hub routes requests by method to dedicated handlers that call the node facade for data queries or manage subscription state for dynamic subscribe/unsubscribe. Strict validation is added at the initial subscribe handshake to reject unknown event types immediately.

## Key Changes
- **New:** `websocket/message.go` — Protocol types (`WSRequest`, `WSResponse`, param structs) and method constants (`get_transaction`, `get_block`, `subscribe`, `unsubscribe`)
- **New:** `websocket/interface.go` — `WSFacade` interface with `GetTransaction`, `GetBlockByHash`, `GetBlockByNonce` (already satisfied by the existing node facade)
- **New:** `indexer/events_test.go` — Tests for `NewEventTypeStrict` and backward compatibility of `NewEventType`
- **New:** `websocket/websocket_test.go` — 12 tests covering all handler paths (success, nil facade, missing params, facade errors, subscribe/unsubscribe, unknown method)
- **Updated:** `indexer/events.go` — Added `ErrUnknownEventType` error and `NewEventTypeStrict()` returning `(EventType, error)` alongside the existing `NewEventType` for backward compatibility
- **Updated:** `websocket/websocket.go` — Added `facade WSFacade` field to `SocketHub`, updated `NewHub` signature, added `HandleClientRequest` router, four private handlers, and `HandleClientRemoval` method
- **Updated:** `websocket/client.go` — `loopIn()` now captures message bytes and dispatches `ws.TextMessage` to `HandleClientRequest`; ping/close handling unchanged
- **Updated:** `network/api/websocket/routes.go` — Replaced `NewEventType` with `NewEventTypeStrict` at initial subscribe; invalid types now return an error JSON and close the connection
- **Updated:** `network/api/api.go` — Type-asserts the facade to `WSFacade` and passes it to `NewHub`
- **Updated:** `network/api/websocket/routes_test.go` — Updated `NewHub` call to include the new facade parameter (`nil`)

## Testing
- [x] All existing tests pass (`go build ./...` compiles, `go test ./indexer/ ./websocket/` passes)
- [x] New tests added for new functionality
  - `indexer/events_test.go`: 3 tests — valid types, invalid type returns `ErrUnknownEventType`, backward compat
  - `websocket/websocket_test.go`: 12 tests — `HandleGetTransaction` (success, nil facade, empty hash, facade error), `HandleGetBlock` (by nonce, by hash, no params, nil facade), `HandleDynamicSubscribe` (success, invalid type), `HandleDynamicUnsubscribe` (success), `HandleClientRequest` (unknown method)
- [x] Manual testing performed:
  - Connect via WS, send `{"id":"1","method":"get_transaction","params":{"hash":"...","withResults":true}}`
  - Connect via WS, send `{"id":"2","method":"subscribe","params":{"types":["blocks"],"addresses":[]}}`
  - Connect with invalid type in initial handshake, verify error JSON returned and connection closed

## Configuration Changes
None. No configuration files were modified. The feature activates automatically when the `subscribe` API route is enabled (existing `config/node/api.yaml` setting).

## Breaking Changes
- `websocket.NewHub()` now requires a third parameter `facade WSFacade`. Callers must pass a facade implementing `GetTransaction`, `GetBlockByHash`, `GetBlockByNonce` — or `nil` if query support is not needed.
- Initial WS subscribe now rejects unknown event types with an error JSON and closes the connection, instead of silently mapping them to `UNKNOWN`. Clients sending invalid types like `"foo"` will now be disconnected.
- Event transactions padronized as transactions everywhere and event user_transaction renamed to user_transactions

## Related Issues
Fixes KLC-2088

## Checklist
- [x] Code follows project style guidelines (`goimports` clean)
- [x] Tests added/updated and passing
- [x] Documentation updated (README, code comments)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unnecessary files included
- [x] Breaking changes documented above
- [x] Configuration changes documented above
