### PR TITLE
[KLC-1952] Enhance node monitoring API with new metrics

### DIFF
--- a/cmd/node/metrics/machineStatistics.go
+++ b/cmd/node/metrics/machineStatistics.go
@@ -2,17 +2,19 @@ package metrics
 
 import (
 	"errors"
+	"path/filepath"
 	"time"
 
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/appStatusPolling"
 	"github.com/klever-io/klever-go/core/statistics/machine"
 	"github.com/klever-io/klever-go/eventNotifier"
+	"github.com/klever-io/klever-go/factory"
 	"github.com/klever-io/klever-go/tools/check"
 )
 
 // StartMachineStatisticsPolling will start read information about current running machine
-func StartMachineStatisticsPolling(ash core.AppStatusHandler, notifier eventNotifier.EpochStartEventNotifier, pollingInterval time.Duration) error {
+func StartMachineStatisticsPolling(ash core.AppStatusHandler, notifier eventNotifier.EpochStartEventNotifier, pollingInterval time.Duration, workingDir string) error {
 	if check.IfNil(ash) {
 		return errors.New("nil AppStatusHandler")
 	}
@@ -33,6 +35,11 @@ func StartMachineStatisticsPolling(ash core.AppStatusHandler, notifier eventNoti
 	}
 
 	err = registerNetStatistics(appStatusPollingHandler, notifier)
+	if err != nil {
+		return err
+	}
+
+	err = registerDiskStatistics(appStatusPollingHandler, workingDir)
 	if err != nil {
 		return err
 	}
@@ -78,6 +85,24 @@ func registerNetStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPo
 	})
 }
 
