### PR TITLE
[KLC-2309] Dispatch websocket account events without indexer

### DIFF
--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -729,6 +729,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		ValidatorPubkeyConverter: validatorPubkeyConverter,
 		Indexer:                  esIndexer,
 		KAppController:           stateComponents.KAppController,
+		AccountsDB:               stateComponents.AccountsAdapter,
 	})
 	if err != nil {
 		return err

--- a/data/indexer/dtos.go
+++ b/data/indexer/dtos.go
@@ -11,11 +11,9 @@ type ArgsSaveBlockData struct {
 	Signer           []byte
 	TransactionsPool *Pool
 	Validators       []string
-	// Prepared optionally carries pre-computed block data produced by the
-	// events orchestrator (concretely a *indexer/data.PreparedBlockData). When
-	// non-nil, downstream consumers (e.g., elasticProcessor.SaveTransactions)
-	// must reuse it instead of recomputing. Typed as any so this public DTO
-	// does not depend on the internal indexer/data package.
+	// Prepared, when non-nil, is a *indexer/data.PreparedBlockData consumers
+	// reuse instead of re-prepping. Typed as any to avoid importing the
+	// internal indexer/data package.
 	Prepared any
 }
 

--- a/data/indexer/dtos.go
+++ b/data/indexer/dtos.go
@@ -11,6 +11,12 @@ type ArgsSaveBlockData struct {
 	Signer           []byte
 	TransactionsPool *Pool
 	Validators       []string
+	// Prepared optionally carries pre-computed block data produced by the
+	// events orchestrator (concretely a *indexer/data.PreparedBlockData). When
+	// non-nil, downstream consumers (e.g., elasticProcessor.SaveTransactions)
+	// must reuse it instead of recomputing. Typed as any so this public DTO
+	// does not depend on the internal indexer/data package.
+	Prepared any
 }
 
 // Pool will holds all types of transaction

--- a/indexer/accountInfo.go
+++ b/indexer/accountInfo.go
@@ -1,0 +1,106 @@
+package indexer
+
+import (
+	"encoding/hex"
+
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/kapp"
+	"github.com/klever-io/klever-go/core/process/kda/kdautils"
+	dataState "github.com/klever-io/klever-go/data/state"
+	"github.com/klever-io/klever-go/indexer/data"
+	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/tools/check"
+)
+
+// buildAccountInfo is the single source of truth for AccountInfo payloads consumed
+// by both the elastic indexer and the websocket dispatcher. Keep this in sync — any
+// new field must appear here, not in a caller-local helper.
+func buildAccountInfo(
+	addressPubkeyConverter core.PubkeyConverter,
+	kappsController kapp.KAppController,
+	userAccount dataState.UserAccountHandler,
+	blockTimestamp int64,
+) (*data.AccountInfo, error) {
+	userKDA, err := userAccount.GetUserKDA(kdautils.KLVIdentifier, nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data.AccountInfo{
+		Address:         addressPubkeyConverter.Encode(userAccount.AddressBytes()),
+		Nonce:           userAccount.GetNonce(),
+		Name:            string(userAccount.GetName()),
+		RootHash:        hex.EncodeToString(userAccount.GetRootHash()),
+		Balance:         userAccount.GetBalance(kdautils.KLVIdentifier, true),
+		FrozenBalance:   userKDA.FrozenBalance,
+		UnfrozenBalance: calculateUnfrozenBalance(userKDA.Buckets),
+		Allowance:       getAllowanceWithPendingRewards(kappsController, userAccount),
+		Permissions:     convertPermissions(addressPubkeyConverter, userAccount.GetPermissions()),
+		Timestamp:       toMilliseconds(blockTimestamp),
+		UpdatedAt:       toMilliseconds(blockTimestamp),
+		CodeHash:        hex.EncodeToString(userAccount.GetCodeHash()),
+		CodeMetadata:    hex.EncodeToString(userAccount.GetCodeMetadata()),
+		Foundation:      false,
+	}, nil
+}
+
+// convertPermissions converts user account permissions to the indexer payload type.
+func convertPermissions(
+	addressPubkeyConverter core.PubkeyConverter,
+	perms []*dataState.Permission,
+) []data.Permissions {
+	permissions := make([]data.Permissions, 0, len(perms))
+	for _, p := range perms {
+		keys := make([]data.PermissionKey, 0, len(p.Signers))
+		for _, k := range p.Signers {
+			keys = append(keys, data.PermissionKey{
+				Address: addressPubkeyConverter.Encode(k.Address),
+				Weight:  k.Weight,
+			})
+		}
+		permissions = append(permissions, data.Permissions{
+			ID:             p.ID,
+			Type:           int32(p.Type),
+			PermissionName: p.PermissionName,
+			Threshold:      p.Threshold,
+			Operations:     hex.EncodeToString(p.Operations),
+			Signers:        keys,
+		})
+	}
+	return permissions
+}
+
+// calculateUnfrozenBalance sums the value of all unstaked buckets.
+func calculateUnfrozenBalance(buckets map[string]*kapps.UserBucket) int64 {
+	unfrozenBalance := int64(0)
+	for _, bucket := range buckets {
+		if bucket.UnstakedEpoch != core.DefaultUnstakedEpoch {
+			unfrozenBalance += bucket.Value
+		}
+	}
+	return unfrozenBalance
+}
+
+// getAllowanceWithPendingRewards returns the user allowance including V2 pending
+// validator rewards. A nil controller (or missing validators kapp) returns the
+// raw allowance, matching prior behavior on both code paths.
+func getAllowanceWithPendingRewards(
+	kappsController kapp.KAppController,
+	userAccount dataState.UserAccountHandler,
+) int64 {
+	allowance := userAccount.GetAllowance()
+	if check.IfNil(kappsController) {
+		return allowance
+	}
+
+	validatorsKApp := kappsController.GetValidatorsKApp()
+	if check.IfNil(validatorsKApp) {
+		return allowance
+	}
+
+	pendingRewards, err := validatorsKApp.GetPendingRewards(userAccount.AddressBytes())
+	if err == nil && pendingRewards > 0 {
+		allowance += pendingRewards
+	}
+	return allowance
+}

--- a/indexer/accountInfo.go
+++ b/indexer/accountInfo.go
@@ -12,9 +12,8 @@ import (
 	"github.com/klever-io/klever-go/tools/check"
 )
 
-// buildAccountInfo is the single source of truth for AccountInfo payloads consumed
-// by both the elastic indexer and the websocket dispatcher. Keep this in sync — any
-// new field must appear here, not in a caller-local helper.
+// buildAccountInfo builds the AccountInfo payload shared by the elastic
+// indexer and the websocket dispatcher.
 func buildAccountInfo(
 	addressPubkeyConverter core.PubkeyConverter,
 	kappsController kapp.KAppController,
@@ -44,7 +43,6 @@ func buildAccountInfo(
 	}, nil
 }
 
-// convertPermissions converts user account permissions to the indexer payload type.
 func convertPermissions(
 	addressPubkeyConverter core.PubkeyConverter,
 	perms []*dataState.Permission,
@@ -70,7 +68,6 @@ func convertPermissions(
 	return permissions
 }
 
-// calculateUnfrozenBalance sums the value of all unstaked buckets.
 func calculateUnfrozenBalance(buckets map[string]*kapps.UserBucket) int64 {
 	unfrozenBalance := int64(0)
 	for _, bucket := range buckets {
@@ -81,9 +78,9 @@ func calculateUnfrozenBalance(buckets map[string]*kapps.UserBucket) int64 {
 	return unfrozenBalance
 }
 
-// getAllowanceWithPendingRewards returns the user allowance including V2 pending
-// validator rewards. A nil controller (or missing validators kapp) returns the
-// raw allowance, matching prior behavior on both code paths.
+// getAllowanceWithPendingRewards returns the user allowance plus any V2
+// pending validator rewards. A nil controller or missing validators kapp
+// returns the raw allowance.
 func getAllowanceWithPendingRewards(
 	kappsController kapp.KAppController,
 	userAccount dataState.UserAccountHandler,

--- a/indexer/data/prepared.go
+++ b/indexer/data/prepared.go
@@ -1,9 +1,7 @@
 package data
 
-// PreparedBlockData carries the result of prepareTransactionsForDatabase so
-// the events orchestrator can pre-compute it once on the commit goroutine and
-// hand it to the indexer worker (avoiding duplicate prep and decoupling
-// websocket dispatch from the elastic worker's lifecycle).
+// PreparedBlockData carries the result of prepareTransactionsForDatabase
+// shared between the websocket dispatcher and the elastic worker.
 type PreparedBlockData struct {
 	Txs     []*Transaction
 	TxsMap  map[string]*Transaction

--- a/indexer/data/prepared.go
+++ b/indexer/data/prepared.go
@@ -1,0 +1,11 @@
+package data
+
+// PreparedBlockData carries the result of prepareTransactionsForDatabase so
+// the events orchestrator can pre-compute it once on the commit goroutine and
+// hand it to the indexer worker (avoiding duplicate prep and decoupling
+// websocket dispatch from the elastic worker's lifecycle).
+type PreparedBlockData struct {
+	Txs     []*Transaction
+	TxsMap  map[string]*Transaction
+	Altered *AlteredData
+}

--- a/indexer/dataIndexerArgs.go
+++ b/indexer/dataIndexerArgs.go
@@ -54,4 +54,5 @@ type ArgEventsProcessor struct {
 	ValidatorPubkeyConverter core.PubkeyConverter
 	Indexer                  Indexer
 	KAppController           kapp.KAppController
+	AccountsDB               state.AccountsAdapter
 }

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -534,86 +534,68 @@ func (ei *elasticProcessor) SaveTransactions(
 ) error {
 	headerTimestamp := header.GetTimestamp()
 
-	var (
-		txs    []*data.Transaction
-		txsMap map[string]*data.Transaction
-		ad     *data.AlteredData
-		err    error
-	)
-	if p, ok := prepared.(*data.PreparedBlockData); ok && p != nil {
-		txs, txsMap, ad = p.Txs, p.TxsMap, p.Altered
-	} else {
-		txs, txsMap, ad, err = ei.prepareTransactionsForDatabase(header, pool)
-		if err != nil {
-			return err
-		}
+	txs, txsMap, ad, err := ei.resolvePreparedBlockData(header, pool, prepared)
+	if err != nil {
+		return err
 	}
 
 	ld := ei.logsAndEventsProc.ExtractDataFromLogs(pool, txs, headerTimestamp)
-
 	buffers := data.NewBufferSlice(data.DefaultMaxBulkSize)
 
-	err = ei.indexTransactions(txs, buffers)
-	if err != nil {
+	if err := ei.indexBlockArtifacts(buffers, headerTimestamp, txs, txsMap, ad, ld, pool); err != nil {
 		return err
 	}
 
-	err = ei.indexKDAPools(ad.KDAPool.GetAll(), buffers)
-	if err != nil {
+	if err := ei.doBulkRequests("", buffers.Buffers()); err != nil {
+		log.Warn("indexer indexing bulk of transactions", "error", err.Error())
 		return err
 	}
 
-	err = ei.indexAssets(ad.Assets.GetAll(), buffers)
-	if err != nil {
-		return err
-	}
+	return nil
+}
 
-	err = ei.indexProposals(ad.Proposals.GetAll(), buffers)
-	if err != nil {
-		return err
+// resolvePreparedBlockData returns the prepared block data if provided,
+// otherwise it runs prepareTransactionsForDatabase as a fallback.
+func (ei *elasticProcessor) resolvePreparedBlockData(
+	header nodeData.HeaderHandler,
+	pool *indexer.Pool,
+	prepared any,
+) ([]*data.Transaction, map[string]*data.Transaction, *data.AlteredData, error) {
+	if p, ok := prepared.(*data.PreparedBlockData); ok && p != nil {
+		return p.Txs, p.TxsMap, p.Altered, nil
 	}
+	return ei.prepareTransactionsForDatabase(header, pool)
+}
 
-	err = ei.indexITOs(ad.ITO.GetAll(), buffers)
-	if err != nil {
-		return err
+// indexBlockArtifacts runs every sub-index step for a block. The list is
+// linear; on the first error the pipeline stops and the error is returned.
+func (ei *elasticProcessor) indexBlockArtifacts(
+	buffers *data.BufferSlice,
+	headerTimestamp int64,
+	txs []*data.Transaction,
+	txsMap map[string]*data.Transaction,
+	ad *data.AlteredData,
+	ld *data.PreparedLogsResults,
+	pool *indexer.Pool,
+) error {
+	steps := []func() error{
+		func() error { return ei.indexTransactions(txs, buffers) },
+		func() error { return ei.indexKDAPools(ad.KDAPool.GetAll(), buffers) },
+		func() error { return ei.indexAssets(ad.Assets.GetAll(), buffers) },
+		func() error { return ei.indexProposals(ad.Proposals.GetAll(), buffers) },
+		func() error { return ei.indexITOs(ad.ITO.GetAll(), buffers) },
+		func() error { return ei.indexMarketplaces(ad.Marketplaces.GetAll(), buffers) },
+		func() error { return ei.indexOrders(ad.Orders.GetAll(), buffers) },
+		func() error { return ei.indexAlteredAccounts(headerTimestamp, ad.Accounts.GetAll(), buffers) },
+		func() error { return ei.prepareAndIndexLogs(pool.Logs, txsMap, headerTimestamp, buffers) },
+		func() error { return ei.indexScDeploys(ld.ScDeploys, buffers) },
+		func() error { return ei.indexAlteredSmartContracts(ld.AlteredSCs, buffers) },
 	}
-
-	err = ei.indexMarketplaces(ad.Marketplaces.GetAll(), buffers)
-	if err != nil {
-		return err
+	for _, step := range steps {
+		if err := step(); err != nil {
+			return err
+		}
 	}
-
-	err = ei.indexOrders(ad.Orders.GetAll(), buffers)
-	if err != nil {
-		return err
-	}
-
-	if err := ei.indexAlteredAccounts(headerTimestamp, ad.Accounts.GetAll(), buffers); err != nil {
-		return err
-	}
-
-	err = ei.prepareAndIndexLogs(pool.Logs, txsMap, headerTimestamp, buffers)
-	if err != nil {
-		return err
-	}
-
-	err = ei.indexScDeploys(ld.ScDeploys, buffers)
-	if err != nil {
-		return err
-	}
-
-	err = ei.indexAlteredSmartContracts(ld.AlteredSCs, buffers)
-	if err != nil {
-		return err
-	}
-
-	err = ei.doBulkRequests("", buffers.Buffers())
-	if err != nil {
-		log.Warn("indexer indexing bulk of transactions",
-			"error", err.Error())
-		return err
-	}
-
 	return nil
 }
 

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -327,13 +327,8 @@ func (ei *elasticProcessor) SaveHeader(
 		return err
 	}
 
-	if UseEventQueue {
-		trySendEvent(Event{
-			EvType:  BLOCKS,
-			Message: serializedBlock,
-		})
-	}
-
+	// Websocket BLOCKS dispatch is performed by eventsProcessor.SaveBlock on the
+	// commit goroutine so it is decoupled from elastic write timing/health.
 	return nil
 }
 
@@ -531,31 +526,34 @@ func (ei *elasticProcessor) updateAccountBalance(address string, balance int64, 
 	return ei.elasticClient.DoUpdate(accountsIndex, address, &updateBody)
 }
 
-// SaveTransactions will prepare and save information about a transactions in elasticsearch server
+// SaveTransactions will prepare and save information about a transactions in elasticsearch server.
+// When prepared is a non-nil *data.PreparedBlockData, its contents are reused (single-source-of-truth
+// produced by the events orchestrator on the commit goroutine); otherwise, the legacy path runs
+// prepareTransactionsForDatabase here. Websocket dispatch is NOT performed in this path — the
+// orchestrator owns it so events are decoupled from elastic write success and timing.
 func (ei *elasticProcessor) SaveTransactions(
 	header nodeData.HeaderHandler,
 	pool *indexer.Pool,
+	prepared any,
 ) error {
 	headerTimestamp := header.GetTimestamp()
 
-	txs, txsMap, ad, err := ei.prepareTransactionsForDatabase(header, pool)
-	if err != nil {
-		return err
+	var (
+		txs    []*data.Transaction
+		txsMap map[string]*data.Transaction
+		ad     *data.AlteredData
+		err    error
+	)
+	if p, ok := prepared.(*data.PreparedBlockData); ok && p != nil {
+		txs, txsMap, ad = p.Txs, p.TxsMap, p.Altered
+	} else {
+		txs, txsMap, ad, err = ei.prepareTransactionsForDatabase(header, pool)
+		if err != nil {
+			return err
+		}
 	}
 
 	ld := ei.logsAndEventsProc.ExtractDataFromLogs(pool, txs, headerTimestamp)
-
-	// Dispatch events
-	if UseEventQueue && len(txs) > 0 {
-		trySendEvent(Event{
-			EvType:  USER_TRANSACTIONS,
-			Message: txs,
-		})
-		trySendEvent(Event{
-			EvType:  TRANSACTIONS,
-			Message: txs,
-		})
-	}
 
 	buffers := data.NewBufferSlice(data.DefaultMaxBulkSize)
 
@@ -1588,54 +1586,6 @@ func (ei *elasticProcessor) SaveAccounts(
 	return ei.doBulkRequests(accountsIndex, buffSlice.Buffers())
 }
 
-// convertPermissions converts user account permissions to indexer format.
-func (ei *elasticProcessor) convertPermissions(perms []*state.Permission) []data.Permissions {
-	permissions := make([]data.Permissions, 0, len(perms))
-	for _, p := range perms {
-		keys := make([]data.PermissionKey, 0, len(p.Signers))
-		for _, k := range p.Signers {
-			keys = append(keys, data.PermissionKey{
-				Address: ei.addressPubkeyConverter.Encode(k.Address),
-				Weight:  k.Weight,
-			})
-		}
-		permissions = append(permissions, data.Permissions{
-			ID:             p.ID,
-			Type:           int32(p.Type),
-			PermissionName: p.PermissionName,
-			Threshold:      p.Threshold,
-			Operations:     hex.EncodeToString(p.Operations),
-			Signers:        keys,
-		})
-	}
-	return permissions
-}
-
-// calculateUnfrozenBalance sums the value of all unstaked buckets.
-func calculateUnfrozenBalance(buckets map[string]*kapps.UserBucket) int64 {
-	unfrozenBalance := int64(0)
-	for _, bucket := range buckets {
-		if bucket.UnstakedEpoch != core.DefaultUnstakedEpoch {
-			unfrozenBalance += bucket.Value
-		}
-	}
-	return unfrozenBalance
-}
-
-// getAllowanceWithPendingRewards returns the allowance including V2 pending rewards.
-func (ei *elasticProcessor) getAllowanceWithPendingRewards(userAccount state.UserAccountHandler) int64 {
-	allowance := userAccount.GetAllowance()
-	if check.IfNil(ei.kappsController) {
-		return allowance
-	}
-
-	pendingRewards, err := ei.kappsController.GetValidatorsKApp().GetPendingRewards(userAccount.AddressBytes())
-	if err == nil && pendingRewards > 0 {
-		allowance += pendingRewards
-	}
-	return allowance
-}
-
 // dispatchAccountEvents sends account events to the event queue if enabled.
 func dispatchAccountEvents(accountsMap map[string]*data.AccountInfo) {
 	if UseEventQueue && len(accountsMap) > 0 {
@@ -1660,7 +1610,7 @@ func (ei *elasticProcessor) saveAccounts(
 	historyAccountsMap := make(map[string]*data.AccountInfo)
 
 	for _, userAccount := range accountsSlice {
-		acc, err := ei.buildAccountInfo(userAccount, blockTimestamp)
+		acc, err := buildAccountInfo(ei.addressPubkeyConverter, ei.kappsController, userAccount.UserAccount, blockTimestamp)
 		if err != nil {
 			return err
 		}
@@ -1674,8 +1624,9 @@ func (ei *elasticProcessor) saveAccounts(
 		historyAccountsMap[address] = acc
 	}
 
-	dispatchAccountEvents(newAccountsMap)
-	dispatchAccountEvents(updateAccountsMap)
+	// Websocket ACCOUNTS dispatch is performed by eventsProcessor.SaveBlock on
+	// the commit goroutine. No event emission here — keeps the elastic write
+	// path side-effect free for subscribers.
 
 	if err := serializeAccounts(newAccountsMap, buffSlice, accountsIndex); err != nil {
 		return err
@@ -1686,34 +1637,6 @@ func (ei *elasticProcessor) saveAccounts(
 	}
 
 	return ei.saveAccountsHistory(blockTimestamp, historyAccountsMap)
-}
-
-// buildAccountInfo creates an AccountInfo from a user account.
-func (ei *elasticProcessor) buildAccountInfo(userAccount *data.Account, blockTimestamp int64) (*data.AccountInfo, error) {
-	address := ei.addressPubkeyConverter.Encode(userAccount.UserAccount.AddressBytes())
-	permissions := ei.convertPermissions(userAccount.UserAccount.GetPermissions())
-
-	userKDA, err := userAccount.UserAccount.GetUserKDA(kdautils.KLVIdentifier, nil, true)
-	if err != nil {
-		return nil, err
-	}
-
-	return &data.AccountInfo{
-		Address:         address,
-		Nonce:           userAccount.UserAccount.GetNonce(),
-		Name:            string(userAccount.UserAccount.GetName()),
-		RootHash:        hex.EncodeToString(userAccount.UserAccount.GetRootHash()),
-		Balance:         userAccount.UserAccount.GetBalance(kdautils.KLVIdentifier, true),
-		FrozenBalance:   userKDA.FrozenBalance,
-		UnfrozenBalance: calculateUnfrozenBalance(userKDA.Buckets),
-		Allowance:       ei.getAllowanceWithPendingRewards(userAccount.UserAccount),
-		Permissions:     permissions,
-		Timestamp:       toMilliseconds(blockTimestamp),
-		UpdatedAt:       toMilliseconds(blockTimestamp),
-		CodeHash:        hex.EncodeToString(userAccount.UserAccount.GetCodeHash()),
-		CodeMetadata:    hex.EncodeToString(userAccount.UserAccount.GetCodeMetadata()),
-		Foundation:      false,
-	}, nil
 }
 
 func (ei *elasticProcessor) saveAccountsHistory(blockTimestamp int64, accountsInfoMap map[string]*data.AccountInfo) error {

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -327,8 +327,6 @@ func (ei *elasticProcessor) SaveHeader(
 		return err
 	}
 
-	// Websocket BLOCKS dispatch is performed by eventsProcessor.SaveBlock on the
-	// commit goroutine so it is decoupled from elastic write timing/health.
 	return nil
 }
 
@@ -526,11 +524,9 @@ func (ei *elasticProcessor) updateAccountBalance(address string, balance int64, 
 	return ei.elasticClient.DoUpdate(accountsIndex, address, &updateBody)
 }
 
-// SaveTransactions will prepare and save information about a transactions in elasticsearch server.
-// When prepared is a non-nil *data.PreparedBlockData, its contents are reused (single-source-of-truth
-// produced by the events orchestrator on the commit goroutine); otherwise, the legacy path runs
-// prepareTransactionsForDatabase here. Websocket dispatch is NOT performed in this path — the
-// orchestrator owns it so events are decoupled from elastic write success and timing.
+// SaveTransactions saves a block's transactions to elasticsearch. If prepared
+// is a non-nil *data.PreparedBlockData, its contents are reused; otherwise
+// prepareTransactionsForDatabase runs here as a fallback.
 func (ei *elasticProcessor) SaveTransactions(
 	header nodeData.HeaderHandler,
 	pool *indexer.Pool,
@@ -1623,10 +1619,6 @@ func (ei *elasticProcessor) saveAccounts(
 		}
 		historyAccountsMap[address] = acc
 	}
-
-	// Websocket ACCOUNTS dispatch is performed by eventsProcessor.SaveBlock on
-	// the commit goroutine. No event emission here — keeps the elastic write
-	// path side-effect free for subscribers.
 
 	if err := serializeAccounts(newAccountsMap, buffSlice, accountsIndex); err != nil {
 		return err

--- a/indexer/elasticProcessor_test.go
+++ b/indexer/elasticProcessor_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -166,6 +167,43 @@ func TestElasticseachDatabaseSaveHeader_CheckRequestBody(t *testing.T) {
 	require.Nil(t, err)
 }
 
+// TestElasticProcessor_SaveTransactions_FallbackPrepWhenPreparedNil locks in the
+// safety-net contract: when the orchestrator did NOT pre-compute a payload (or
+// is bypassed entirely, e.g., direct test calls), SaveTransactions must run
+// prepareTransactionsForDatabase itself rather than no-op or panic on a nil
+// payload. The bulk write is the observable side effect.
+func TestElasticProcessor_SaveTransactions_FallbackPrepWhenPreparedNil(t *testing.T) {
+	var bulkInvocations int32
+	dbWriter := &imock.DatabaseWriterStub{
+		DoBulkRequestCalled: func(_ *bytes.Buffer, _ string) error {
+			atomic.AddInt32(&bulkInvocations, 1)
+			return nil
+		},
+	}
+
+	contract := transaction.TransferContract{
+		ToAddress: []byte("klv1d05ju9jaj6u99zph0ant9jh7gksg"),
+		Amount:    45,
+	}
+	tx, err := createTransactionHandlerMock(&contract, transaction.TXContract_TransferContractType,
+		[]byte("klv1d05ju9jaj6u99zph0ant9jh7gksf"))
+	require.NoError(t, err)
+
+	header := &dataBlock.Block{
+		Header:   &dataBlock.BlockHeader{Nonce: 7, Timestamp: 100},
+		TxHashes: [][]byte{[]byte("h1")},
+	}
+	pool := &indexer.Pool{
+		Txs:  map[string]nodeData.TransactionHandler{"h1": tx},
+		Logs: []*nodeData.LogData{},
+	}
+
+	ep := newTestElasticSearchDatabase(dbWriter, createMockElasticProcessorArgs())
+	require.NoError(t, ep.SaveTransactions(header, pool, nil))
+	require.Greater(t, atomic.LoadInt32(&bulkInvocations), int32(0),
+		"fallback must run the full indexing pipeline when prepared is nil")
+}
+
 func TestElasticseachSaveTransactions_ShouldReturnErr(t *testing.T) {
 	localErr := errors.New("localErr")
 	arguments := createMockElasticProcessorArgs()
@@ -201,7 +239,7 @@ func TestElasticseachSaveTransactions_ShouldReturnErr(t *testing.T) {
 	logsPool := []*nodeData.LogData{}
 
 	elasticDatabase := newTestElasticSearchDatabase(dbWriter, arguments)
-	err := elasticDatabase.SaveTransactions(header, &indexer.Pool{Txs: txPool, Logs: logsPool})
+	err := elasticDatabase.SaveTransactions(header, &indexer.Pool{Txs: txPool, Logs: logsPool}, nil)
 	require.Equal(t, localErr, err)
 }
 
@@ -269,7 +307,7 @@ func TestUpdateTransaction(t *testing.T) {
 	}
 
 	// insert
-	err = esDatabase.SaveTransactions(body, &indexer.Pool{Txs: txPool})
+	err = esDatabase.SaveTransactions(body, &indexer.Pool{Txs: txPool}, nil)
 	require.Nil(t, err)
 
 	fmt.Println(hex.EncodeToString(txHash1))
@@ -283,7 +321,7 @@ func TestUpdateTransaction(t *testing.T) {
 	body.TxHashes = append(body.TxHashes, txHash3)
 
 	// update
-	err = esDatabase.SaveTransactions(body, &indexer.Pool{Txs: txPool})
+	err = esDatabase.SaveTransactions(body, &indexer.Pool{Txs: txPool}, nil)
 	require.Nil(t, err)
 }
 
@@ -323,7 +361,7 @@ func TestDoBulkRequestLimit(t *testing.T) {
 
 		header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1}}
 
-		err := esDatabase.SaveTransactions(header, &indexer.Pool{Txs: txsPool})
+		err := esDatabase.SaveTransactions(header, &indexer.Pool{Txs: txsPool}, nil)
 		require.Nil(t, err)
 	}
 }
@@ -1096,7 +1134,7 @@ func TestGetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(1000), result)
 	})
 
@@ -1128,7 +1166,7 @@ func TestGetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(2500), result)
 	})
 
@@ -1160,7 +1198,7 @@ func TestGetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(3000), result)
 	})
 
@@ -1192,7 +1230,7 @@ func TestGetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(4000), result)
 	})
 }
@@ -1204,13 +1242,13 @@ func TestConvertPermissions(t *testing.T) {
 	ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
 
 	t.Run("nil permissions returns empty slice", func(t *testing.T) {
-		result := ep.convertPermissions(nil)
+		result := convertPermissions(ep.addressPubkeyConverter, nil)
 		require.Empty(t, result)
 		require.NotNil(t, result)
 	})
 
 	t.Run("empty permissions returns empty slice", func(t *testing.T) {
-		result := ep.convertPermissions([]*state.Permission{})
+		result := convertPermissions(ep.addressPubkeyConverter, []*state.Permission{})
 		require.Empty(t, result)
 	})
 
@@ -1229,7 +1267,7 @@ func TestConvertPermissions(t *testing.T) {
 			},
 		}
 
-		result := ep.convertPermissions(perms)
+		result := convertPermissions(ep.addressPubkeyConverter, perms)
 		require.Len(t, result, 1)
 		require.Equal(t, int32(1), result[0].ID)
 		require.Equal(t, int32(state.Permission_Owner), result[0].Type)
@@ -1328,7 +1366,11 @@ func TestDispatchAccountEvents(t *testing.T) {
 	})
 }
 
-func TestElasticProcessor_SaveHeader_DispatchesEventWhenQueueEnabled(t *testing.T) {
+// TestElasticProcessor_SaveHeader_DoesNotDispatchEvents verifies the
+// centralization invariant: elasticProcessor.SaveHeader must NOT emit a BLOCKS
+// event. The orchestrator (eventsProcessor.SaveBlock) owns BLOCKS dispatch on
+// the commit goroutine, decoupled from elastic write timing/health.
+func TestElasticProcessor_SaveHeader_DoesNotDispatchEvents(t *testing.T) {
 	originalUseEventQueue := UseEventQueue
 	originalEventQueue := EventQueue
 	testQueue := make(chan Event, 10)
@@ -1355,16 +1397,14 @@ func TestElasticProcessor_SaveHeader_DispatchesEventWhenQueueEnabled(t *testing.
 	err := elasticDatabase.SaveHeader(header, signer, 1, []string{})
 	require.Nil(t, err)
 
-	select {
-	case event := <-testQueue:
-		require.Equal(t, BLOCKS, event.EvType)
-		require.NotNil(t, event.Message)
-	default:
-		t.Fatal("expected block event to be dispatched")
-	}
+	require.Len(t, testQueue, 0, "elasticProcessor must not enqueue BLOCKS events; dispatch is owned by eventsProcessor")
 }
 
-func TestElasticProcessor_SaveTransactions_DispatchesEventsWhenQueueEnabled(t *testing.T) {
+// TestElasticProcessor_SaveTransactions_DoesNotDispatchEvents verifies the
+// centralization invariant: elasticProcessor.SaveTransactions must NOT emit
+// USER_TRANSACTIONS/TRANSACTIONS events even when UseEventQueue is enabled.
+// Those events are owned by eventsProcessor.SaveBlock on the commit goroutine.
+func TestElasticProcessor_SaveTransactions_DoesNotDispatchEvents(t *testing.T) {
 	originalUseEventQueue := UseEventQueue
 	originalEventQueue := EventQueue
 	testQueue := make(chan Event, 10)
@@ -1402,17 +1442,10 @@ func TestElasticProcessor_SaveTransactions_DispatchesEventsWhenQueueEnabled(t *t
 	logsPool := []*nodeData.LogData{}
 
 	elasticDatabase := newTestElasticSearchDatabase(dbWriter, arguments)
-	err := elasticDatabase.SaveTransactions(header, &indexer.Pool{Txs: txPool, Logs: logsPool})
+	err := elasticDatabase.SaveTransactions(header, &indexer.Pool{Txs: txPool, Logs: logsPool}, nil)
 	require.Nil(t, err)
 
-	userTxEvent := <-testQueue
-	require.Equal(t, USER_TRANSACTIONS, userTxEvent.EvType)
-	txs, ok := userTxEvent.Message.([]*data.Transaction)
-	require.True(t, ok)
-	require.Len(t, txs, 1)
-
-	txEvent := <-testQueue
-	require.Equal(t, TRANSACTIONS, txEvent.EvType)
+	require.Len(t, testQueue, 0, "elasticProcessor must not enqueue events; events are dispatched by eventsProcessor")
 }
 
 func TestBuildAccountInfo(t *testing.T) {
@@ -1466,7 +1499,7 @@ func TestBuildAccountInfo(t *testing.T) {
 			IsSender:    true,
 		}
 
-		result, err := ep.buildAccountInfo(account, 1234567890)
+		result, err := buildAccountInfo(ep.addressPubkeyConverter, ep.kappsController, account.UserAccount, 1234567890)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -1500,7 +1533,7 @@ func TestBuildAccountInfo(t *testing.T) {
 			IsSender:    true,
 		}
 
-		result, err := ep.buildAccountInfo(account, 1234567890)
+		result, err := buildAccountInfo(ep.addressPubkeyConverter, ep.kappsController, account.UserAccount, 1234567890)
 
 		require.Error(t, err)
 		require.Nil(t, result)
@@ -1567,7 +1600,7 @@ func TestBuildAccountInfo(t *testing.T) {
 			IsSender:    true,
 		}
 
-		result, err := ep.buildAccountInfo(account, 1234567890)
+		result, err := buildAccountInfo(ep.addressPubkeyConverter, ep.kappsController, account.UserAccount, 1234567890)
 
 		require.NoError(t, err)
 		require.NotNil(t, result)

--- a/indexer/elasticProcessor_test.go
+++ b/indexer/elasticProcessor_test.go
@@ -167,11 +167,7 @@ func TestElasticseachDatabaseSaveHeader_CheckRequestBody(t *testing.T) {
 	require.Nil(t, err)
 }
 
-// TestElasticProcessor_SaveTransactions_FallbackPrepWhenPreparedNil locks in the
-// safety-net contract: when the orchestrator did NOT pre-compute a payload (or
-// is bypassed entirely, e.g., direct test calls), SaveTransactions must run
-// prepareTransactionsForDatabase itself rather than no-op or panic on a nil
-// payload. The bulk write is the observable side effect.
+// Fallback: when Prepared is nil, SaveTransactions must run prep itself.
 func TestElasticProcessor_SaveTransactions_FallbackPrepWhenPreparedNil(t *testing.T) {
 	var bulkInvocations int32
 	dbWriter := &imock.DatabaseWriterStub{
@@ -1366,10 +1362,6 @@ func TestDispatchAccountEvents(t *testing.T) {
 	})
 }
 
-// TestElasticProcessor_SaveHeader_DoesNotDispatchEvents verifies the
-// centralization invariant: elasticProcessor.SaveHeader must NOT emit a BLOCKS
-// event. The orchestrator (eventsProcessor.SaveBlock) owns BLOCKS dispatch on
-// the commit goroutine, decoupled from elastic write timing/health.
 func TestElasticProcessor_SaveHeader_DoesNotDispatchEvents(t *testing.T) {
 	originalUseEventQueue := UseEventQueue
 	originalEventQueue := EventQueue
@@ -1400,10 +1392,6 @@ func TestElasticProcessor_SaveHeader_DoesNotDispatchEvents(t *testing.T) {
 	require.Len(t, testQueue, 0, "elasticProcessor must not enqueue BLOCKS events; dispatch is owned by eventsProcessor")
 }
 
-// TestElasticProcessor_SaveTransactions_DoesNotDispatchEvents verifies the
-// centralization invariant: elasticProcessor.SaveTransactions must NOT emit
-// USER_TRANSACTIONS/TRANSACTIONS events even when UseEventQueue is enabled.
-// Those events are owned by eventsProcessor.SaveBlock on the commit goroutine.
 func TestElasticProcessor_SaveTransactions_DoesNotDispatchEvents(t *testing.T) {
 	originalUseEventQueue := UseEventQueue
 	originalEventQueue := EventQueue

--- a/indexer/eventsProcessor.go
+++ b/indexer/eventsProcessor.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core/kapp"
@@ -64,52 +65,54 @@ func checkArgEventsProcessor(arguments ArgEventsProcessor) error {
 }
 
 func (ep *eventsProcessor) Enabled() bool {
-	return UseEventQueue || (ep.indexer != nil && !ep.indexer.IsNilIndexer())
+	return UseEventQueue || ep.indexerEnabled()
 }
 
-// SaveBlock is the single per-block orchestrator. It runs on the commit
-// goroutine and is the only place that calls prepareTransactionsForDatabase
-// for a given block. Websocket events are enqueued here (non-blocking
-// trySendEvent) so subscribers see consistent timing across configurations,
-// and the prepared payload is then forwarded to the indexer via
-// ArgsSaveBlockData.Prepared so the elastic worker never re-preps.
+func (ep *eventsProcessor) indexerEnabled() bool {
+	return !check.IfNil(ep.indexer) && !ep.indexer.IsNilIndexer()
+}
+
 func (ep *eventsProcessor) SaveBlock(args *indexerData.ArgsSaveBlockData) {
 	wsEnabled := UseEventQueue
-	indexerEnabled := !check.IfNil(ep.indexer) && !ep.indexer.IsNilIndexer()
+	indexerEnabled := ep.indexerEnabled()
 	if !wsEnabled && !indexerEnabled {
 		return
 	}
 
-	var prepared *data.PreparedBlockData
-	if args.TransactionsPool != nil && len(args.TransactionsPool.Txs) > 0 {
-		txs, txsMap, ad, err := ep.prepareTransactionsForDatabase(args.Header, args.TransactionsPool)
-		if err != nil {
-			// Per-block prep failure: ws subscribers get no TXN/ACCOUNT events for this
-			// block, and the indexer worker's fallback re-prep will hit the same error.
-			// Loud signal so it shows up in node operator alerting.
-			log.Error("eventsProcessor.SaveBlock: prepare failed", "nonce", args.Header.GetNonce(), "error", err)
-		} else {
-			prepared = &data.PreparedBlockData{Txs: txs, TxsMap: txsMap, Altered: ad}
-		}
-	}
-
+	// Prep runs on the commit goroutine only when websocket subscribers need
+	// it. Indexer-only nodes let the elastic worker re-prep on its own
+	// goroutine via the fallback in elasticProcessor.SaveTransactions.
 	if wsEnabled {
+		prepared := ep.prepare(args)
 		ep.dispatchBlockEvent(args)
 		if prepared != nil {
 			ep.dispatchTransactionEvents(prepared.Txs)
 			ep.dispatchAccountEventsFromAlteredAccounts(args.Header.GetTimestamp(), prepared.Altered.Accounts)
 		}
+		if indexerEnabled {
+			args.Prepared = prepared
+		}
 	}
 
 	if indexerEnabled {
-		args.Prepared = prepared
 		ep.indexer.SaveBlock(args)
 	}
 }
 
+func (ep *eventsProcessor) prepare(args *indexerData.ArgsSaveBlockData) *data.PreparedBlockData {
+	if args.TransactionsPool == nil || len(args.TransactionsPool.Txs) == 0 {
+		return nil
+	}
+	txs, txsMap, ad, err := ep.prepareTransactionsForDatabase(args.Header, args.TransactionsPool)
+	if err != nil {
+		log.Error("eventsProcessor.SaveBlock: prepare failed", "nonce", args.Header.GetNonce(), "error", err)
+		return nil
+	}
+	return &data.PreparedBlockData{Txs: txs, TxsMap: txsMap, Altered: ad}
+}
+
 func (ep *eventsProcessor) dispatchBlockEvent(args *indexerData.ArgsSaveBlockData) {
-	// Use byte-size (not tx count) so the BLOCKS event payload's SizeTxs/VirtualBlockSize
-	// match what the elastic indexer writes via workItems.ComputeSizeOfTxs in SaveHeader.
+	// byte-size to match SaveHeader's SizeTxs.
 	txsSize := 0
 	if args.TransactionsPool != nil {
 		txsSize = workItems.ComputeSizeOfTxs(args.TransactionsPool)
@@ -146,6 +149,9 @@ func (ep *eventsProcessor) dispatchTransactionEvents(txs []*data.Transaction) {
 	})
 }
 
+// dispatchAccountEventsFromAlteredAccounts uses GetExistingAccount so that
+// addresses with no persisted state (e.g. ZeroAddress) are silently dropped
+// rather than broadcast as empty ghost accounts.
 func (ep *eventsProcessor) dispatchAccountEventsFromAlteredAccounts(blockTimestamp int64, alteredAccounts data.AlteredAccountsHandler) {
 	if check.IfNil(ep.accountsDB) || alteredAccounts.Len() == 0 {
 		return
@@ -153,33 +159,12 @@ func (ep *eventsProcessor) dispatchAccountEventsFromAlteredAccounts(blockTimesta
 
 	accountsMap := make(map[string]*data.AccountInfo, alteredAccounts.Len())
 	for address := range alteredAccounts.GetAll() {
-		addrBytes, err := ep.addressPubkeyConverter.Decode(address)
+		info, err := ep.buildAlteredAccountInfo(address, blockTimestamp)
 		if err != nil {
-			log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot decode address", "address", address, "error", err)
+			log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts", "address", address, "error", err)
 			continue
 		}
-
-		// GetExistingAccount (vs LoadAccount used by the indexer): we do not
-		// want to broadcast empty ghost-account payloads for addresses that
-		// have no persisted state (e.g., ZeroAddress); a missing account is
-		// a no-op for subscribers.
-		accountHandler, err := ep.accountsDB.GetExistingAccount(addrBytes)
-		if err != nil {
-			if !errors.Is(err, common.ErrAccNotFound) {
-				log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot load account", "address", address, "error", err)
-			}
-			continue
-		}
-
-		userAccount, ok := accountHandler.(dataState.UserAccountHandler)
-		if !ok {
-			log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot cast AccountHandler to UserAccountHandler", "address", address)
-			continue
-		}
-
-		info, err := buildAccountInfo(ep.addressPubkeyConverter, ep.kappsController, userAccount, blockTimestamp)
-		if err != nil {
-			log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot build account info", "address", address, "error", err)
+		if info == nil {
 			continue
 		}
 		accountsMap[info.Address] = info
@@ -192,38 +177,59 @@ func (ep *eventsProcessor) dispatchAccountEventsFromAlteredAccounts(blockTimesta
 	dispatchAccountEvents(accountsMap)
 }
 
+// buildAlteredAccountInfo resolves an altered address into an AccountInfo.
+// Returns (nil, nil) when the account doesn't exist — a normal no-op skip.
+func (ep *eventsProcessor) buildAlteredAccountInfo(address string, blockTimestamp int64) (*data.AccountInfo, error) {
+	addrBytes, err := ep.addressPubkeyConverter.Decode(address)
+	if err != nil {
+		return nil, fmt.Errorf("decode address: %w", err)
+	}
+
+	accountHandler, err := ep.accountsDB.GetExistingAccount(addrBytes)
+	if err != nil {
+		if errors.Is(err, common.ErrAccNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("load account: %w", err)
+	}
+
+	userAccount, ok := accountHandler.(dataState.UserAccountHandler)
+	if !ok {
+		return nil, fmt.Errorf("account is not a UserAccountHandler")
+	}
+
+	return buildAccountInfo(ep.addressPubkeyConverter, ep.kappsController, userAccount, blockTimestamp)
+}
+
 func (ep *eventsProcessor) RevertIndexedBlock(header nodeData.HeaderHandler) {
-	if ep.indexer == nil || ep.indexer.IsNilIndexer() {
+	if !ep.indexerEnabled() {
 		return
 	}
 	ep.indexer.RevertIndexedBlock(header)
 }
 
 func (ep *eventsProcessor) SaveValidatorsRating(validators []kapp.ValidatorAccountInfoHandler) {
-	if ep.indexer == nil || ep.indexer.IsNilIndexer() {
+	if !ep.indexerEnabled() {
 		return
 	}
 	ep.indexer.SavePeersAccounts(validators)
 }
 
 func (ep *eventsProcessor) SaveEpochInfo(epoch uint32, validators []kapp.ValidatorAccountInfoHandler) {
-	if ep.indexer == nil || ep.indexer.IsNilIndexer() {
+	if !ep.indexerEnabled() {
 		return
 	}
 	ep.indexer.SaveEpochInfo(epoch, validators)
 }
 
 func (ep *eventsProcessor) UpdateProposalsAndParameters(proposalIDs []string) {
-	if ep.indexer == nil || ep.indexer.IsNilIndexer() {
+	if !ep.indexerEnabled() {
 		return
 	}
 	ep.indexer.UpdateProposalsAndParameters(proposalIDs)
 }
 
 func (ep *eventsProcessor) SaveAccounts(blockTimestamp int64, acc []dataState.UserAccountHandler) {
-	// Websocket dispatch is independent of indexer enablement — fire whenever
-	// the event queue is on. The duplicate dispatch in elasticProcessor.saveAccounts
-	// has been removed so this is the single source of ACCOUNTS events.
 	if UseEventQueue && len(acc) > 0 {
 		accountsMap := make(map[string]*data.AccountInfo, len(acc))
 		for _, userAccount := range acc {
@@ -237,7 +243,7 @@ func (ep *eventsProcessor) SaveAccounts(blockTimestamp int64, acc []dataState.Us
 		dispatchAccountEvents(accountsMap)
 	}
 
-	if ep.indexer == nil || ep.indexer.IsNilIndexer() {
+	if !ep.indexerEnabled() {
 		return
 	}
 	ep.indexer.SaveAccounts(blockTimestamp, acc)

--- a/indexer/eventsProcessor.go
+++ b/indexer/eventsProcessor.go
@@ -1,16 +1,15 @@
 package indexer
 
 import (
-	"encoding/hex"
+	"errors"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core/kapp"
-	"github.com/klever-io/klever-go/core/process/kda/kdautils"
 	nodeData "github.com/klever-io/klever-go/data"
 	indexerData "github.com/klever-io/klever-go/data/indexer"
 	dataState "github.com/klever-io/klever-go/data/state"
-	dataTx "github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/indexer/data"
+	"github.com/klever-io/klever-go/indexer/workItems"
 	"github.com/klever-io/klever-go/tools/check"
 )
 
@@ -19,6 +18,7 @@ type eventsProcessor struct {
 	indexer         Indexer
 	parser          *dataParser
 	kappsController kapp.KAppController
+	accountsDB      dataState.AccountsAdapter
 }
 
 func NewEventsProcessor(arguments ArgEventsProcessor) (*eventsProcessor, error) {
@@ -41,6 +41,7 @@ func NewEventsProcessor(arguments ArgEventsProcessor) (*eventsProcessor, error) 
 			marshalizer: arguments.Marshalizer,
 		},
 		kappsController: arguments.KAppController,
+		accountsDB:      arguments.AccountsDB,
 	}
 
 	return ep, nil
@@ -66,26 +67,52 @@ func (ep *eventsProcessor) Enabled() bool {
 	return UseEventQueue || (ep.indexer != nil && !ep.indexer.IsNilIndexer())
 }
 
+// SaveBlock is the single per-block orchestrator. It runs on the commit
+// goroutine and is the only place that calls prepareTransactionsForDatabase
+// for a given block. Websocket events are enqueued here (non-blocking
+// trySendEvent) so subscribers see consistent timing across configurations,
+// and the prepared payload is then forwarded to the indexer via
+// ArgsSaveBlockData.Prepared so the elastic worker never re-preps.
 func (ep *eventsProcessor) SaveBlock(args *indexerData.ArgsSaveBlockData) {
-	ep.dispatchWebsocketEvents(args)
-	ep.dispatchToIndexer(args)
-}
-
-func (ep *eventsProcessor) dispatchWebsocketEvents(args *indexerData.ArgsSaveBlockData) {
-	if !UseEventQueue {
+	wsEnabled := UseEventQueue
+	indexerEnabled := !check.IfNil(ep.indexer) && !ep.indexer.IsNilIndexer()
+	if !wsEnabled && !indexerEnabled {
 		return
 	}
 
-	if ep.indexer == nil || ep.indexer.IsNilIndexer() {
+	var prepared *data.PreparedBlockData
+	if args.TransactionsPool != nil && len(args.TransactionsPool.Txs) > 0 {
+		txs, txsMap, ad, err := ep.prepareTransactionsForDatabase(args.Header, args.TransactionsPool)
+		if err != nil {
+			// Per-block prep failure: ws subscribers get no TXN/ACCOUNT events for this
+			// block, and the indexer worker's fallback re-prep will hit the same error.
+			// Loud signal so it shows up in node operator alerting.
+			log.Error("eventsProcessor.SaveBlock: prepare failed", "nonce", args.Header.GetNonce(), "error", err)
+		} else {
+			prepared = &data.PreparedBlockData{Txs: txs, TxsMap: txsMap, Altered: ad}
+		}
+	}
+
+	if wsEnabled {
 		ep.dispatchBlockEvent(args)
-		ep.processTransactionEvents(args.Header, args.TransactionsPool)
+		if prepared != nil {
+			ep.dispatchTransactionEvents(prepared.Txs)
+			ep.dispatchAccountEventsFromAlteredAccounts(args.Header.GetTimestamp(), prepared.Altered.Accounts)
+		}
+	}
+
+	if indexerEnabled {
+		args.Prepared = prepared
+		ep.indexer.SaveBlock(args)
 	}
 }
 
 func (ep *eventsProcessor) dispatchBlockEvent(args *indexerData.ArgsSaveBlockData) {
+	// Use byte-size (not tx count) so the BLOCKS event payload's SizeTxs/VirtualBlockSize
+	// match what the elastic indexer writes via workItems.ComputeSizeOfTxs in SaveHeader.
 	txsSize := 0
 	if args.TransactionsPool != nil {
-		txsSize = len(args.TransactionsPool.Txs)
+		txsSize = workItems.ComputeSizeOfTxs(args.TransactionsPool)
 	}
 
 	serializedBlock, _, err := ep.parser.getSerializedElasticBlockAndHeaderHash(
@@ -105,23 +132,10 @@ func (ep *eventsProcessor) dispatchBlockEvent(args *indexerData.ArgsSaveBlockDat
 	})
 }
 
-func (ep *eventsProcessor) dispatchToIndexer(args *indexerData.ArgsSaveBlockData) {
-	if ep.indexer == nil || ep.indexer.IsNilIndexer() {
-		return
-	}
-	ep.indexer.SaveBlock(args)
-}
-
-func (ep *eventsProcessor) processTransactionEvents(header nodeData.HeaderHandler, pool *indexerData.Pool) {
-	if pool == nil || len(pool.Txs) == 0 {
-		return
-	}
-
-	txs := ep.prepareTransactionsForEvents(header, pool)
+func (ep *eventsProcessor) dispatchTransactionEvents(txs []*data.Transaction) {
 	if len(txs) == 0 {
 		return
 	}
-
 	trySendEvent(Event{
 		EvType:  USER_TRANSACTIONS,
 		Message: txs,
@@ -132,27 +146,50 @@ func (ep *eventsProcessor) processTransactionEvents(header nodeData.HeaderHandle
 	})
 }
 
-func (ep *eventsProcessor) prepareTransactionsForEvents(header nodeData.HeaderHandler, pool *indexerData.Pool) []*data.Transaction {
-	txs := make([]*data.Transaction, 0, len(pool.Txs))
-
-	for txHash, txHandler := range pool.Txs {
-		tx, ok := txHandler.(*dataTx.Transaction)
-		if !ok {
-			continue
-		}
-
-		hash := hex.EncodeToString([]byte(txHash))
-		dbTx := ep.BuildTransaction(tx, hash, header)
-		if dbTx == nil {
-			continue
-		}
-
-		_ = ep.DecodeContract(dbTx, tx, nil, nil, nil, header.GetTimestamp())
-
-		txs = append(txs, dbTx)
+func (ep *eventsProcessor) dispatchAccountEventsFromAlteredAccounts(blockTimestamp int64, alteredAccounts data.AlteredAccountsHandler) {
+	if check.IfNil(ep.accountsDB) || alteredAccounts.Len() == 0 {
+		return
 	}
 
-	return txs
+	accountsMap := make(map[string]*data.AccountInfo, alteredAccounts.Len())
+	for address := range alteredAccounts.GetAll() {
+		addrBytes, err := ep.addressPubkeyConverter.Decode(address)
+		if err != nil {
+			log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot decode address", "address", address, "error", err)
+			continue
+		}
+
+		// GetExistingAccount (vs LoadAccount used by the indexer): we do not
+		// want to broadcast empty ghost-account payloads for addresses that
+		// have no persisted state (e.g., ZeroAddress); a missing account is
+		// a no-op for subscribers.
+		accountHandler, err := ep.accountsDB.GetExistingAccount(addrBytes)
+		if err != nil {
+			if !errors.Is(err, common.ErrAccNotFound) {
+				log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot load account", "address", address, "error", err)
+			}
+			continue
+		}
+
+		userAccount, ok := accountHandler.(dataState.UserAccountHandler)
+		if !ok {
+			log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot cast AccountHandler to UserAccountHandler", "address", address)
+			continue
+		}
+
+		info, err := buildAccountInfo(ep.addressPubkeyConverter, ep.kappsController, userAccount, blockTimestamp)
+		if err != nil {
+			log.Warn("eventsProcessor.dispatchAccountEventsFromAlteredAccounts: cannot build account info", "address", address, "error", err)
+			continue
+		}
+		accountsMap[info.Address] = info
+	}
+
+	if len(accountsMap) == 0 {
+		return
+	}
+
+	dispatchAccountEvents(accountsMap)
 }
 
 func (ep *eventsProcessor) RevertIndexedBlock(header nodeData.HeaderHandler) {
@@ -184,32 +221,18 @@ func (ep *eventsProcessor) UpdateProposalsAndParameters(proposalIDs []string) {
 }
 
 func (ep *eventsProcessor) SaveAccounts(blockTimestamp int64, acc []dataState.UserAccountHandler) {
-	if UseEventQueue && len(acc) > 0 && (ep.indexer == nil || ep.indexer.IsNilIndexer()) {
+	// Websocket dispatch is independent of indexer enablement — fire whenever
+	// the event queue is on. The duplicate dispatch in elasticProcessor.saveAccounts
+	// has been removed so this is the single source of ACCOUNTS events.
+	if UseEventQueue && len(acc) > 0 {
 		accountsMap := make(map[string]*data.AccountInfo, len(acc))
 		for _, userAccount := range acc {
-			address := ep.addressPubkeyConverter.Encode(userAccount.AddressBytes())
-
-			userKDA, err := userAccount.GetUserKDA(kdautils.KLVIdentifier, nil, true)
+			info, err := buildAccountInfo(ep.addressPubkeyConverter, ep.kappsController, userAccount, blockTimestamp)
 			if err != nil {
 				log.Warn("eventsProcessor.SaveAccounts", "error", err.Error())
 				continue
 			}
-
-			accountsMap[address] = &data.AccountInfo{
-				Address:         address,
-				Nonce:           userAccount.GetNonce(),
-				Name:            string(userAccount.GetName()),
-				RootHash:        hex.EncodeToString(userAccount.GetRootHash()),
-				Balance:         userAccount.GetBalance(kdautils.KLVIdentifier, true),
-				FrozenBalance:   userKDA.FrozenBalance,
-				UnfrozenBalance: calculateUnfrozenBalance(userKDA.Buckets),
-				Allowance:       ep.getAllowanceWithPendingRewards(userAccount),
-				Permissions:     ep.convertPermissions(userAccount.GetPermissions()),
-				Timestamp:       toMilliseconds(blockTimestamp),
-				UpdatedAt:       toMilliseconds(blockTimestamp),
-				CodeHash:        hex.EncodeToString(userAccount.GetCodeHash()),
-				CodeMetadata:    hex.EncodeToString(userAccount.GetCodeMetadata()),
-			}
+			accountsMap[info.Address] = info
 		}
 		dispatchAccountEvents(accountsMap)
 	}
@@ -218,46 +241,6 @@ func (ep *eventsProcessor) SaveAccounts(blockTimestamp int64, acc []dataState.Us
 		return
 	}
 	ep.indexer.SaveAccounts(blockTimestamp, acc)
-}
-
-func (ep *eventsProcessor) convertPermissions(perms []*dataState.Permission) []data.Permissions {
-	permissions := make([]data.Permissions, 0, len(perms))
-	for _, p := range perms {
-		keys := make([]data.PermissionKey, 0, len(p.Signers))
-		for _, k := range p.Signers {
-			keys = append(keys, data.PermissionKey{
-				Address: ep.addressPubkeyConverter.Encode(k.Address),
-				Weight:  k.Weight,
-			})
-		}
-		permissions = append(permissions, data.Permissions{
-			ID:             p.ID,
-			Type:           int32(p.Type),
-			PermissionName: p.PermissionName,
-			Threshold:      p.Threshold,
-			Operations:     hex.EncodeToString(p.Operations),
-			Signers:        keys,
-		})
-	}
-	return permissions
-}
-
-func (ep *eventsProcessor) getAllowanceWithPendingRewards(userAccount dataState.UserAccountHandler) int64 {
-	allowance := userAccount.GetAllowance()
-	if check.IfNil(ep.kappsController) {
-		return allowance
-	}
-
-	validatorsKApp := ep.kappsController.GetValidatorsKApp()
-	if check.IfNil(validatorsKApp) {
-		return allowance
-	}
-
-	pendingRewards, err := validatorsKApp.GetPendingRewards(userAccount.AddressBytes())
-	if err == nil && pendingRewards > 0 {
-		allowance += pendingRewards
-	}
-	return allowance
 }
 
 func (ep *eventsProcessor) IsInterfaceNil() bool {

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -1,12 +1,15 @@
 package indexer
 
 import (
+	"encoding/hex"
 	"errors"
 	"sync/atomic"
 	"testing"
 
+	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core/kapp"
+	ptx "github.com/klever-io/klever-go/core/process/transaction"
 	nodeData "github.com/klever-io/klever-go/data"
 	dataBlock "github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/indexer"
@@ -87,6 +90,33 @@ func createTestEventsProcessorWithIndexer(idx Indexer) *eventsProcessor {
 	return ep
 }
 
+func createTestEventsProcessorWithKApp(t *testing.T, ctrl kapp.KAppController) *eventsProcessor {
+	t.Helper()
+	ep, err := NewEventsProcessor(ArgEventsProcessor{
+		Marshalizer:              &mock.MarshalizerMock{},
+		Hasher:                   &mock.HasherMock{},
+		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
+		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
+		Indexer:                  nil,
+		KAppController:           ctrl,
+	})
+	require.NoError(t, err)
+	return ep
+}
+
+func createTestEventsProcessorWithAccountsDB(t *testing.T, accountsDB state.AccountsAdapter) *eventsProcessor {
+	t.Helper()
+	ep, err := NewEventsProcessor(ArgEventsProcessor{
+		Marshalizer:              &mock.MarshalizerMock{},
+		Hasher:                   &mock.HasherMock{},
+		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
+		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
+		AccountsDB:               accountsDB,
+	})
+	require.NoError(t, err)
+	return ep
+}
+
 func createTestAccountStub() *mock.UserAccountHandlerStub {
 	return &mock.UserAccountHandlerStub{
 		AddressBytesCalled:    func() []byte { return []byte("testaddr") },
@@ -119,6 +149,67 @@ func saveAndRestoreEventQueue(t *testing.T, useQueue bool) chan Event {
 		EventQueue = originalEventQueue
 	})
 	return testQueue
+}
+
+func drainTestQueue(ch chan Event) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+// pad32 returns a 32-byte slice with s copied into it, zero-padded.
+func pad32(s string) []byte {
+	b := make([]byte, 32)
+	copy(b, s)
+	return b
+}
+
+// bareTransactionWithReceipts creates a minimal transaction (no contracts) carrying
+// the given receipts, exercising the receipt-based account-detection path.
+func bareTransactionWithReceipts(senderBytes []byte, receipts ...*transaction.Transaction_Receipt) *transaction.Transaction {
+	return &transaction.Transaction{
+		Signature: [][]byte{[]byte("sig")},
+		RawData:   &transaction.Transaction_Raw{Sender: senderBytes},
+		Result:    transaction.Transaction_SUCCESS,
+		Receipts:  receipts,
+	}
+}
+
+// makeReceipt builds a Transaction_Receipt where data[0] is {receiptType, cID=0}
+// followed by fields.
+func makeReceipt(receiptType ptx.ReceiptType, fields ...[]byte) *transaction.Transaction_Receipt {
+	d := make([][]byte, 0, 1+len(fields))
+	d = append(d, []byte{byte(receiptType), 0})
+	d = append(d, fields...)
+	return &transaction.Transaction_Receipt{Data: d}
+}
+
+// runReceiptAddressTest is a shared helper for single-address receipt tests: it
+// runs SaveBlock and asserts that expectedAddrBytes was loaded from accountsDB.
+func runReceiptAddressTest(t *testing.T, tx *transaction.Transaction, expectedAddrBytes []byte) {
+	t.Helper()
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	loaded := make(map[string]struct{})
+	acc := createTestAccountStub()
+	ep := createTestEventsProcessorWithAccountsDB(t, &mock.AccountsStub{
+		GetExistingAccountCalled: func(addrBytes []byte) (state.AccountHandler, error) {
+			loaded[hex.EncodeToString(addrBytes)] = struct{}{}
+			return acc, nil
+		},
+	})
+
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100}}
+	pool := &indexer.Pool{Txs: map[string]nodeData.TransactionHandler{"tx1": tx}}
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{Header: header, TransactionsPool: pool})
+	drainTestQueue(testQueue)
+
+	require.Contains(t, loaded, hex.EncodeToString(expectedAddrBytes))
 }
 
 func TestNewEventsProcessor(t *testing.T) {
@@ -260,7 +351,8 @@ func TestEventsProcessor_SaveBlock_DispatchesTransactionEvents(t *testing.T) {
 		ToAddress: []byte("receiver"),
 		Amount:    100,
 	}
-	tx, _ := createTransactionHandlerMock(&contract, transaction.TXContract_TransferContractType, []byte("sender"))
+	tx, err := createTransactionHandlerMock(&contract, transaction.TXContract_TransferContractType, []byte("sender"))
+	require.NoError(t, err)
 
 	header := &dataBlock.Block{
 		Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100},
@@ -290,7 +382,9 @@ func TestEventsProcessor_SaveBlock_DispatchesTransactionEvents(t *testing.T) {
 	require.Equal(t, TRANSACTIONS, txEvent.EvType)
 }
 
-func TestEventsProcessor_SaveBlock_SkipsWebsocketWhenIndexerActive(t *testing.T) {
+// With centralization, BLOCKS now fires on every websocket-enabled config —
+// including indexer-active nodes — directly from the commit goroutine.
+func TestEventsProcessor_SaveBlock_DispatchesBlocksEventWithIndexerActive(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
 
 	var saveBlockCalled int32
@@ -311,9 +405,12 @@ func TestEventsProcessor_SaveBlock_SkipsWebsocketWhenIndexerActive(t *testing.T)
 		TransactionsPool: &indexer.Pool{},
 	})
 
+	ev := <-testQueue
+	require.Equal(t, BLOCKS, ev.EvType)
+
 	select {
-	case <-testQueue:
-		t.Fatal("expected no websocket events when indexer is active")
+	case extra := <-testQueue:
+		t.Fatalf("unexpected extra event: %s", extra.EvType)
 	default:
 	}
 
@@ -341,6 +438,274 @@ func TestEventsProcessor_SaveBlock_NilPool(t *testing.T) {
 		t.Fatal("expected no tx events with nil pool")
 	default:
 	}
+}
+
+func TestEventsProcessor_SaveBlock_DispatchesAccountEvents(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	acc := createTestAccountStub()
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			return acc, nil
+		},
+	}
+	ep := createTestEventsProcessorWithAccountsDB(t, accountsDB)
+
+	contract := transaction.TransferContract{
+		ToAddress: []byte("receiver"),
+		Amount:    100,
+	}
+	tx, err := createTransactionHandlerMock(&contract, transaction.TXContract_TransferContractType, []byte("sender"))
+	require.NoError(t, err)
+
+	header := &dataBlock.Block{
+		Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100},
+	}
+	pool := &indexer.Pool{
+		Txs: map[string]nodeData.TransactionHandler{
+			"txHash1": tx,
+		},
+	}
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{
+		Header:           header,
+		TransactionsPool: pool,
+	})
+
+	var accountEvent *Event
+	for i := 0; i < 10; i++ {
+		select {
+		case ev := <-testQueue:
+			if ev.EvType == ACCOUNTS {
+				evCopy := ev
+				accountEvent = &evCopy
+			}
+		default:
+			i = 10
+		}
+	}
+	require.NotNil(t, accountEvent, "expected an ACCOUNTS event to be dispatched")
+	accountsMap, ok := accountEvent.Message.(map[string]*data.AccountInfo)
+	require.True(t, ok)
+	require.NotEmpty(t, accountsMap)
+}
+
+func TestEventsProcessor_SaveBlock_SkipsAccountEventsWhenNoAccountsDB(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+	ep := createTestEventsProcessor(t)
+
+	contract := transaction.TransferContract{
+		ToAddress: []byte("receiver"),
+		Amount:    100,
+	}
+	tx, err := createTransactionHandlerMock(&contract, transaction.TXContract_TransferContractType, []byte("sender"))
+	require.NoError(t, err)
+
+	header := &dataBlock.Block{
+		Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100},
+	}
+	pool := &indexer.Pool{
+		Txs: map[string]nodeData.TransactionHandler{
+			"txHash1": tx,
+		},
+	}
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{
+		Header:           header,
+		TransactionsPool: pool,
+	})
+
+	for i := 0; i < 10; i++ {
+		select {
+		case ev := <-testQueue:
+			require.NotEqual(t, ACCOUNTS, ev.EvType, "expected no ACCOUNTS event when accountsDB is nil")
+		default:
+			i = 10
+		}
+	}
+}
+
+// With centralization: indexer-active path also dispatches BLOCKS, TX, and
+// ACCOUNTS websocket events, AND the indexer receives a non-nil Prepared
+// payload (no duplicate prep downstream). This is the (true, true) cell of
+// the (UseEventQueue, indexer) test matrix.
+func TestEventsProcessor_SaveBlock_DispatchesAllEventsAndPreparesIndexer(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	acc := createTestAccountStub()
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			return acc, nil
+		},
+	}
+
+	var receivedPrepared any
+	var saveBlockCount int32
+	idx := &indexerStub{
+		isNilIndexer: false,
+		saveBlockCalled: func(args *indexer.ArgsSaveBlockData) {
+			atomic.AddInt32(&saveBlockCount, 1)
+			receivedPrepared = args.Prepared
+		},
+	}
+
+	ep, err := NewEventsProcessor(ArgEventsProcessor{
+		Marshalizer:              &mock.MarshalizerMock{},
+		Hasher:                   &mock.HasherMock{},
+		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
+		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
+		Indexer:                  idx,
+		AccountsDB:               accountsDB,
+	})
+	require.NoError(t, err)
+
+	contract := transaction.TransferContract{
+		ToAddress: []byte("receiver"),
+		Amount:    100,
+	}
+	tx, err := createTransactionHandlerMock(&contract, transaction.TXContract_TransferContractType, []byte("sender"))
+	require.NoError(t, err)
+	header := &dataBlock.Block{
+		Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100},
+	}
+	pool := &indexer.Pool{
+		Txs: map[string]nodeData.TransactionHandler{"txHash1": tx},
+	}
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{
+		Header:           header,
+		TransactionsPool: pool,
+	})
+
+	seen := map[EventType]bool{}
+	for i := 0; i < 8; i++ {
+		select {
+		case ev := <-testQueue:
+			seen[ev.EvType] = true
+		default:
+			i = 8
+		}
+	}
+	require.True(t, seen[BLOCKS], "BLOCKS event must fire with indexer active")
+	require.True(t, seen[USER_TRANSACTIONS], "USER_TRANSACTIONS event must fire with indexer active")
+	require.True(t, seen[TRANSACTIONS], "TRANSACTIONS event must fire with indexer active")
+	require.True(t, seen[ACCOUNTS], "ACCOUNTS event must fire with indexer active")
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&saveBlockCount))
+	prepared, ok := receivedPrepared.(*data.PreparedBlockData)
+	require.True(t, ok, "indexer must receive *data.PreparedBlockData via args.Prepared")
+	require.NotNil(t, prepared)
+	require.NotEmpty(t, prepared.Txs)
+	require.NotNil(t, prepared.Altered)
+}
+
+// Regression: the orchestrator must NOT mutate args.TransactionsPool.Txs. The
+// elastic worker reads it later (ComputeSizeOfTxs on the work item, and the
+// fallback prepareTransactionsForDatabase path), and a drained pool produced a
+// SizeTxs=0 block in the elastic index. Asserting non-mutation here is the
+// invariant — not the bytes-vs-count of SizeTxs, which is a separate concern.
+func TestEventsProcessor_SaveBlock_DoesNotMutatePool(t *testing.T) {
+	saveAndRestoreEventQueue(t, true)
+
+	acc := createTestAccountStub()
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) { return acc, nil },
+	}
+	idx := &indexerStub{isNilIndexer: false, saveBlockCalled: func(_ *indexer.ArgsSaveBlockData) {}}
+
+	ep, err := NewEventsProcessor(ArgEventsProcessor{
+		Marshalizer:              &mock.MarshalizerMock{},
+		Hasher:                   &mock.HasherMock{},
+		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
+		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
+		Indexer:                  idx,
+		AccountsDB:               accountsDB,
+	})
+	require.NoError(t, err)
+
+	tx1, err := createTransactionHandlerMock(
+		&transaction.TransferContract{ToAddress: []byte("rcv1"), Amount: 100},
+		transaction.TXContract_TransferContractType, []byte("snd1"))
+	require.NoError(t, err)
+	tx2, err := createTransactionHandlerMock(
+		&transaction.TransferContract{ToAddress: []byte("rcv2"), Amount: 200},
+		transaction.TXContract_TransferContractType, []byte("snd2"))
+	require.NoError(t, err)
+
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100}}
+	pool := &indexer.Pool{
+		Txs: map[string]nodeData.TransactionHandler{
+			"h1": tx1,
+			"h2": tx2,
+		},
+	}
+	require.Len(t, pool.Txs, 2)
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{Header: header, TransactionsPool: pool})
+
+	require.Len(t, pool.Txs, 2, "SaveBlock must not drain TransactionsPool.Txs — work item still reads it for ComputeSizeOfTxs")
+}
+
+// (false, true) cell: indexer enabled but websocket disabled — no events fire
+// but the indexer still receives a Prepared payload (single prep invariant).
+func TestEventsProcessor_SaveBlock_NoEventsButPreparedWhenWebsocketDisabled(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, false)
+
+	acc := createTestAccountStub()
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			return acc, nil
+		},
+	}
+
+	var receivedPrepared any
+	idx := &indexerStub{
+		isNilIndexer:    false,
+		saveBlockCalled: func(args *indexer.ArgsSaveBlockData) { receivedPrepared = args.Prepared },
+	}
+
+	ep, err := NewEventsProcessor(ArgEventsProcessor{
+		Marshalizer:              &mock.MarshalizerMock{},
+		Hasher:                   &mock.HasherMock{},
+		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
+		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
+		Indexer:                  idx,
+		AccountsDB:               accountsDB,
+	})
+	require.NoError(t, err)
+
+	tx, err := createTransactionHandlerMock(&transaction.TransferContract{ToAddress: []byte("rcv"), Amount: 1},
+		transaction.TXContract_TransferContractType, []byte("snd"))
+	require.NoError(t, err)
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100}}
+	pool := &indexer.Pool{Txs: map[string]nodeData.TransactionHandler{"h": tx}}
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{Header: header, TransactionsPool: pool})
+
+	select {
+	case ev := <-testQueue:
+		t.Fatalf("expected no events when UseEventQueue=false, got %s", ev.EvType)
+	default:
+	}
+
+	prepared, ok := receivedPrepared.(*data.PreparedBlockData)
+	require.True(t, ok)
+	require.NotNil(t, prepared)
+}
+
+// (false, false) cell: when nothing is enabled, SaveBlock must short-circuit —
+// no prep work, no events, no indexer call.
+func TestEventsProcessor_SaveBlock_NoOpWhenNothingEnabled(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, false)
+
+	ep := createTestEventsProcessor(t)
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100}}
+	pool := &indexer.Pool{Txs: map[string]nodeData.TransactionHandler{"h": nil}}
+
+	require.NotPanics(t, func() {
+		ep.SaveBlock(&indexer.ArgsSaveBlockData{Header: header, TransactionsPool: pool})
+	})
+	require.Len(t, testQueue, 0)
 }
 
 func TestEventsProcessor_SaveAccounts_DispatchesWhenEnabled(t *testing.T) {
@@ -382,7 +747,9 @@ func TestEventsProcessor_SaveAccounts_SkipsWhenDisabled(t *testing.T) {
 	}
 }
 
-func TestEventsProcessor_SaveAccounts_SkipsWebsocketWhenIndexerActive(t *testing.T) {
+// With centralization: standalone SaveAccounts dispatches websocket ACCOUNTS
+// independently of indexer enablement, AND still forwards to the indexer.
+func TestEventsProcessor_SaveAccounts_DispatchesWebsocketAndForwardsToIndexer(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
 
 	var called int32
@@ -397,12 +764,8 @@ func TestEventsProcessor_SaveAccounts_SkipsWebsocketWhenIndexerActive(t *testing
 
 	ep.SaveAccounts(100, []state.UserAccountHandler{acc})
 
-	select {
-	case <-testQueue:
-		t.Fatal("expected no websocket account events when indexer is active")
-	default:
-	}
-
+	ev := <-testQueue
+	require.Equal(t, ACCOUNTS, ev.EvType)
 	require.Equal(t, int32(1), atomic.LoadInt32(&called))
 }
 
@@ -477,6 +840,40 @@ func TestEventsProcessor_SaveAccounts_WithPermissions(t *testing.T) {
 			require.Len(t, info.Permissions, 1)
 			require.Equal(t, "owner", info.Permissions[0].PermissionName)
 			require.Len(t, info.Permissions[0].Signers, 1)
+		}
+	default:
+		t.Fatal("expected account event to be dispatched")
+	}
+}
+
+func TestEventsProcessor_SaveAccounts_AllowanceIncludesPendingRewards(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	validatorsKapp := &mock.ValidatorsKAppStub{
+		GetPendingRewardsCalled: func(address []byte) (int64, error) {
+			return 100, nil
+		},
+	}
+
+	kappController := &stub.KAppControllerStub{
+		GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
+			return validatorsKapp
+		},
+	}
+
+	ep := createTestEventsProcessorWithKApp(t, kappController)
+	acc := createTestAccountStub()
+
+	ep.SaveAccounts(100, []state.UserAccountHandler{acc})
+
+	select {
+	case event := <-testQueue:
+		require.Equal(t, ACCOUNTS, event.EvType)
+		accountsMap, ok := event.Message.(map[string]*data.AccountInfo)
+		require.True(t, ok)
+		require.Len(t, accountsMap, 1)
+		for _, info := range accountsMap {
+			require.Equal(t, int64(150), info.Allowance)
 		}
 	default:
 		t.Fatal("expected account event to be dispatched")
@@ -598,20 +995,6 @@ func TestTrySendEvent_QueueFull(t *testing.T) {
 	require.Equal(t, BLOCKS, event.EvType)
 }
 
-func createTestEventsProcessorWithKApp(t *testing.T, ctrl kapp.KAppController) *eventsProcessor {
-	t.Helper()
-	ep, err := NewEventsProcessor(ArgEventsProcessor{
-		Marshalizer:              &mock.MarshalizerMock{},
-		Hasher:                   &mock.HasherMock{},
-		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
-		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
-		Indexer:                  nil,
-		KAppController:           ctrl,
-	})
-	require.NoError(t, err)
-	return ep
-}
-
 func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 	t.Parallel()
 
@@ -626,7 +1009,7 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(1000), result)
 	})
 
@@ -656,7 +1039,7 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(2500), result)
 	})
 
