### PR TITLE
[KLC-2339] Add title and description fields to error receipts

### DIFF
--- a/indexer/common.go
+++ b/indexer/common.go
@@ -395,6 +395,13 @@ func (cm *commonProcessor) receiptToMap(data [][]byte) (map[string]interface{}, 
 			return nil, fmt.Errorf("%w: (%d/%d)", ErrInvalidDataMapLen, len(data), 2)
 		}
 		m["address"] = cm.addressPubkeyConverter.Encode(data[1])
+	case ptx.Error:
+		if len(data) > 1 {
+			m["title"] = string(data[1])
+		}
+		if len(data) > 2 {
+			m["description"] = string(data[2])
+		}
 	}
 
 	return m, nil

--- a/indexer/common_test.go
+++ b/indexer/common_test.go
@@ -975,4 +975,46 @@ func Test_receiptToMap(t *testing.T) {
 		require.Equal(t, ptx.UpdateAccountPermission, result["type"])
 		require.Equal(t, "klv1account", result["address"])
 	})
+
+	t.Run("Error", func(t *testing.T) {
+		data := [][]byte{
+			{byte(ptx.Error), 0},
+			[]byte("InvalidAmount"),
+			[]byte("amount must be positive"),
+		}
+
+		result, err := cp.receiptToMap(data)
+		require.NoError(t, err)
+		require.Equal(t, ptx.Error, result["type"])
+		require.Equal(t, 0, result["cID"])
+		require.Equal(t, "Error", result["typeString"])
+		require.Equal(t, "InvalidAmount", result["title"])
+		require.Equal(t, "amount must be positive", result["description"])
+	})
+
+	t.Run("Error_TitleOnly", func(t *testing.T) {
+		data := [][]byte{
+			{byte(ptx.Error), 3},
+			[]byte("InvalidPermission"),
+		}
+
+		result, err := cp.receiptToMap(data)
+		require.NoError(t, err)
+		require.Equal(t, ptx.Error, result["type"])
+		require.Equal(t, 3, result["cID"])
+		require.Equal(t, "InvalidPermission", result["title"])
+		require.NotContains(t, result, "description")
+	})
+
+	t.Run("Error_NoParams", func(t *testing.T) {
+		data := [][]byte{
+			{byte(ptx.Error), 0},
+		}
+
+		result, err := cp.receiptToMap(data)
+		require.NoError(t, err)
+		require.Equal(t, ptx.Error, result["type"])
+		require.NotContains(t, result, "title")
+		require.NotContains(t, result, "description")
+	})
 }

--- a/indexer/processTransactions.go
+++ b/indexer/processTransactions.go
@@ -280,10 +280,6 @@ func (tdp *txDatabaseProcessor) indexReceipt(
 			ad.Accounts.Add(m["address"].(string), &data.AlteredAccount{
 				IsSender: false,
 			})
-
-		case ptx.SignedBy:
-			// nothing to do
-
 		case ptx.Buy:
 			ad.Orders.Add(m["orderId"].(string), &data.MarketOperations{
 				IsNew:   false,
@@ -428,6 +424,8 @@ func (tdp *txDatabaseProcessor) indexReceipt(
 				IsSender:        isSender,
 				IsSmartContract: isSmartContract,
 			})
+		case ptx.Error, ptx.Debug, ptx.Warning, ptx.SignedBy:
+			// nothing to do
 		default:
 			_ = bugsnag.Notify(fmt.Errorf("indexReceipt not able to index. Hash: %s, Type: %v", txHash, m["type"]))
 			log.Error("indexReceipt not able to index", "type", m["type"], "txHash", txHash)


### PR DESCRIPTION
## Summary                                             
  Adds `title` and `description` fields to error receipts
   in the indexer, enabling downstream consumers to      
  surface human-readable error context from on-chain     
  error receipts.                                        
                                                         
  ## Problem                                             
  Error receipts emitted by the chain carry a title and  
  description payload, but the indexer's `receiptToMap`  
  did not decode them — only the receipt `type` and `cID`
   were exposed. As a result, error metadata was lost    
  when receipts were indexed, and `indexReceipt` was
  emitting Bugsnag notifications for `Error`, `Debug`,
  `Warning`, and `SignedBy` receipt types that have no
  indexable side effects.

  ## Solution
  Extended `commonProcessor.receiptToMap` with a
  `ptx.Error` case that decodes `data[1]` as `title` and 
  `data[2]` as `description` (each guarded by length
  checks so partial payloads are tolerated). Consolidated
   `Error`, `Debug`, `Warning`, and `SignedBy` into a
  single no-op `case` in `indexReceipt` so they are
  explicitly recognized and don't trigger the default
  Bugsnag fallback.

  ## Key Changes
  - **New:**
    - `indexer/common.go` — `ptx.Error` branch in
  `receiptToMap` populating `title` and `description`    
    - `indexer/common_test.go` — `Error`,
  `Error_TitleOnly`, and `Error_NoParams` subtests       
  covering full payload, title-only, and no-params
  scenarios                                              
  - **Updated:**  
    - `indexer/processTransactions.go` — merged `Error`,
  `Debug`, `Warning`, `SignedBy` into a single no-op case
   in `indexReceipt`
  - **Removed:**                                         
    - `indexer/processTransactions.go` — standalone
  `ptx.SignedBy` no-op case (folded into the merged case 
  above)
                                                         
  ## Testing      
  - [x] All existing tests pass (`make tests`)
  - [x] New tests added for new functionality
  - [ ] Manual testing performed:                        
    - Verified `receiptToMap` returns
  `title`/`description` for full Error payloads          
    - Verified missing description is omitted (not
  empty-stringed) when only title is provided            
    - Verified neither field is set when no params are
  present                                                
                  
  ## Configuration Changes
  None.

  ```yaml
  # N/A
  ```

  ## Breaking Changes
  None. The change is additive — existing receipt types
  are unaffected, and the new `title`/`description`      
  fields are only present on `Error` receipts.
                                                         
  ## Related Issues
  Fixes KLC-2339
  Related to #
                                                         
  ## Checklist
  - [x] Code follows project style guidelines (`make     
  goimports`)     
  - [x] Tests added/updated and passing
  - [ ] Documentation updated (README, CLAUDE.md, code
  comments)                                              
  - [x] Commit messages follow [Conventional 
  Commits](https://www.conventionalcommits.org/)         
  - [x] No unnecessary files included
  - [x] Breaking changes documented above
  - [x] Configuration changes documented above   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Scope & Impact

This PR is an **off-chain indexing enhancement** with no impact on consensus, transaction processing, state management, or node stability. The indexer is a separate component that converts finalized blockchain data into structured Elasticsearch indices for downstream API consumption.

## Changes Summary

**Off-chain Indexing Only:**
- Extended `receiptToMap()` function to decode human-readable `title` and `description` fields from on-chain error receipts (`ptx.Error` type)
- Consolidated error handling in `indexReceipt()` by grouping non-indexable receipt types (`Error`, `Debug`, `Warning`, `SignedBy`) into a single explicit no-op case

**Key improvements:**
- Enables downstream API consumers to surface human-readable error context from transactions
- Reduces erroneous Bugsnag alerts by preventing unintended fallback notifications for system receipt types with no indexable side effects
- Gracefully handles partial payloads through length checks before accessing decoded fields

## Testing & Safety

- All existing tests pass; new test cases added covering full payloads, partial payloads (title-only), and no-parameter scenarios
- No configuration changes required; purely additive and non-breaking
- Zero impact on blockchain consensus, transaction finality, or state integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->