+func registerDiskStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPolling, workingDir string) error {
+	dbPath := filepath.Join(workingDir, factory.DefaultDBPath)
+	diskStats := machine.NewDiskStatistics(workingDir, dbPath)
+	go func() {
+		for {
+			diskStats.ComputeStatistics()
+			time.Sleep(60 * time.Second)
+		}
+	}()
+
+	return appStatusPollingHandler.RegisterPollingFunc(func(appStatusHandler core.AppStatusHandler) {
+		appStatusHandler.SetUInt64Value(core.MetricDiskTotalBytes, diskStats.DiskTotal())
+		appStatusHandler.SetUInt64Value(core.MetricDiskAvailableBytes, diskStats.DiskAvailable())
+		appStatusHandler.SetUInt64Value(core.MetricDiskUsagePercent, diskStats.DiskPercent())
+		appStatusHandler.SetUInt64Value(core.MetricDbSizeBytes, diskStats.DbSize())
+	})
+}
+
 func registerCPUStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPolling) error {
 	cpuStats, err := machine.NewCpuStatistics()
 	if err != nil {
@@ -92,5 +117,6 @@ func registerCPUStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPo
 
 	return appStatusPollingHandler.RegisterPollingFunc(func(appStatusHandler core.AppStatusHandler) {
 		appStatusHandler.SetUInt64Value(core.MetricCPULoadPercent, cpuStats.CpuPercentUsage())
+		appStatusHandler.SetUInt64Value(core.MetricSystemCPUPercent, cpuStats.SystemCpuPercentUsage())
 	})
 }

--- a/cmd/node/metrics/matics_test.go
+++ b/cmd/node/metrics/matics_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/appStatusPolling"
+	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/factory"
 	"github.com/klever-io/klever-go/network/p2p"
 	"github.com/klever-io/klever-go/sharding"
@@ -499,6 +500,42 @@ func TestRegisterPollProbableHighestNonce(t *testing.T) {
 	if exists {
 		assert.Equal(t, probableNonce, value)
 	}
+}
+
+func TestStartNodeMetricsPolling_NilHandler(t *testing.T) {
+	t.Parallel()
+
+	redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{}
+	err := StartNodeMetricsPolling(nil, time.Second, redundancyHandler)
+	assert.Error(t, err)
+}
+
+func TestStartNodeMetricsPolling_NilRedundancyHandler(t *testing.T) {
+	t.Parallel()
+
+	handler := &mock.AppStatusHandlerStub{}
+	err := StartNodeMetricsPolling(handler, time.Second, nil)
+	assert.Error(t, err)
+}
+
+func TestStartNodeMetricsPolling_Valid(t *testing.T) {
+	t.Parallel()
+
+	setValues := make(map[string]uint64)
+	handler := &mock.AppStatusHandlerStub{
+		SetUInt64ValueHandler: func(key string, value uint64) {
+			setValues[key] = value
+		},
+	}
+	redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{
+		GetSlotsOfInactivityCalled: func() uint64 { return 3 },
+	}
+
+	err := StartNodeMetricsPolling(handler, time.Second, redundancyHandler)
+	assert.NoError(t, err)
+
+	// Start timestamp should be set immediately (non-zero)
+	assert.Greater(t, setValues[core.MetricNodeStartTimestamp], uint64(0))
 }
 
 func TestSliceToString(t *testing.T) {

--- a/cmd/node/metrics/matics_test.go
+++ b/cmd/node/metrics/matics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -521,10 +522,13 @@ func TestStartNodeMetricsPolling_NilRedundancyHandler(t *testing.T) {
 func TestStartNodeMetricsPolling_Valid(t *testing.T) {
 	t.Parallel()
 
+	var mu sync.Mutex
 	setValues := make(map[string]uint64)
 	handler := &mock.AppStatusHandlerStub{
 		SetUInt64ValueHandler: func(key string, value uint64) {
+			mu.Lock()
 			setValues[key] = value
+			mu.Unlock()
 		},
 	}
 	redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{
@@ -535,7 +539,10 @@ func TestStartNodeMetricsPolling_Valid(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start timestamp should be set immediately (non-zero)
-	assert.Greater(t, setValues[core.MetricNodeStartTimestamp], uint64(0))
+	mu.Lock()
+	ts := setValues[core.MetricNodeStartTimestamp]
+	mu.Unlock()
+	assert.Greater(t, ts, uint64(0))
 }
 
 func TestSliceToString(t *testing.T) {

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/appStatusPolling"
-	consensus "github.com/klever-io/klever-go/core/consensus"
+	"github.com/klever-io/klever-go/core/consensus"
 	"github.com/klever-io/klever-go/factory"
 	"github.com/klever-io/klever-go/network/p2p"
 	"github.com/klever-io/klever-go/sharding"

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -246,7 +246,7 @@ func StartNodeMetricsPolling(
 
 	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
 	if err != nil {
-		return errors.New("cannot init AppStatusPolling for node metrics")
+		return fmt.Errorf("cannot init AppStatusPolling for node metrics: %w", err)
 	}
 
 	err = appStatusPollingHandler.RegisterPollingFunc(func(appStatusHandler core.AppStatusHandler) {
@@ -254,7 +254,7 @@ func StartNodeMetricsPolling(
 		appStatusHandler.SetUInt64Value(core.MetricRedundancySlotsInactive, redundancyHandler.GetSlotsOfInactivity())
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot register node metrics polling function: %w", err)
 	}
 
 	appStatusPollingHandler.Poll()

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/appStatusPolling"
+	consensus "github.com/klever-io/klever-go/core/consensus"
 	"github.com/klever-io/klever-go/factory"
 	"github.com/klever-io/klever-go/network/p2p"
 	"github.com/klever-io/klever-go/sharding"
@@ -83,6 +84,17 @@ func InitMetrics(
 	appStatusHandler.SetStringValue(core.MetricDevRewards, initZeroString)
 	appStatusHandler.SetStringValue(core.MetricTotalFees, initZeroString)
 	appStatusHandler.SetUInt64Value(core.MetricEpochForEconomicsData, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricBlockProcessDuration, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricBlockCommitDuration, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricTxProcessingDuration, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricSystemCPUPercent, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricDiskTotalBytes, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricDiskAvailableBytes, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricDiskUsagePercent, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricDbSizeBytes, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricNodeUptimeSeconds, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricNodeStartTimestamp, initUint)
+	appStatusHandler.SetUInt64Value(core.MetricRedundancySlotsInactive, initUint)
 
 	validatorsNodes, _, err := nodesConfig.InitialNodesInfo()
 	if err != nil {
@@ -213,6 +225,40 @@ func setCurrentP2pNodeAddresses(
 	networkComponents *factory.NetworkComponents,
 ) {
 	appStatusHandler.SetStringValue(core.MetricP2PPeerInfo, sliceToString(networkComponents.NetMessenger.Addresses()))
+}
+
+// StartNodeMetricsPolling starts polling for uptime and redundancy metrics on a single shared
+// polling goroutine, avoiding the overhead of separate AppStatusPolling instances for each.
+func StartNodeMetricsPolling(
+	ash core.AppStatusHandler,
+	pollingInterval time.Duration,
+	redundancyHandler consensus.NodeRedundancyHandler,
+) error {
+	if check.IfNil(ash) {
+		return errors.New("nil AppStatusHandler")
+	}
+	if check.IfNil(redundancyHandler) {
+		return errors.New("nil NodeRedundancyHandler")
+	}
+
+	startTime := time.Now()
+	ash.SetUInt64Value(core.MetricNodeStartTimestamp, uint64(startTime.Unix())) // #nosec G115
+
+	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
+	if err != nil {
+		return errors.New("cannot init AppStatusPolling for node metrics")
+	}
+
+	err = appStatusPollingHandler.RegisterPollingFunc(func(appStatusHandler core.AppStatusHandler) {
+		appStatusHandler.SetUInt64Value(core.MetricNodeUptimeSeconds, uint64(time.Since(startTime).Seconds())) // #nosec G115
+		appStatusHandler.SetUInt64Value(core.MetricRedundancySlotsInactive, redundancyHandler.GetSlotsOfInactivity())
+	})
+	if err != nil {
+		return err
+	}
+
+	appStatusPollingHandler.Poll()
+	return nil
 }
 
 func registerPollProbableHighestNonce(

--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -977,7 +977,12 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	}
 
 	updateMachineStatisticsDuration := time.Second
-	err = metrics.StartMachineStatisticsPolling(coreComponents.StatusHandler, epochStartNotifier, updateMachineStatisticsDuration)
+	err = metrics.StartMachineStatisticsPolling(coreComponents.StatusHandler, epochStartNotifier, updateMachineStatisticsDuration, workingDir)
+	if err != nil {
+		return err
+	}
+
+	err = metrics.StartNodeMetricsPolling(coreComponents.StatusHandler, statusPollingInterval, nodeRedundancy)
 	if err != nil {
 		return err
 	}

--- a/core/consensus/interface.go
+++ b/core/consensus/interface.go
@@ -141,5 +141,6 @@ type NodeRedundancyHandler interface {
 	ObserverPrivateKey() crypto.PrivateKey
 	SetInternalRedundancyLevel(level int64) error
 	GetInternalRedundancyLevel() int64
+	GetSlotsOfInactivity() uint64
 	IsInterfaceNil() bool
 }

--- a/core/consensus/mock/nodeRedundancyHandlerStub.go
+++ b/core/consensus/mock/nodeRedundancyHandlerStub.go
@@ -13,6 +13,7 @@ type NodeRedundancyHandlerStub struct {
 	AdjustInactivityIfNeededCalled func(selfPubKey string, consensusPubKeys []string, roundIndex int64)
 	ResetInactivityIfNeededCalled  func(selfPubKey string, consensusMsgPubKey string, consensusMsgPeerID core.PeerID)
 	ObserverPrivateKeyCalled       func() crypto.PrivateKey
+	GetSlotsOfInactivityCalled     func() uint64
 }
 
 // IsRedundancyNode -
@@ -61,6 +62,14 @@ func (nrhs *NodeRedundancyHandlerStub) ObserverPrivateKey() crypto.PrivateKey {
 	}
 
 	return &cryptoMock.PrivateKeyMock{}
+}
+
+// GetSlotsOfInactivity -
+func (nrhs *NodeRedundancyHandlerStub) GetSlotsOfInactivity() uint64 {
+	if nrhs.GetSlotsOfInactivityCalled != nil {
+		return nrhs.GetSlotsOfInactivityCalled()
+	}
+	return 0
 }
 
 // IsInterfaceNil -

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -251,3 +251,36 @@ const MetricRedundancyLevel = "klv_redundancy_level" // #nosec G101: false posit
 
 // MetricRedundancyIsMainActive is the metric that specifies data about the redundancy main machine
 const MetricRedundancyIsMainActive = "klv_redundancy_is_main_active"
+
+// MetricBlockProcessDuration is the metric for the duration in milliseconds of ProcessBlock()
+const MetricBlockProcessDuration = "klv_block_process_duration_ms"
+
+// MetricBlockCommitDuration is the metric for the duration in milliseconds of CommitBlock()
+const MetricBlockCommitDuration = "klv_block_commit_duration_ms"
+
+// MetricTxProcessingDuration is the metric for the duration in milliseconds of transaction processing
+const MetricTxProcessingDuration = "klv_tx_processing_duration_ms"
+
+// MetricSystemCPUPercent is the metric for total system-wide CPU usage percent (all processes)
+const MetricSystemCPUPercent = "klv_system_cpu_percent"
+
+// MetricDiskTotalBytes is the metric for total disk space in bytes
+const MetricDiskTotalBytes = "klv_disk_total_bytes"
+
+// MetricDiskAvailableBytes is the metric for available disk space in bytes
+const MetricDiskAvailableBytes = "klv_disk_available_bytes"
+
+// MetricDiskUsagePercent is the metric for disk usage percentage
+const MetricDiskUsagePercent = "klv_disk_usage_percent"
+
+// MetricDbSizeBytes is the metric for total database directory size in bytes
+const MetricDbSizeBytes = "klv_db_size_bytes"
+
+// MetricNodeUptimeSeconds is the metric for node uptime in seconds since start
+const MetricNodeUptimeSeconds = "klv_node_uptime_seconds"
+
+// MetricNodeStartTimestamp is the metric for node start unix timestamp
+const MetricNodeStartTimestamp = "klv_node_start_timestamp"
+
+// MetricRedundancySlotsInactive is the metric for the redundancy slots of inactivity counter
+const MetricRedundancySlotsInactive = "klv_redundancy_slots_inactive"

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -224,13 +224,11 @@ func (mp *metaProcessor) ProcessBlock(
 
 	// Process Transactions
 	startTx := time.Now()
-	defer func() {
-		mp.appStatusHandler.SetUInt64Value(
-			core.MetricTxProcessingDuration,
-			uint64(time.Since(startTx).Milliseconds()), // #nosec G115
-		)
-	}()
 	processResults, err := mp.txCoordinator.ProcessBlockTransactions(header, haveTime)
+	mp.appStatusHandler.SetUInt64Value(
+		core.MetricTxProcessingDuration,
+		uint64(time.Since(startTx).Milliseconds()), // #nosec G115
+	)
 	if err != nil {
 		_ = bugsnag.Notify(fmt.Errorf("process block transactions: %w", err), bugsnag.MetaData{"data": {"header": header}})
 		return err

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -110,6 +110,14 @@ func (mp *metaProcessor) ProcessBlock(
 	headerHandler data.HeaderHandler,
 	haveTime func() time.Duration,
 ) error {
+	startProcess := time.Now()
+
+	defer func() {
+		mp.appStatusHandler.SetUInt64Value(
+			core.MetricBlockProcessDuration,
+			uint64(time.Since(startProcess).Milliseconds()),
+		)
+	}()
 
 	if haveTime == nil {
 		return process.ErrNilHaveTimeHandler
@@ -215,6 +223,13 @@ func (mp *metaProcessor) ProcessBlock(
 	}
 
 	// Process Transactions
+	startTx := time.Now()
+	defer func() {
+		mp.appStatusHandler.SetUInt64Value(
+			core.MetricTxProcessingDuration,
+			uint64(time.Since(startTx).Milliseconds()),
+		)
+	}()
 	processResults, err := mp.txCoordinator.ProcessBlockTransactions(header, haveTime)
 	if err != nil {
 		_ = bugsnag.Notify(fmt.Errorf("process block transactions: %w", err), bugsnag.MetaData{"data": {"header": header}})
@@ -535,6 +550,14 @@ func (mp *metaProcessor) CreateEpochStartHeader(blk *block.Block) error {
 func (mp *metaProcessor) CommitBlock(
 	headerHandler data.HeaderHandler,
 ) error {
+	startCommitBlock := time.Now()
+
+	defer func() {
+		mp.appStatusHandler.SetUInt64Value(
+			core.MetricBlockCommitDuration,
+			uint64(time.Since(startCommitBlock).Milliseconds()),
+		)
+	}()
 	var err error
 	defer func() {
 		if err != nil {
@@ -1083,7 +1106,6 @@ func (mp *metaProcessor) indexBlock(
 }
 
 func (mp *metaProcessor) processEconomicsEndOfEpoch(validatorInfos []*state.ValidatorInfo, headerHandler data.HeaderHandler) error {
-
 	err := mp.kAppController.GetValidatorsKApp().ProcessEconomicsEndOfEpoch(mp.epochStartTrigger.Epoch(), validatorInfos)
 	if err != nil {
 		return err
@@ -1278,7 +1300,7 @@ func (mp *metaProcessor) finalizeProposalUpdates(proposalKApp state.KAppAccountH
 		return err
 	}
 
-	//After All processing, updates block activeParams instance
+	// After All processing, updates block activeParams instance
 	mp.proposalController.UpdateParameters(controller.ActiveParameters)
 
 	return nil

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -115,7 +115,7 @@ func (mp *metaProcessor) ProcessBlock(
 	defer func() {
 		mp.appStatusHandler.SetUInt64Value(
 			core.MetricBlockProcessDuration,
-			uint64(time.Since(startProcess).Milliseconds()),
+			uint64(time.Since(startProcess).Milliseconds()), // #nosec G115
 		)
 	}()
 
@@ -227,7 +227,7 @@ func (mp *metaProcessor) ProcessBlock(
 	defer func() {
 		mp.appStatusHandler.SetUInt64Value(
 			core.MetricTxProcessingDuration,
-			uint64(time.Since(startTx).Milliseconds()),
+			uint64(time.Since(startTx).Milliseconds()), // #nosec G115
 		)
 	}()
 	processResults, err := mp.txCoordinator.ProcessBlockTransactions(header, haveTime)
@@ -555,7 +555,7 @@ func (mp *metaProcessor) CommitBlock(
 	defer func() {
 		mp.appStatusHandler.SetUInt64Value(
 			core.MetricBlockCommitDuration,
-			uint64(time.Since(startCommitBlock).Milliseconds()),
+			uint64(time.Since(startCommitBlock).Milliseconds()), // #nosec G115
 		)
 	}()
 	var err error

--- a/core/redundancy/export_test.go
+++ b/core/redundancy/export_test.go
@@ -5,11 +5,6 @@ func GetMaxSlotsOfInactivityAccepted() uint64 {
 	return maxSlotsOfInactivityAccepted
 }
 
-// GetSlotsOfInactivity -
-func (nr *nodeRedundancy) GetSlotsOfInactivity() uint64 {
-	return nr.slotsOfInactivity
-}
-
 // SetSlotsOfInactivity -
 func (nr *nodeRedundancy) SetSlotsOfInactivity(slotsOfInactivity uint64) {
 	nr.slotsOfInactivity = slotsOfInactivity

--- a/core/redundancy/redundancy.go
+++ b/core/redundancy/redundancy.go
@@ -120,6 +120,14 @@ func (nr *nodeRedundancy) GetInternalRedundancyLevel() int64 {
 	return nr.redundancyLevel
 }
 
+// GetSlotsOfInactivity returns the current slots of inactivity counter
+func (nr *nodeRedundancy) GetSlotsOfInactivity() uint64 {
+	nr.mutNodeRedundancy.RLock()
+	defer nr.mutNodeRedundancy.RUnlock()
+
+	return nr.slotsOfInactivity
+}
+
 func (nr *nodeRedundancy) isMainMachineActive() bool {
 	if nr.redundancyLevel < 0 {
 		return true

--- a/core/redundancy/redundnacy_test.go
+++ b/core/redundancy/redundnacy_test.go
@@ -1,6 +1,7 @@
 package redundancy_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/klever-io/klever-go/core"
@@ -250,6 +251,30 @@ func TestNodeRedundancy_GetSlotsOfInactivity_AfterAdjust(t *testing.T) {
 
 	nr.AdjustInactivityIfNeeded(selfPubKey, []string{selfPubKey}, 2)
 	assert.Equal(t, uint64(2), nr.GetSlotsOfInactivity())
+}
+
+func TestNodeRedundancy_GetSlotsOfInactivity_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArguments(1)
+	nr, err := redundancy.NewNodeRedundancy(arg)
+	require.NoError(t, err)
+
+	selfPubKey := "self"
+	consensusKeys := []string{selfPubKey}
+
+	var wg sync.WaitGroup
+	for i := int64(1); i <= 100; i++ {
+		wg.Add(1)
+		go func(slot int64) {
+			defer wg.Done()
+			nr.AdjustInactivityIfNeeded(selfPubKey, consensusKeys, slot)
+			_ = nr.GetSlotsOfInactivity()
+		}(i)
+	}
+	wg.Wait()
+
+	assert.GreaterOrEqual(t, nr.GetSlotsOfInactivity(), uint64(1))
 }
 
 func TestNodeRedundancy_ObserverPrivateKey(t *testing.T) {

--- a/core/redundancy/redundnacy_test.go
+++ b/core/redundancy/redundnacy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/klever-io/klever-go/core/redundancy/mock"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createMockArguments(redundancyLevel int64) redundancy.ArgNodeRedundancy {
@@ -230,7 +231,8 @@ func TestNodeRedundancy_GetSlotsOfInactivity_InitiallyZero(t *testing.T) {
 	t.Parallel()
 
 	arg := createMockArguments(1)
-	nr, _ := redundancy.NewNodeRedundancy(arg)
+	nr, err := redundancy.NewNodeRedundancy(arg)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint64(0), nr.GetSlotsOfInactivity())
 }
@@ -240,7 +242,8 @@ func TestNodeRedundancy_GetSlotsOfInactivity_AfterAdjust(t *testing.T) {
 
 	selfPubKey := "self"
 	arg := createMockArguments(1)
-	nr, _ := redundancy.NewNodeRedundancy(arg)
+	nr, err := redundancy.NewNodeRedundancy(arg)
+	require.NoError(t, err)
 
 	nr.AdjustInactivityIfNeeded(selfPubKey, []string{selfPubKey}, 1)
 	assert.Equal(t, uint64(1), nr.GetSlotsOfInactivity())

--- a/core/redundancy/redundnacy_test.go
+++ b/core/redundancy/redundnacy_test.go
@@ -226,6 +226,29 @@ func TestResetInactivityIfNeeded_ShouldResetSlotsOfInactivity(t *testing.T) {
 	assert.Equal(t, uint64(0), nr.GetSlotsOfInactivity())
 }
 
+func TestNodeRedundancy_GetSlotsOfInactivity_InitiallyZero(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArguments(1)
+	nr, _ := redundancy.NewNodeRedundancy(arg)
+
+	assert.Equal(t, uint64(0), nr.GetSlotsOfInactivity())
+}
+
+func TestNodeRedundancy_GetSlotsOfInactivity_AfterAdjust(t *testing.T) {
+	t.Parallel()
+
+	selfPubKey := "self"
+	arg := createMockArguments(1)
+	nr, _ := redundancy.NewNodeRedundancy(arg)
+
+	nr.AdjustInactivityIfNeeded(selfPubKey, []string{selfPubKey}, 1)
+	assert.Equal(t, uint64(1), nr.GetSlotsOfInactivity())
+
+	nr.AdjustInactivityIfNeeded(selfPubKey, []string{selfPubKey}, 2)
+	assert.Equal(t, uint64(2), nr.GetSlotsOfInactivity())
+}
+
 func TestNodeRedundancy_ObserverPrivateKey(t *testing.T) {
 	t.Parallel()
 

--- a/core/statistics/machine/cpuStatistics.go
+++ b/core/statistics/machine/cpuStatistics.go
@@ -13,8 +13,9 @@ var errCpuCount = errors.New("cpu count is zero")
 
 // CpuStatistics can compute the cpu usage percent
 type CpuStatistics struct {
-	numCpu          int
-	cpuUsagePercent uint64
+	numCpu                int
+	cpuUsagePercent       uint64
+	systemCpuUsagePercent uint64
 }
 
 // NewCpuStatistics will create a CpuStatistics object
@@ -41,17 +42,26 @@ func (cs *CpuStatistics) ComputeStatistics() {
 		return
 	}
 
-	percent, err := currentProcess.Percent(time.Second)
+	percent, err := currentProcess.Percent(durationSecond)
 	if err != nil {
 		return
 	}
 
-	cpuUsagePercent := percent / float64(cs.numCpu)
+	atomic.StoreUint64(&cs.cpuUsagePercent, uint64(percent/float64(cs.numCpu)))
 
-	atomic.StoreUint64(&cs.cpuUsagePercent, uint64(cpuUsagePercent))
+	percents, err := cpu.Percent(0, false)
+	if err != nil || len(percents) == 0 {
+		return
+	}
+	atomic.StoreUint64(&cs.systemCpuUsagePercent, uint64(percents[0]))
 }
 
 // CpuPercentUsage will return the cpu percent usage. Concurrent safe.
 func (cs *CpuStatistics) CpuPercentUsage() uint64 {
 	return atomic.LoadUint64(&cs.cpuUsagePercent)
+}
+
+// SystemCpuPercentUsage will return the total system cpu percent usage
+func (cs *CpuStatistics) SystemCpuPercentUsage() uint64 {
+	return atomic.LoadUint64(&cs.systemCpuUsagePercent)
 }

--- a/core/statistics/machine/diskStatistics.go
+++ b/core/statistics/machine/diskStatistics.go
@@ -1,0 +1,99 @@
+package machine
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	logger "github.com/klever-io/klever-go-logger"
+	"github.com/shirou/gopsutil/disk"
+)
+
+var diskLog = logger.GetOrCreate("statistics/machine/disk")
+
+const dbSizeCacheIntervalSec = 300 // 5 minutes
+
+// DiskStatistics can compute disk usage and database directory size
+type DiskStatistics struct {
+	diskTotal     uint64
+	diskAvailable uint64
+	diskPercent   uint64
+	dbSize        uint64
+	lastDbCheck   int64 // unix timestamp of last DB size computation
+	workingDir    string
+	dbPath        string
+}
+
+// NewDiskStatistics creates a DiskStatistics object
+func NewDiskStatistics(workingDir string, dbPath string) *DiskStatistics {
+	return &DiskStatistics{
+		workingDir: workingDir,
+		dbPath:     dbPath,
+	}
+}
+
+// ComputeStatistics computes disk usage and DB size statistics.
+// Disk stats are refreshed every call. DB size is cached for 5 minutes.
+func (ds *DiskStatistics) ComputeStatistics() {
+	ds.computeDiskUsage()
+	ds.computeDbSizeIfNeeded()
+}
+
+func (ds *DiskStatistics) computeDiskUsage() {
+	usage, err := disk.Usage(ds.workingDir)
+	if err != nil {
+		diskLog.Trace("failed to get disk usage", "error", err)
+		return
+	}
+
+	atomic.StoreUint64(&ds.diskTotal, usage.Total)
+	atomic.StoreUint64(&ds.diskAvailable, usage.Free)
+	atomic.StoreUint64(&ds.diskPercent, uint64(usage.UsedPercent))
+}
+
+func (ds *DiskStatistics) computeDbSizeIfNeeded() {
+	now := time.Now().Unix()
+	lastCheck := atomic.LoadInt64(&ds.lastDbCheck)
+	if now-lastCheck < dbSizeCacheIntervalSec {
+		return
+	}
+
+	size := getDirSizeBytes(ds.dbPath)
+	atomic.StoreUint64(&ds.dbSize, size)
+	atomic.StoreInt64(&ds.lastDbCheck, now)
+}
+
+func getDirSizeBytes(dir string) uint64 {
+	var size uint64
+	_ = filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			size += uint64(info.Size()) // #nosec G115
+		}
+		return nil
+	})
+	return size
+}
+
+// DiskTotal returns total disk space in bytes
+func (ds *DiskStatistics) DiskTotal() uint64 {
+	return atomic.LoadUint64(&ds.diskTotal)
+}
+
+// DiskAvailable returns available disk space in bytes
+func (ds *DiskStatistics) DiskAvailable() uint64 {
+	return atomic.LoadUint64(&ds.diskAvailable)
+}
+
+// DiskPercent returns disk usage percent
+func (ds *DiskStatistics) DiskPercent() uint64 {
+	return atomic.LoadUint64(&ds.diskPercent)
+}
+
+// DbSize returns total database directory size in bytes
+func (ds *DiskStatistics) DbSize() uint64 {
+	return atomic.LoadUint64(&ds.dbSize)
+}

--- a/core/statistics/machine/diskStatistics_test.go
+++ b/core/statistics/machine/diskStatistics_test.go
@@ -45,14 +45,23 @@ func TestDiskStatistics_DbSize_CachesResult(t *testing.T) {
 	tmpDir := t.TempDir()
 	ds := NewDiskStatistics(tmpDir, tmpDir)
 
-	// First call should compute and set lastDbCheck
+	err := os.WriteFile(filepath.Join(tmpDir, "db.dat"), make([]byte, 100), 0600)
+	require.NoError(t, err)
+
+	// First call should compute and set lastDbCheck and DbSize
 	ds.computeDbSizeIfNeeded()
 	firstCheck := ds.lastDbCheck
+	firstSize := ds.DbSize()
 	assert.Greater(t, firstCheck, int64(0))
+	assert.Equal(t, uint64(100), firstSize)
 
-	// Immediate second call should skip (cached), lastDbCheck unchanged
+	err = os.WriteFile(filepath.Join(tmpDir, "db2.dat"), make([]byte, 100), 0600)
+	require.NoError(t, err)
+
+	// Immediate second call should skip (cached), both lastDbCheck and DbSize unchanged
 	ds.computeDbSizeIfNeeded()
 	assert.Equal(t, firstCheck, ds.lastDbCheck)
+	assert.Equal(t, firstSize, ds.DbSize())
 }
 
 func TestGetDirSizeBytes_EmptyDir(t *testing.T) {

--- a/core/statistics/machine/diskStatistics_test.go
+++ b/core/statistics/machine/diskStatistics_test.go
@@ -31,7 +31,8 @@ func TestDiskStatistics_InitialValuesAreZero(t *testing.T) {
 func TestDiskStatistics_ComputeDiskUsage_SetsValues(t *testing.T) {
 	t.Parallel()
 
-	ds := NewDiskStatistics("/tmp", "/tmp")
+	tmpDir := t.TempDir()
+	ds := NewDiskStatistics(tmpDir, tmpDir)
 	ds.computeDiskUsage()
 
 	assert.Greater(t, ds.DiskTotal(), uint64(0))

--- a/core/statistics/machine/diskStatistics_test.go
+++ b/core/statistics/machine/diskStatistics_test.go
@@ -1,0 +1,102 @@
+package machine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDiskStatistics_CreatesInstance(t *testing.T) {
+	t.Parallel()
+
+	ds := NewDiskStatistics("/tmp", "/tmp/db")
+	require.NotNil(t, ds)
+	assert.Equal(t, "/tmp", ds.workingDir)
+	assert.Equal(t, "/tmp/db", ds.dbPath)
+}
+
+func TestDiskStatistics_InitialValuesAreZero(t *testing.T) {
+	t.Parallel()
+
+	ds := NewDiskStatistics("/tmp", "/tmp/db")
+	assert.Equal(t, uint64(0), ds.DiskTotal())
+	assert.Equal(t, uint64(0), ds.DiskAvailable())
+	assert.Equal(t, uint64(0), ds.DiskPercent())
+	assert.Equal(t, uint64(0), ds.DbSize())
+}
+
+func TestDiskStatistics_ComputeDiskUsage_SetsValues(t *testing.T) {
+	t.Parallel()
+
+	ds := NewDiskStatistics("/tmp", "/tmp")
+	ds.computeDiskUsage()
+
+	assert.Greater(t, ds.DiskTotal(), uint64(0))
+	assert.Greater(t, ds.DiskAvailable(), uint64(0))
+}
+
+func TestDiskStatistics_DbSize_CachesResult(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	ds := NewDiskStatistics(tmpDir, tmpDir)
+
+	// First call should compute and set lastDbCheck
+	ds.computeDbSizeIfNeeded()
+	firstCheck := ds.lastDbCheck
+	assert.Greater(t, firstCheck, int64(0))
+
+	// Immediate second call should skip (cached), lastDbCheck unchanged
+	ds.computeDbSizeIfNeeded()
+	assert.Equal(t, firstCheck, ds.lastDbCheck)
+}
+
+func TestGetDirSizeBytes_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	size := getDirSizeBytes(tmpDir)
+	assert.Equal(t, uint64(0), size)
+}
+
+func TestGetDirSizeBytes_NonexistentDir(t *testing.T) {
+	t.Parallel()
+
+	size := getDirSizeBytes("/nonexistent/path/that/does/not/exist")
+	assert.Equal(t, uint64(0), size)
+}
+
+func TestGetDirSizeBytes_WithFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Write two files with known sizes
+	err := os.WriteFile(filepath.Join(tmpDir, "a.dat"), make([]byte, 100), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "b.dat"), make([]byte, 200), 0600)
+	require.NoError(t, err)
+
+	size := getDirSizeBytes(tmpDir)
+	assert.Equal(t, uint64(300), size)
+}
+
+func TestGetDirSizeBytes_Recursive(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "sub")
+	err := os.Mkdir(subDir, 0700)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(tmpDir, "root.dat"), make([]byte, 50), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(subDir, "nested.dat"), make([]byte, 150), 0600)
+	require.NoError(t, err)
+
+	size := getDirSizeBytes(tmpDir)
+	assert.Equal(t, uint64(200), size)
+}

--- a/node/heartbeat/mock/redundancyHandlerStub.go
+++ b/node/heartbeat/mock/redundancyHandlerStub.go
@@ -7,9 +7,10 @@ import (
 
 // RedundancyHandlerStub -
 type RedundancyHandlerStub struct {
-	IsRedundancyNodeCalled    func() bool
-	IsMainMachineActiveCalled func() bool
-	ObserverPrivateKeyCalled  func() crypto.PrivateKey
+	IsRedundancyNodeCalled     func() bool
+	IsMainMachineActiveCalled  func() bool
+	ObserverPrivateKeyCalled   func() crypto.PrivateKey
+	GetSlotsOfInactivityCalled func() uint64
 }
 
 func (rhs *RedundancyHandlerStub) AdjustInactivityIfNeeded(selfPubKey string, consensusPubKeys []string, slotIndex int64) {
@@ -51,6 +52,14 @@ func (rhs *RedundancyHandlerStub) ObserverPrivateKey() crypto.PrivateKey {
 	}
 
 	return &PrivateKeyStub{}
+}
+
+// GetSlotsOfInactivity -
+func (rhs *RedundancyHandlerStub) GetSlotsOfInactivity() uint64 {
+	if rhs.GetSlotsOfInactivityCalled != nil {
+		return rhs.GetSlotsOfInactivityCalled()
+	}
+	return 0
 }
 
 // IsInterfaceNil -

--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -141,6 +141,15 @@ func (sm *statusMetrics) StatusMetricsWithoutP2PPrometheusString() string {
 		}
 	}
 
+	version := sm.loadStringMetric(core.MetricAppVersion)
+	if version != "" {
+		nodeType := sm.loadStringMetric(core.MetricNodeType)
+		stringBuilder.WriteString(fmt.Sprintf(
+			"klv_build_info{version=\"%s\",chain_id=\"%s\",node_type=\"%s\"} 1\n",
+			version, chainID, nodeType,
+		))
+	}
+
 	return stringBuilder.String()
 }
 

--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -127,6 +127,16 @@ func (sm *statusMetrics) StatusP2pMetricsMap() map[string]interface{} {
 	return statusMetricsMap
 }
 
+var prometheusLabelEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	"\n", `\n`,
+	`"`, `\"`,
+)
+
+func escapePrometheusLabel(v string) string {
+	return prometheusLabelEscaper.Replace(v)
+}
+
 // StatusMetricsWithoutP2PPrometheusString returns the metrics in a string format which respects prometheus style
 func (sm *statusMetrics) StatusMetricsWithoutP2PPrometheusString() string {
 	chainID := sm.loadStringMetric(core.MetricChainID)
@@ -137,7 +147,7 @@ func (sm *statusMetrics) StatusMetricsWithoutP2PPrometheusString() string {
 		_, isInt64 := value.(int64)
 		isNumericValue := isUint64 || isInt64
 		if isNumericValue {
-			stringBuilder.WriteString(fmt.Sprintf("%s{chainID=\"%s\"} %v\n", key, chainID, value))
+			stringBuilder.WriteString(fmt.Sprintf("%s{chainID=\"%s\"} %v\n", key, escapePrometheusLabel(chainID), value))
 		}
 	}
 
@@ -146,7 +156,7 @@ func (sm *statusMetrics) StatusMetricsWithoutP2PPrometheusString() string {
 		nodeType := sm.loadStringMetric(core.MetricNodeType)
 		stringBuilder.WriteString(fmt.Sprintf(
 			"klv_build_info{version=\"%s\",chain_id=\"%s\",node_type=\"%s\"} 1\n",
-			version, chainID, nodeType,
+			escapePrometheusLabel(version), escapePrometheusLabel(chainID), escapePrometheusLabel(nodeType),
 		))
 	}
 

--- a/statusHandler/statusMetricsProvider.go
+++ b/statusHandler/statusMetricsProvider.go
@@ -147,17 +147,17 @@ func (sm *statusMetrics) StatusMetricsWithoutP2PPrometheusString() string {
 		_, isInt64 := value.(int64)
 		isNumericValue := isUint64 || isInt64
 		if isNumericValue {
-			stringBuilder.WriteString(fmt.Sprintf("%s{chainID=\"%s\"} %v\n", key, escapePrometheusLabel(chainID), value))
+			fmt.Fprintf(&stringBuilder, "%s{chainID=\"%s\"} %v\n", key, escapePrometheusLabel(chainID), value)
 		}
 	}
 
 	version := sm.loadStringMetric(core.MetricAppVersion)
 	if version != "" {
 		nodeType := sm.loadStringMetric(core.MetricNodeType)
-		stringBuilder.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&stringBuilder,
 			"klv_build_info{version=\"%s\",chain_id=\"%s\",node_type=\"%s\"} 1\n",
 			escapePrometheusLabel(version), escapePrometheusLabel(chainID), escapePrometheusLabel(nodeType),
-		))
+		)
 	}
 
 	return stringBuilder.String()

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -10,6 +10,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStatusMetrics_PrometheusString_ContainsBuildInfo(t *testing.T) {
+	t.Parallel()
+
+	sm := statusHandler.NewStatusMetrics()
+	sm.SetStringValue(core.MetricAppVersion, "v1.2.3")
+	sm.SetStringValue(core.MetricChainID, "testnet")
+	sm.SetStringValue(core.MetricNodeType, "validator")
+
+	result := sm.StatusMetricsWithoutP2PPrometheusString()
+
+	assert.True(t, strings.Contains(result, `klv_build_info{version="v1.2.3",chain_id="testnet",node_type="validator"} 1`))
+}
+
+func TestStatusMetrics_PrometheusString_NoBuildInfoWhenVersionEmpty(t *testing.T) {
+	t.Parallel()
+
+	sm := statusHandler.NewStatusMetrics()
+	sm.SetStringValue(core.MetricAppVersion, "")
+	sm.SetStringValue(core.MetricChainID, "testnet")
+
+	result := sm.StatusMetricsWithoutP2PPrometheusString()
+
+	assert.False(t, strings.Contains(result, "klv_build_info"))
+}
+
+func TestStatusMetrics_PrometheusString_NumericMetricsPresent(t *testing.T) {
+	t.Parallel()
+
+	sm := statusHandler.NewStatusMetrics()
+	sm.SetUInt64Value("klv_some_counter", uint64(42))
+	sm.SetStringValue(core.MetricChainID, "1")
+
+	result := sm.StatusMetricsWithoutP2PPrometheusString()
+
+	assert.True(t, strings.Contains(result, fmt.Sprintf(`klv_some_counter{chainID="1"} 42`)))
+}
+
 func TestNewStatusMetricsProvider(t *testing.T) {
 	t.Parallel()
 

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -47,6 +47,20 @@ func TestStatusMetrics_PrometheusString_NumericMetricsPresent(t *testing.T) {
 	assert.True(t, strings.Contains(result, fmt.Sprintf(`klv_some_counter{chainID="1"} 42`)))
 }
 
+func TestStatusMetrics_PrometheusString_BuildInfoEscapesLabels(t *testing.T) {
+	t.Parallel()
+
+	sm := statusHandler.NewStatusMetrics()
+	sm.SetStringValue(core.MetricAppVersion, "v1\"2\\3")
+	sm.SetStringValue(core.MetricChainID, "test\nnet")
+	sm.SetStringValue(core.MetricNodeType, "validator")
+
+	result := sm.StatusMetricsWithoutP2PPrometheusString()
+
+	assert.NotContains(t, result, "test\nnet")
+	assert.Contains(t, result, `version="v1\"2\\3"`)
+}
+
 func TestNewStatusMetricsProvider(t *testing.T) {
 	t.Parallel()
 

--- a/statusHandler/statusMetricsProvider_test.go
+++ b/statusHandler/statusMetricsProvider_test.go
@@ -61,6 +61,19 @@ func TestStatusMetrics_PrometheusString_BuildInfoEscapesLabels(t *testing.T) {
 	assert.Contains(t, result, `version="v1\"2\\3"`)
 }
 
+func TestStatusMetrics_PrometheusString_NumericMetricsEscapesChainID(t *testing.T) {
+	t.Parallel()
+
+	sm := statusHandler.NewStatusMetrics()
+	sm.SetUInt64Value("klv_some_counter", uint64(42))
+	sm.SetStringValue(core.MetricChainID, "te\"st\\\nnet")
+
+	result := sm.StatusMetricsWithoutP2PPrometheusString()
+
+	assert.NotContains(t, result, "te\"st\\\nnet")
+	assert.Contains(t, result, `klv_some_counter{chainID="te\"st\\\nnet"} 42`)
+}
+
 func TestNewStatusMetricsProvider(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary                            
  Adds critical observability metrics to the Klever validator node, covering block processing performance, system resources, uptime, redundancy state. 
                                                                                                                                          
 ## Problem                                                                                                                              
  The node lacked visibility into key operational indicators, making incident prevention and performance diagnostics reactive rather than 
  proactive:                                                                                                                              
                                                                                                                                          
  - No block processing time visibility → impossible to detect validator slot degradation before it happens                               
  - System-wide CPU untracked → process CPU alone misses contention from other services on the host                                       
  - No disk monitoring → nodes can fail when disk fills without warning                                              
  - No database growth tracking → capacity planning based on guesswork
  - No uptime tracking → difficult to prove SLA compliance or correlate restarts with anomalies                                           
  - Redundancy inactivity counter invisible externally → failover state opaque to monitoring                                              
                                                                                                                                          
  ## Solution                                                                                                                             
  Implements all missing metrics following the existing `AppStatusHandler` polling pattern — metric constants in `core/metrics.go`                                                                             
                                                                                                                                          
                                                                           
                                                                                                                                                                                                                                          
  ## Key Changes                                                                                                                          
                                                                                                                                      
  - **New:**
    - `core/statistics/machine/diskStatistics.go` — `DiskStatistics` struct with `disk.Usage()` (60s via caller goroutine) and recursive
  DB size via `filepath.Walk` (5-minute cache)                                                                                            
    - `core/statistics/machine/diskStatistics_test.go` — 6 tests covering construction, disk usage, DB size caching, and recursive        
  directory sizing                                                                                                                        
                                                                                                                                          
  - **Updated:**                                                                                                                      
    - `core/metrics.go` — 7 new metric constants (`klv_disk_*`, `klv_db_size_bytes`, `klv_node_uptime_seconds`,
  `klv_node_start_timestamp`, `klv_redundancy_slots_inactive`) + doc comments on 4 existing constants                                     
    - `cmd/node/metrics/metrics.go` — 7 new metric initializations; new `StartNodeMetricsPolling` (uptime + redundancy on one goroutine)  
    - `cmd/node/metrics/machineStatistics.go` — `workingDir` parameter added; new `registerDiskStatistics` following existing CPU/net     
  pattern                                                                                                                                 
    - `core/statistics/machine/cpuStatistics.go` — `systemCpuUsagePercent` field + `SystemCpuPercentUsage()` getter; `ComputeStatistics`  
  uses `cpu.Percent(0)` non-blocking after process measurement                                                                            
    - `core/process/block/block.go` — `defer`-based timing for `ProcessBlock`, `CommitBlock`, and TX processing (consistent pattern across
   all three)                                                                                                                             
    - `core/redundancy/redundancy.go` — public `GetSlotsOfInactivity() uint64` (thread-safe via existing `mutNodeRedundancy`)             
    - `core/consensus/interface.go` — `GetSlotsOfInactivity()` added to `NodeRedundancyHandler`                                           
    - `core/consensus/mock/nodeRedundancyHandlerStub.go` — callback field + method for new interface method                               
    - `node/heartbeat/mock/redundancyHandlerStub.go` — same callback pattern                                                              
    - `statusHandler/statusMetricsProvider.go` — `klv_build_info` info gauge appended in `StatusMetricsWithoutP2PPrometheusString`        
    - `cmd/node/startup.go` — wires `workingDir` to machine statistics, calls `StartNodeMetricsPolling`                                   
                                                                                                                                          
  - **Removed:**                                                                                                                          
    - `GetSlotsOfInactivity` test helper from `core/redundancy/export_test.go` — superseded by the promoted production method             
                                                                                                                                          
  ## Testing                                                                                                                              
                                                                                                                                          
  - [x] All existing tests pass (`make tests`)                                                                                            
  - [x] New tests added for new functionality                                                                                             
  - [x] Manual testing performed:                                                                                                     
    - Verified all new `klv_*` metrics appear in `/node/status` JSON response
    - Verified `klv_build_info{...} 1` line appears in `/node/metrics` Prometheus output
    - Verified `klv_block_process_duration_ms`, `klv_block_commit_duration_ms`, and `klv_tx_processing_duration_ms` update on each block  
                                                                                                                                          
  ## Configuration Changes                                                                                                                
  None. Disk metrics use `workingDir` (existing flag) to locate the database directory.                                                   
                                                                                                                                          
  ## Breaking Changes                                                                                                                 
  `StartMachineStatisticsPolling` gains a `workingDir string` parameter. The `NodeRedundancyHandler` interface (in `core/consensus`) gains
   `GetSlotsOfInactivity() uint64`. Any external implementations of this interface must add the method.                                   
                                                                                                                                                                                                                                                                  
  ## Checklist
  - [x] Code follows project style guidelines (`make goimports`)
  - [x] Tests added/updated and passing                                                                                                   
  - [x] Documentation updated (code comments on all new constants)                                                                        
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)                                               
  - [x] No unnecessary files included                                                                                                     
  - [x] Breaking changes documented above                                                                                                 
  - [x] Configuration changes documented above 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Blockchain-Critical Component Changes

**Block Processing & Transactions**
- Only observability instrumentation added: defer-based end-to-end timers for ProcessBlock and CommitBlock, and a scoped timer for per-block TX processing (metrics: klv_block_process_duration_ms, klv_block_commit_duration_ms, klv_tx_processing_duration_ms). 
- No control-flow, state-transition, transaction semantics, KVM execution, persistence, or consensus logic changes — timers record durations only and write atomic metric values.

**Consensus / Redundancy**
- NodeRedundancyHandler interface extended with GetSlotsOfInactivity() uint64 (breaking change). Mocks/stubs updated; production redundancy exposes a new thread-safe getter (read-locked).
- The change surfaces inactivity counts to observability (klv_redundancy_slots_inactive) only — it does not alter election/consensus algorithms or redundancy decision logic.

**State Management / Storage**
- Read-only monitoring added:
  - Disk usage via gopsutil/disk.Usage() on workingDir (polled ~60s).
  - DB directory size computed recursively with filepath.Walk and cached for 5 minutes to limit cost.
- Walk/traversal errors are logged/ignored; these routines do not mutate on-disk data or storage formats.

**Networking & KVM**
- No changes to networking stacks or KVM/instruction execution.

## Node Stability & Data Integrity

- Core mutation and consensus behavior remain unchanged; data integrity is preserved.
- Observability runs in background polling and is implemented to minimize impact (atomic fields for metrics, cached DB size).
- Important operational change: startup wiring now invokes StartMachineStatisticsPolling(…, workingDir) and StartNodeMetricsPolling — startNode returns an error if these fail. Metric initialization failures (e.g., inaccessible workingDir/DB path or permission errors) can therefore cause node startup to fail (availability risk).

## Concurrency & Error Handling

- Concurrency protections:
  - CPU, disk, and DB-size values stored via atomics.
  - Redundancy GetSlotsOfInactivity() uses RWMutex to allow safe concurrent reads.
- Error handling:
  - Disk/DB/stat collection errors are logged and do not abort polling loops.
  - System CPU sampling uses cpu.Percent(0) (non-blocking); errors cause the sampling call to early-return and retain previous metric values.
  - Defer-based timing ensures duration metrics are recorded even on early returns or panics in instrumented functions.

## Observability & Operational Impact

- New metrics exposed (status JSON + Prometheus): klv_block_process_duration_ms, klv_block_commit_duration_ms, klv_tx_processing_duration_ms, klv_system_cpu_percent, klv_disk_total_bytes, klv_disk_available_bytes, klv_disk_usage_percent, klv_db_size_bytes, klv_node_uptime_seconds, klv_node_start_timestamp, klv_redundancy_slots_inactive. klv_build_info is appended to Prometheus output when build/version info is present.
- New exported API: StartNodeMetricsPolling(...) to drive uptime/redundancy polling; InitMetrics pre-initializes new metric keys.

## Breaking Changes & Action Items

- Required code updates:
  - Add GetSlotsOfInactivity() uint64 to any external implementations of core/consensus.NodeRedundancyHandler.
  - Update callers to the new StartMachineStatisticsPolling(..., workingDir string) signature.
- Operational guidance:
  - Ensure workingDir and DB path are accessible and readable by the node process to avoid startup failures from metric initialization.
- Tests: New unit tests for disk/DB-size, CPU sampling, redundancy getter, and metrics polling added; existing tests reportedly pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->