@@ -686,7 +1069,7 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(3000), result)
 	})
 
@@ -716,41 +1099,322 @@ func TestEventsProcessor_GetAllowanceWithPendingRewards(t *testing.T) {
 			},
 		}
 
-		result := ep.getAllowanceWithPendingRewards(userAccount)
+		result := getAllowanceWithPendingRewards(ep.kappsController, userAccount)
 		require.Equal(t, int64(4000), result)
 	})
 }
 
-func TestEventsProcessor_SaveAccounts_AllowanceIncludesPendingRewards(t *testing.T) {
+func TestEventsProcessor_DispatchAccountEventsFromAlteredAccounts_IncludesAllAddresses(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
 
-	validatorsKapp := &mock.ValidatorsKAppStub{
-		GetPendingRewardsCalled: func(address []byte) (int64, error) {
-			return 100, nil
-		},
-	}
-
-	kappController := &stub.KAppControllerStub{
-		GetValidatorsKAppCalled: func() kapp.ValidatorsKapp {
-			return validatorsKapp
-		},
-	}
-
-	ep := createTestEventsProcessorWithKApp(t, kappController)
+	var loadCount int32
 	acc := createTestAccountStub()
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			atomic.AddInt32(&loadCount, 1)
+			return acc, nil
+		},
+	}
+	ep := createTestEventsProcessorWithAccountsDB(t, accountsDB)
 
-	ep.SaveAccounts(100, []state.UserAccountHandler{acc})
+	senderAddr := hex.EncodeToString([]byte("sender"))
+	fromAddr := hex.EncodeToString([]byte("from_sc"))
+	toAddr := hex.EncodeToString([]byte("receiver"))
 
-	select {
-	case event := <-testQueue:
-		require.Equal(t, ACCOUNTS, event.EvType)
-		accountsMap, ok := event.Message.(map[string]*data.AccountInfo)
-		require.True(t, ok)
-		require.Len(t, accountsMap, 1)
-		for _, info := range accountsMap {
-			require.Equal(t, int64(150), info.Allowance)
+	alteredAccounts := data.NewAlteredAccounts()
+	alteredAccounts.Add(senderAddr, &data.AlteredAccount{IsSender: true, BalanceChange: true})
+	alteredAccounts.Add(fromAddr, &data.AlteredAccount{IsSender: true, BalanceChange: true})
+	alteredAccounts.Add(toAddr, &data.AlteredAccount{BalanceChange: true})
+
+	ep.dispatchAccountEventsFromAlteredAccounts(100, alteredAccounts)
+
+	require.Equal(t, int32(3), atomic.LoadInt32(&loadCount), "expected LoadAccount called for sender, from, and to")
+
+	var accountEvent *Event
+	for i := 0; i < 10; i++ {
+		select {
+		case ev := <-testQueue:
+			if ev.EvType == ACCOUNTS {
+				evCopy := ev
+				accountEvent = &evCopy
+			}
+		default:
+			i = 10
 		}
-	default:
-		t.Fatal("expected account event to be dispatched")
+	}
+	require.NotNil(t, accountEvent, "expected an ACCOUNTS event to be dispatched")
+	_, ok := accountEvent.Message.(map[string]*data.AccountInfo)
+	require.True(t, ok)
+}
+
+func TestEventsProcessor_DispatchAccountEventsFromAlteredAccounts_SkipsZeroAddress(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	var loadCount int32
+	acc := createTestAccountStub()
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			atomic.AddInt32(&loadCount, 1)
+			return acc, nil
+		},
+	}
+	ep := createTestEventsProcessorWithAccountsDB(t, accountsDB)
+
+	alteredAccounts := data.NewAlteredAccounts()
+	alteredAccounts.Add(ZeroAddressDecoded, &data.AlteredAccount{IsSender: true})
+	alteredAccounts.Add(hex.EncodeToString([]byte("validaddr1234567")), &data.AlteredAccount{IsSender: false})
+
+	ep.dispatchAccountEventsFromAlteredAccounts(100, alteredAccounts)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&loadCount), "zero address must not trigger a trie lookup")
+
+	for {
+		select {
+		case ev := <-testQueue:
+			if ev.EvType == ACCOUNTS {
+				accountsMap, ok := ev.Message.(map[string]*data.AccountInfo)
+				require.True(t, ok)
+				for addr := range accountsMap {
+					require.NotEqual(t, ZeroAddressDecoded, addr, "zero address must not appear in dispatched accounts")
+				}
+			}
+		default:
+			return
+		}
 	}
 }
+
+func TestEventsProcessor_DispatchAccountEventsFromAlteredAccounts_ErrAccNotFoundIgnoredQuietly(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			return nil, common.ErrAccNotFound
+		},
+	}
+	ep := createTestEventsProcessorWithAccountsDB(t, accountsDB)
+
+	alteredAccounts := data.NewAlteredAccounts()
+	alteredAccounts.Add(hex.EncodeToString([]byte("missingaddr12345")), &data.AlteredAccount{IsSender: true})
+
+	ep.dispatchAccountEventsFromAlteredAccounts(100, alteredAccounts)
+
+	select {
+	case ev := <-testQueue:
+		require.NotEqual(t, ACCOUNTS, ev.EvType, "missing account must not produce an ACCOUNTS event")
+	default:
+	}
+}
+
+func TestEventsProcessor_SaveBlock_TransferDispatchesSenderAndRecipient(t *testing.T) {
+	testQueue := saveAndRestoreEventQueue(t, true)
+
+	senderAddr := pad32("sender")
+	recipientAddr := pad32("recipient")
+
+	loaded := make(map[string]struct{})
+	acc := createTestAccountStub()
+	ep := createTestEventsProcessorWithAccountsDB(t, &mock.AccountsStub{
+		GetExistingAccountCalled: func(addrBytes []byte) (state.AccountHandler, error) {
+			loaded[hex.EncodeToString(addrBytes)] = struct{}{}
+			return acc, nil
+		},
+	})
+
+	tx := bareTransactionWithReceipts(senderAddr,
+		makeReceipt(ptx.Transfer,
+			senderAddr, recipientAddr,
+			[]byte("100"), []byte("KLV"),
+			[]byte(nil), []byte{0}, []byte(nil), []byte(nil),
+		),
+	)
+
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100}}
+	pool := &indexer.Pool{Txs: map[string]nodeData.TransactionHandler{"tx1": tx}}
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{Header: header, TransactionsPool: pool})
+	drainTestQueue(testQueue)
+
+	require.Contains(t, loaded, hex.EncodeToString(senderAddr), "sender must be dispatched")
+	require.Contains(t, loaded, hex.EncodeToString(recipientAddr), "recipient must be dispatched")
+}
+
+func TestEventsProcessor_SaveBlock_UpdateValidatorDispatchesValidatorAddress(t *testing.T) {
+	validatorAddr := pad32("validator")
+	tx := bareTransactionWithReceipts(pad32("sender"),
+		makeReceipt(ptx.UpdateValidator, validatorAddr),
+	)
+	runReceiptAddressTest(t, tx, validatorAddr)
+}
+
+func TestEventsProcessor_SaveBlock_UpdateAccountPermissionDispatchesTargetAddress(t *testing.T) {
+	targetAddr := pad32("permission_target_ab")
+	tx := bareTransactionWithReceipts(pad32("sender"),
+		makeReceipt(ptx.UpdateAccountPermission, targetAddr),
+	)
+	runReceiptAddressTest(t, tx, targetAddr)
+}
+
+func TestEventsProcessor_SaveBlock_UpdateMetadataDispatchesOwnerAddress(t *testing.T) {
+	ownerAddr := pad32("nft_owner_address_ab")
+	tx := bareTransactionWithReceipts(pad32("sender"),
+		makeReceipt(ptx.UpdateMetadata, ownerAddr, []byte("KDA-1"), []byte("1")),
+	)
+	runReceiptAddressTest(t, tx, ownerAddr)
+}
+
+func TestEventsProcessor_SaveBlock_SCTriggerDispatchesContractAddress(t *testing.T) {
+	contractAddr := pad32("smart_contract_12345")
+	tx := bareTransactionWithReceipts(pad32("sender"),
+		makeReceipt(ptx.SCTrigger, []byte("0"), pad32("from_addr_12345678"), contractAddr),
+	)
+	runReceiptAddressTest(t, tx, contractAddr)
+}
+
+func TestEventsProcessor_SaveBlock_SetAccountNameDispatchesTargetAddress(t *testing.T) {
+	targetAddr := pad32("account_owner_12345a")
+	tx := bareTransactionWithReceipts(pad32("sender"),
+		makeReceipt(ptx.SetAccountName, []byte("myname"), targetAddr),
+	)
+	runReceiptAddressTest(t, tx, targetAddr)
+}
+
+func TestEventsProcessor_WebsocketAndIndexerProduceSameAddressSet(t *testing.T) {
+	senderBytes := pad32("sender_address_12345")
+	validatorBytes := pad32("validator_address_ab")
+
+	makeTx := func() *transaction.Transaction {
+		return bareTransactionWithReceipts(senderBytes,
+			makeReceipt(ptx.UpdateValidator, validatorBytes),
+		)
+	}
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100}}
+
+	// Step 1: collect the indexer's altered account set.
+	proc := newTxDatabaseProcessor(
+		&mock.HasherMock{},
+		&mock.MarshalizerMock{},
+		mock.NewPubkeyConverterMock(32),
+		mock.NewPubkeyConverterMock(32),
+		false,
+	)
+	_, _, ad, err := proc.prepareTransactionsForDatabase(header,
+		&indexer.Pool{Txs: map[string]nodeData.TransactionHandler{"tx1": makeTx()}},
+	)
+	require.NoError(t, err)
+
+	// websocket path no longer applies a manual ZeroAddress skip; instead,
+	// GetExistingAccount returns ErrAccNotFound for missing addresses (incl.
+	// zero address) and the loop silently drops them. So we now compare the
+	// raw indexer set to the addresses the websocket actually attempted to
+	// load — they must match.
+	indexerAddrs := make(map[string]struct{})
+	for addr := range ad.Accounts.GetAll() {
+		indexerAddrs[addr] = struct{}{}
+	}
+
+	// Step 2: collect addresses loaded by the websocket fallback path.
+	testQueue := saveAndRestoreEventQueue(t, true)
+	wsLoadedAddrs := make(map[string]struct{})
+	acc := createTestAccountStub()
+	ep := createTestEventsProcessorWithAccountsDB(t, &mock.AccountsStub{
+		GetExistingAccountCalled: func(addrBytes []byte) (state.AccountHandler, error) {
+			wsLoadedAddrs[hex.EncodeToString(addrBytes)] = struct{}{}
+			return acc, nil
+		},
+	})
+
+	ep.SaveBlock(&indexer.ArgsSaveBlockData{
+		Header:           header,
+		TransactionsPool: &indexer.Pool{Txs: map[string]nodeData.TransactionHandler{"tx1": makeTx()}},
+	})
+	drainTestQueue(testQueue)
+
+	require.Equal(t, indexerAddrs, wsLoadedAddrs,
+		"websocket fallback must query exactly the same accounts as the indexer path")
+}
+
+// benchSaveBlock runs ep.SaveBlock against a synthetic pool of transferTxs
+// transfer txs. Use it to anchor commit-thread cost of the orchestrator
+// (prepareTransactionsForDatabase + dispatch + indexer enqueue).
+//
+//	go test -bench=BenchmarkEventsProcessor_SaveBlock -benchmem ./indexer/
+//
+// Read each result as cost-per-block, not per-tx; b.N is the number of blocks
+// processed in the run, each containing transferTxs synthetic transactions.
+func benchSaveBlock(b *testing.B, transferTxs int, wsEnabled bool, indexerEnabled bool) {
+	b.Helper()
+
+	originalUseEventQueue := UseEventQueue
+	originalEventQueue := EventQueue
+	testQueue := make(chan Event, 1024)
+	UseEventQueue = wsEnabled
+	EventQueue = testQueue
+	b.Cleanup(func() {
+		UseEventQueue = originalUseEventQueue
+		EventQueue = originalEventQueue
+		// Close the local channel (not the global, which may have been swapped)
+		// so the drain goroutine exits cleanly instead of leaking across benches.
+		close(testQueue)
+	})
+	go func() {
+		// drain the local channel so trySendEvent's non-blocking send doesn't
+		// fall back to drop logging. Ranging over testQueue (local) instead of
+		// the package-level EventQueue avoids racing with the cleanup-time write.
+		for range testQueue {
+		}
+	}()
+
+	acc := createTestAccountStub()
+	accountsDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) { return acc, nil },
+	}
+
+	args := ArgEventsProcessor{
+		Marshalizer:              &mock.MarshalizerMock{},
+		Hasher:                   &mock.HasherMock{},
+		AddressPubkeyConverter:   mock.NewPubkeyConverterMock(32),
+		ValidatorPubkeyConverter: mock.NewPubkeyConverterMock(32),
+		AccountsDB:               accountsDB,
+	}
+	if indexerEnabled {
+		args.Indexer = &indexerStub{
+			isNilIndexer:    false,
+			saveBlockCalled: func(_ *indexer.ArgsSaveBlockData) {},
+		}
+	}
+	ep, err := NewEventsProcessor(args)
+	require.NoError(b, err)
+
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 1, Timestamp: 100}}
+
+	// Pre-build the pool template once; cloning into a fresh map per iter is the
+	// only mutation the orchestrator could perform on it (it shouldn't, post-fix —
+	// but we want the bench to measure steady-state, not first-iteration warmup).
+	contract := transaction.TransferContract{ToAddress: pad32("rcv"), Amount: 1}
+	template := make(map[string]nodeData.TransactionHandler, transferTxs)
+	for i := 0; i < transferTxs; i++ {
+		tx, err := createTransactionHandlerMock(&contract,
+			transaction.TXContract_TransferContractType, pad32("snd"))
+		require.NoError(b, err)
+		template[hex.EncodeToString([]byte{byte(i >> 8), byte(i)})] = tx
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pool := make(map[string]nodeData.TransactionHandler, transferTxs)
+		for k, v := range template {
+			pool[k] = v
+		}
+		ep.SaveBlock(&indexer.ArgsSaveBlockData{
+			Header:           header,
+			TransactionsPool: &indexer.Pool{Txs: pool},
+		})
+	}
+}
+
+func BenchmarkEventsProcessor_SaveBlock_Empty_WSOnly(b *testing.B) { benchSaveBlock(b, 0, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_50tx_WSOnly(b *testing.B)  { benchSaveBlock(b, 50, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_500tx_WSOnly(b *testing.B) { benchSaveBlock(b, 500, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_50tx_Both(b *testing.B)    { benchSaveBlock(b, 50, true, true) }
+func BenchmarkEventsProcessor_SaveBlock_500tx_Both(b *testing.B)   { benchSaveBlock(b, 500, true, true) }

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -382,8 +382,6 @@ func TestEventsProcessor_SaveBlock_DispatchesTransactionEvents(t *testing.T) {
 	require.Equal(t, TRANSACTIONS, txEvent.EvType)
 }
 
-// With centralization, BLOCKS now fires on every websocket-enabled config —
-// including indexer-active nodes — directly from the commit goroutine.
 func TestEventsProcessor_SaveBlock_DispatchesBlocksEventWithIndexerActive(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
 
@@ -525,10 +523,6 @@ func TestEventsProcessor_SaveBlock_SkipsAccountEventsWhenNoAccountsDB(t *testing
 	}
 }
 
-// With centralization: indexer-active path also dispatches BLOCKS, TX, and
-// ACCOUNTS websocket events, AND the indexer receives a non-nil Prepared
-// payload (no duplicate prep downstream). This is the (true, true) cell of
-// the (UseEventQueue, indexer) test matrix.
 func TestEventsProcessor_SaveBlock_DispatchesAllEventsAndPreparesIndexer(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
 
@@ -599,11 +593,8 @@ func TestEventsProcessor_SaveBlock_DispatchesAllEventsAndPreparesIndexer(t *test
 	require.NotNil(t, prepared.Altered)
 }
 
-// Regression: the orchestrator must NOT mutate args.TransactionsPool.Txs. The
-// elastic worker reads it later (ComputeSizeOfTxs on the work item, and the
-// fallback prepareTransactionsForDatabase path), and a drained pool produced a
-// SizeTxs=0 block in the elastic index. Asserting non-mutation here is the
-// invariant — not the bytes-vs-count of SizeTxs, which is a separate concern.
+// Regression: SaveBlock must not drain TransactionsPool.Txs — the work item
+// later calls ComputeSizeOfTxs and the elastic fallback re-preps.
 func TestEventsProcessor_SaveBlock_DoesNotMutatePool(t *testing.T) {
 	saveAndRestoreEventQueue(t, true)
 
@@ -646,9 +637,10 @@ func TestEventsProcessor_SaveBlock_DoesNotMutatePool(t *testing.T) {
 	require.Len(t, pool.Txs, 2, "SaveBlock must not drain TransactionsPool.Txs — work item still reads it for ComputeSizeOfTxs")
 }
 
-// (false, true) cell: indexer enabled but websocket disabled — no events fire
-// but the indexer still receives a Prepared payload (single prep invariant).
-func TestEventsProcessor_SaveBlock_NoEventsButPreparedWhenWebsocketDisabled(t *testing.T) {
+// When ws is disabled and only the indexer is enabled, SaveBlock must NOT
+// prep on the commit goroutine — the worker re-preps via the fallback in
+// elasticProcessor.SaveTransactions, keeping commit-thread cost flat.
+func TestEventsProcessor_SaveBlock_IndexerOnlySkipsCommitThreadPrep(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, false)
 
 	acc := createTestAccountStub()
@@ -688,13 +680,9 @@ func TestEventsProcessor_SaveBlock_NoEventsButPreparedWhenWebsocketDisabled(t *t
 	default:
 	}
 
-	prepared, ok := receivedPrepared.(*data.PreparedBlockData)
-	require.True(t, ok)
-	require.NotNil(t, prepared)
+	require.Nil(t, receivedPrepared, "Prepared must be nil when ws is disabled — worker re-preps on its own goroutine")
 }
 
-// (false, false) cell: when nothing is enabled, SaveBlock must short-circuit —
-// no prep work, no events, no indexer call.
 func TestEventsProcessor_SaveBlock_NoOpWhenNothingEnabled(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, false)
 
@@ -747,8 +735,6 @@ func TestEventsProcessor_SaveAccounts_SkipsWhenDisabled(t *testing.T) {
 	}
 }
 
-// With centralization: standalone SaveAccounts dispatches websocket ACCOUNTS
-// independently of indexer enablement, AND still forwards to the indexer.
 func TestEventsProcessor_SaveAccounts_DispatchesWebsocketAndForwardsToIndexer(t *testing.T) {
 	testQueue := saveAndRestoreEventQueue(t, true)
 
@@ -1303,11 +1289,6 @@ func TestEventsProcessor_WebsocketAndIndexerProduceSameAddressSet(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	// websocket path no longer applies a manual ZeroAddress skip; instead,
-	// GetExistingAccount returns ErrAccNotFound for missing addresses (incl.
-	// zero address) and the loop silently drops them. So we now compare the
-	// raw indexer set to the addresses the websocket actually attempted to
-	// load — they must match.
 	indexerAddrs := make(map[string]struct{})
 	for addr := range ad.Accounts.GetAll() {
 		indexerAddrs[addr] = struct{}{}
@@ -1413,8 +1394,10 @@ func benchSaveBlock(b *testing.B, transferTxs int, wsEnabled bool, indexerEnable
 	}
 }
 
-func BenchmarkEventsProcessor_SaveBlock_Empty_WSOnly(b *testing.B) { benchSaveBlock(b, 0, true, false) }
-func BenchmarkEventsProcessor_SaveBlock_50tx_WSOnly(b *testing.B)  { benchSaveBlock(b, 50, true, false) }
-func BenchmarkEventsProcessor_SaveBlock_500tx_WSOnly(b *testing.B) { benchSaveBlock(b, 500, true, false) }
-func BenchmarkEventsProcessor_SaveBlock_50tx_Both(b *testing.B)    { benchSaveBlock(b, 50, true, true) }
-func BenchmarkEventsProcessor_SaveBlock_500tx_Both(b *testing.B)   { benchSaveBlock(b, 500, true, true) }
+func BenchmarkEventsProcessor_SaveBlock_Empty_WSOnly(b *testing.B)      { benchSaveBlock(b, 0, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_50tx_WSOnly(b *testing.B)       { benchSaveBlock(b, 50, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_500tx_WSOnly(b *testing.B)      { benchSaveBlock(b, 500, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_50tx_IndexerOnly(b *testing.B)  { benchSaveBlock(b, 50, false, true) }
+func BenchmarkEventsProcessor_SaveBlock_500tx_IndexerOnly(b *testing.B) { benchSaveBlock(b, 500, false, true) }
+func BenchmarkEventsProcessor_SaveBlock_50tx_Both(b *testing.B)         { benchSaveBlock(b, 50, true, true) }
+func BenchmarkEventsProcessor_SaveBlock_500tx_Both(b *testing.B)        { benchSaveBlock(b, 500, true, true) }

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -1394,10 +1394,16 @@ func benchSaveBlock(b *testing.B, transferTxs int, wsEnabled bool, indexerEnable
 	}
 }
 
-func BenchmarkEventsProcessor_SaveBlock_Empty_WSOnly(b *testing.B)      { benchSaveBlock(b, 0, true, false) }
-func BenchmarkEventsProcessor_SaveBlock_50tx_WSOnly(b *testing.B)       { benchSaveBlock(b, 50, true, false) }
-func BenchmarkEventsProcessor_SaveBlock_500tx_WSOnly(b *testing.B)      { benchSaveBlock(b, 500, true, false) }
-func BenchmarkEventsProcessor_SaveBlock_50tx_IndexerOnly(b *testing.B)  { benchSaveBlock(b, 50, false, true) }
-func BenchmarkEventsProcessor_SaveBlock_500tx_IndexerOnly(b *testing.B) { benchSaveBlock(b, 500, false, true) }
-func BenchmarkEventsProcessor_SaveBlock_50tx_Both(b *testing.B)         { benchSaveBlock(b, 50, true, true) }
-func BenchmarkEventsProcessor_SaveBlock_500tx_Both(b *testing.B)        { benchSaveBlock(b, 500, true, true) }
+func BenchmarkEventsProcessor_SaveBlock_Empty_WSOnly(b *testing.B) { benchSaveBlock(b, 0, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_50tx_WSOnly(b *testing.B)  { benchSaveBlock(b, 50, true, false) }
+func BenchmarkEventsProcessor_SaveBlock_500tx_WSOnly(b *testing.B) {
+	benchSaveBlock(b, 500, true, false)
+}
+func BenchmarkEventsProcessor_SaveBlock_50tx_IndexerOnly(b *testing.B) {
+	benchSaveBlock(b, 50, false, true)
+}
+func BenchmarkEventsProcessor_SaveBlock_500tx_IndexerOnly(b *testing.B) {
+	benchSaveBlock(b, 500, false, true)
+}
+func BenchmarkEventsProcessor_SaveBlock_50tx_Both(b *testing.B)  { benchSaveBlock(b, 50, true, true) }
+func BenchmarkEventsProcessor_SaveBlock_500tx_Both(b *testing.B) { benchSaveBlock(b, 500, true, true) }

--- a/indexer/interface.go
+++ b/indexer/interface.go
@@ -31,7 +31,7 @@ type ElasticProcessor interface {
 	RemoveTransactions(blk nodeData.HeaderHandler) error
 	RemoveAccountsHistory(blockTimestamp int64) error
 	RevertAccountBalances(blockTimestamp int64) error
-	SaveTransactions(header nodeData.HeaderHandler, pool *indexer.Pool) error
+	SaveTransactions(header nodeData.HeaderHandler, pool *indexer.Pool, prepared any) error
 	SaveEpochInfo(epoch uint32, validators []kapp.ValidatorAccountInfoHandler) error
 	UpdateProposalsAndParameters(proposalIDs []string) error
 	SaveAssets(assets []*data.Asset) error

--- a/indexer/mock/elasticProcessorStub.go
+++ b/indexer/mock/elasticProcessorStub.go
@@ -18,7 +18,7 @@ type ElasticProcessorStub struct {
 	RemoveTransactionsCalled           func(header nodeData.HeaderHandler) error
 	RemoveAccountsHistoryCalled        func(blockTimestamp int64) error
 	RevertAccountBalancesCalled        func(blockTimestamp int64) error
-	SaveTransactionsCalled             func(header nodeData.HeaderHandler, pool *indexer.Pool) error
+	SaveTransactionsCalled             func(header nodeData.HeaderHandler, pool *indexer.Pool, prepared any) error
 	SaveAccountsCalled                 func(timestamp int64, acc []*data.Account) error
 	SavePeerAccountCalled              func(account *data.ValidatorAccountInfo) error
 	UpdateProposalsAndParametersCalled func([]string) error
@@ -85,9 +85,9 @@ func (eim *ElasticProcessorStub) RevertAccountBalances(blockTimestamp int64) err
 }
 
 // SaveTransactions -
-func (eim *ElasticProcessorStub) SaveTransactions(header nodeData.HeaderHandler, pool *indexer.Pool) error {
+func (eim *ElasticProcessorStub) SaveTransactions(header nodeData.HeaderHandler, pool *indexer.Pool, prepared any) error {
 	if eim.SaveTransactionsCalled != nil {
-		return eim.SaveTransactionsCalled(header, pool)
+		return eim.SaveTransactionsCalled(header, pool, prepared)
 	}
 	return nil
 }

--- a/indexer/processTransactions.go
+++ b/indexer/processTransactions.go
@@ -49,11 +49,9 @@ func newTxDatabaseProcessor(
 	}
 }
 
-// prepareTransactionsForDatabase builds the indexer's view of a block's transactions and
-// the set of altered accounts/assets/etc. It does NOT mutate txPool — the caller may
-// safely reuse txPool afterwards (e.g., ComputeSizeOfTxs on the work item, or a fallback
-// re-prep). Centralized by eventsProcessor.SaveBlock so on the happy path it runs once
-// per block and the result is forwarded to the elastic worker via PreparedBlockData.
+// prepareTransactionsForDatabase builds the indexer view of a block's
+// transactions and altered accounts/assets. Must not mutate txPool: callers
+// (work-item ComputeSizeOfTxs, fallback re-prep) read it afterwards.
 func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 	header nodeData.HeaderHandler,
 	txPool *indexer.Pool,

--- a/indexer/processTransactions.go
+++ b/indexer/processTransactions.go
@@ -49,6 +49,11 @@ func newTxDatabaseProcessor(
 	}
 }
 
+// prepareTransactionsForDatabase builds the indexer's view of a block's transactions and
+// the set of altered accounts/assets/etc. It does NOT mutate txPool — the caller may
+// safely reuse txPool afterwards (e.g., ComputeSizeOfTxs on the work item, or a fallback
+// re-prep). Centralized by eventsProcessor.SaveBlock so on the happy path it runs once
+// per block and the result is forwarded to the elastic worker via PreparedBlockData.
 func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 	header nodeData.HeaderHandler,
 	txPool *indexer.Pool,
@@ -90,7 +95,6 @@ func (tdp *txDatabaseProcessor) prepareTransactionsForDatabase(
 		)
 
 		transactions[hash] = dbTx
-		delete(txPool.Txs, hash)
 	}
 
 	transactions = tdp.setTransactionSearchOrder(transactions)

--- a/indexer/workItems/interface.go
+++ b/indexer/workItems/interface.go
@@ -16,7 +16,7 @@ type WorkItemHandler interface {
 
 type saveBlockIndexer interface {
 	SaveHeader(header nodeData.HeaderHandler, signer []byte, txsSize int, validators []string) error
-	SaveTransactions(header nodeData.HeaderHandler, pool *indexer.Pool) error
+	SaveTransactions(header nodeData.HeaderHandler, pool *indexer.Pool, prepared any) error
 }
 
 type removeIndexer interface {

--- a/indexer/workItems/workItemBlock.go
+++ b/indexer/workItems/workItemBlock.go
@@ -58,7 +58,7 @@ func (wib *itemBlock) Save() error {
 			err, hex.EncodeToString(wib.argsSaveBlock.HeaderHash), wib.argsSaveBlock.Header.GetNonce())
 	}
 
-	err = wib.indexer.SaveTransactions(wib.argsSaveBlock.Header, wib.argsSaveBlock.TransactionsPool)
+	err = wib.indexer.SaveTransactions(wib.argsSaveBlock.Header, wib.argsSaveBlock.TransactionsPool, wib.argsSaveBlock.Prepared)
 	if err != nil {
 		return fmt.Errorf("%w when saving transactions, block hash %s, nonce %d",
 			err, hex.EncodeToString(wib.argsSaveBlock.HeaderHash), wib.argsSaveBlock.Header.GetNonce())

--- a/indexer/workItems/workItemBlock_test.go
+++ b/indexer/workItems/workItemBlock_test.go
@@ -52,7 +52,7 @@ func TestItemBlock_SaveTransactionsShouldErr(t *testing.T) {
 	localErr := errors.New("local err")
 	itemBlock := workItems.NewItemBlock(
 		&imock.ElasticProcessorStub{
-			SaveTransactionsCalled: func(header data.HeaderHandler, pool *indexer.Pool) error {
+			SaveTransactionsCalled: func(header data.HeaderHandler, pool *indexer.Pool, prepared any) error {
 				return localErr
 			},
 		},
@@ -78,7 +78,7 @@ func TestItemBlock_SaveShouldWork(t *testing.T) {
 				countCalled++
 				return nil
 			},
-			SaveTransactionsCalled: func(header data.HeaderHandler, pool *indexer.Pool) error {
+			SaveTransactionsCalled: func(header data.HeaderHandler, pool *indexer.Pool, prepared any) error {
 				countCalled++
 				return nil
 			},


### PR DESCRIPTION
  ## Problem                                                                                                                                    
  WebSocket account subscriptions only worked when the Elasticsearch indexer was active. Without it, account state changes were never dispatched
   to subscribers — the entire account event path ran exclusively through the indexer pipeline.                                                 
                                                                                                                                              
  ## Solution                                                                                                                                   
  Added `processAccountEvents` to the `dispatchWebsocketEvents` path inside `eventsProcessor`. When no indexer is active, it extracts the     
  affected addresses (senders + receipt `"to"` fields) from the block's transactions, loads each account's current state from `AccountsDB`, and 
  dispatches the account events directly to the WebSocket event queue.
                                                                                                                                                
  ## Key Changes                                                                                                                              
  - **New:** `processAccountEvents()` in `indexer/eventsProcessor.go` — extracts affected addresses from transactions and dispatches ACCOUNTS 
  events                                                                                                                                        
  - **New:** `buildAccountInfo()` in `indexer/eventsProcessor.go` — builds `*data.AccountInfo` directly from `UserAccountHandler`
  - **Updated:** `ArgEventsProcessor` in `indexer/dataIndexerArgs.go` — added `AccountsDB state.AccountsAdapter` field                          
  - **Updated:** `eventsProcessor` struct — added `accountsDB` dependency injected at construction                                              
  - **Updated:** `cmd/node/startup.go` — passes `stateComponents.AccountsAdapter` when creating `eventsProcessor`                               
  - **Updated:** `indexer/eventsProcessor_test.go` — 3 new test cases covering the new dispatch path                                            
                                                                                                                                                
  ## Testing                                                                                                                                    
  - [x] All existing tests pass (`make tests`)                                                                                                  
  - [x] New tests added for new functionality                                                                                                 
    - `TestEventsProcessor_SaveBlock_DispatchesAccountEvents` — verifies ACCOUNTS event is dispatched when AccountsDB is present              
    - `TestEventsProcessor_SaveBlock_SkipsAccountEventsWhenNoAccountsDB` — verifies no dispatch when AccountsDB is nil                          
    - `TestEventsProcessor_SaveBlock_SkipsAccountEventsWhenIndexerActive` — verifies no websocket events when indexer is handling dispatch      
  - [x] Manual testing performed:                                                                                                               
                                                                                                                                                
  ## Configuration Changes                                                                                                                      
  None                                                                                                                                        
                                                                                                                                              
  ## Breaking Changes
  None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request ensures WebSocket subscribers receive account-state websocket ACCOUNTS events even when the Elasticsearch indexer is not running by dispatching account events directly during the SaveBlock/commit path.

Blockchain-Critical Components Affected
- State management / account state access
  - eventsProcessor now depends on AccountsDB (state.AccountsAdapter) injected via ArgEventsProcessor and wired in cmd/node/startup.go.
  - New code extracts affected addresses from prepared transactions and receipts, loads each account from AccountsDB (read-only) using the UserAccountHandler, and builds data.AccountInfo payloads (nonce, name/root/code hashes, metadata, balances including unfrozen/frozen KDA buckets, allowance including pending rewards, permissions, timestamps).
  - buildAccountInfo centralizes account→data.AccountInfo construction and is reused by indexer/account and events paths.

- Transaction processing / event dispatch
  - The SaveBlock / websocket dispatch path now uses prepared block data to emit USER_TRANSACTIONS/TRANSACTIONS and — when the indexer is not active and AccountsDB is present — dispatches ACCOUNTS events by loading current account state and sending to the WebSocket event queue.
  - The indexer path was refactored to accept optional prepared data (PreparedBlockData) so prepared work can be reused; elasticProcessor.SaveTransactions signature changed to accept a prepared any parameter and no longer enqueues USER_TRANSACTIONS/TRANSACTIONS itself.
  - prepareTransactionsForDatabase was documented/changed to be non-mutating (no longer deletes from the tx pool).

Node Stability, Data Integrity & Error Handling
- No consensus logic, KVM execution, or state-mutation semantics are changed — changes are read-only and observability/eventing focused.
- Per-address failures are isolated: address decoding failures, common.ErrAccNotFound, or individual buildAccountInfo errors are logged and skipped without aborting other event dispatches.
- Existing non-blocking event-queue semantics (trySendEvent) are preserved; no new blocking concurrency primitives added in the event path.
- Operational impact: synchronous AccountsDB reads occur on the commit/SaveBlock goroutine for affected addresses, which can increase I/O/CPU contention for blocks touching many accounts and may affect node latency under load.

Cross-Cutting / Dependency Changes
- ArgEventsProcessor added AccountsDB (state.AccountsAdapter); eventsProcessor stores and receives this dependency via NewEventsProcessor; startup wiring updated to pass stateComponents.AccountsAdapter.
- Introduced data.PreparedBlockData to carry prepared Txs, TxsMap, and Altered metadata so SaveBlock can prepare once and indexer worker can reuse prepared payload.
- Elastic/indexer code moved account-info helpers out of elasticProcessor into shared helpers (indexer/accountInfo.go) and removed event enqueueing from elasticProcessor.SaveTransactions/SaveHeader to centralize websocket enqueueing in SaveBlock/commit.
- work items and interfaces updated to propagate the prepared any parameter into indexer SaveTransactions.

Testing & Verification
- Extensive test additions and updates (indexer/eventsProcessor_test.go, elasticProcessor_test.go, workItem tests) verifying:
  - ACCOUNTS events dispatch when AccountsDB present and indexer inactive.
  - ACCOUNTS events skipped when AccountsDB nil or when indexer active.
  - Address coverage for senders/receipt recipients and various receipt types.
  - Parity between websocket-derived address sets and indexer altered-account sets (excluding zero address).
  - SaveTransactions fallback behavior when prepared is nil.
- Author reports all tests passing; new unit tests added to cover the new paths.

Risk Summary
- Risk to consensus/data integrity: None — no state mutation changes.
- Operational risk: Low-to-moderate — added synchronous account-state reads during SaveBlock may increase latency or lock contention for blocks that touch many accounts; reviewer recommended a follow-up to offload heavy trie reads to a buffered worker to mitigate contention.
- Behavioral change: websocket ACCOUNTS/BLOCKS/TXS enqueueing now centralized in SaveBlock/commit path; when indexer enabled, indexer remains authoritative and the fallback is skipped so no duplicate events are emitted.

Reviewer Notes (design critique)
- A reviewer recommended a larger refactor to (1) make SaveBlock the single orchestrator that prepares per-block data once, (2) enqueue websocket events from the commit goroutine, and (3) pass prepared data to the indexer worker so the indexer skips re-prep. The PR already moves toward this model (PreparedBlockData, central event dispatch) but reviewer flagged performance concerns (sync trie reads on commit) and proposed an 8-step refactor plan and additional parity tests; those design suggestions are relevant for follow-up work but are not required for correctness of this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->