### PR TITLE
[KLC-2332] Override KLV and KFI asset metadata in GetAsset response

### DIFF
--- a/network/api/asset/routes.go
+++ b/network/api/asset/routes.go
@@ -18,8 +18,8 @@ const (
 	getNFTAssetsPath = "/nft/:owner/*id"
 	getKDAPoolPath   = "/pool/:id/"
 
-	KLVAssetID = "KLV"
-	KFIAssetID = "KFI"
+	klvAssetID = "KLV"
+	kfiAssetID = "KFI"
 )
 
 // FacadeHandler interface defines methods that can be used by the gin webserver
@@ -119,12 +119,12 @@ func replaceKDAInfo(asset *kapps.KDAData) {
 	}
 
 	id := string(asset.ID)
-	if id != KLVAssetID && id != KFIAssetID {
+	if id != klvAssetID && id != kfiAssetID {
 		return
 	}
 
 	asset.Logo = "https://kleverscan.org/assets/klv-logo.png"
-	if id == KFIAssetID {
+	if id == kfiAssetID {
 		asset.Logo = "https://kleverscan.org/assets/kfi-logo.png"
 	}
 

--- a/network/api/asset/routes.go
+++ b/network/api/asset/routes.go
@@ -17,6 +17,9 @@ const (
 	getAssetsPath    = "/"
 	getNFTAssetsPath = "/nft/:owner/*id"
 	getKDAPoolPath   = "/pool/:id/"
+
+	KLVAssetID = "KLV"
+	KFIAssetID = "KFI"
 )
 
 // FacadeHandler interface defines methods that can be used by the gin webserver
@@ -94,6 +97,9 @@ func GetAsset(c *gin.Context) {
 		return
 	}
 
+	// We replace the KDA info for KLV and KFI to avoid showing outdated information that is registered at genesis.
+	replaceKDAInfo(asset)
+
 	c.JSON(
 		http.StatusOK,
 		shared.GenericAPIResponse{
@@ -102,6 +108,35 @@ func GetAsset(c *gin.Context) {
 			Code:  shared.ReturnCodeSuccess,
 		},
 	)
+}
+
+// replaceKDAInfo overrides the Logo and URIs returned for KLV and KFI.
+// Their values are registered at genesis and updating them on-chain would
+// require a hard fork, so we patch the API response instead.
+func replaceKDAInfo(asset *kapps.KDAData) {
+	if asset == nil {
+		return
+	}
+
+	id := string(asset.ID)
+	if id != KLVAssetID && id != KFIAssetID {
+		return
+	}
+
+	asset.Logo = "https://kleverscan.org/assets/klv-logo.png"
+	if id == KFIAssetID {
+		asset.Logo = "https://kleverscan.org/assets/kfi-logo.png"
+	}
+
+	asset.URIs = map[string]string{
+		"Whitepaper": "https://bc.klever.finance/wp",
+		"Exchange":   "https://bitcoin.me/",
+		"Github":     "https://github.com/klever-io",
+		"Instagram":  "https://instagram.com/klever.io",
+		"Twitter":    "https://x.com/klever_org",
+		"Wallet":     "https://klever.io/",
+		"Website":    "https://klever.org/",
+	}
 }
 
 type NFTAsset struct {

--- a/network/api/asset/routes_test.go
+++ b/network/api/asset/routes_test.go
@@ -1,6 +1,8 @@
 package asset_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,10 +10,11 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/klever-io/klever-go/config"
-	"github.com/klever-io/klever-go/network/api/address"
+	"github.com/klever-io/klever-go/kapps"
 	"github.com/klever-io/klever-go/network/api/asset"
 	"github.com/klever-io/klever-go/network/api/middleware"
 	"github.com/klever-io/klever-go/network/api/mock"
+	"github.com/klever-io/klever-go/network/api/shared"
 	"github.com/klever-io/klever-go/network/api/wrapper"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,7 +23,7 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-func TestAddressRoute_EmptyTrailReturns404(t *testing.T) {
+func TestAssetRoute_EmptyTrailReturns404(t *testing.T) {
 	t.Parallel()
 	facade := mock.Facade{}
 	ws := startNodeServer(&facade)
@@ -31,6 +34,159 @@ func TestAddressRoute_EmptyTrailReturns404(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.Code)
 }
 
+func TestGetAsset(t *testing.T) {
+	t.Parallel()
+
+	const (
+		klvLogo = "https://kleverscan.org/assets/klv-logo.png"
+		kfiLogo = "https://kleverscan.org/assets/kfi-logo.png"
+	)
+
+	expectedOverriddenURIs := map[string]string{
+		"Whitepaper": "https://bc.klever.finance/wp",
+		"Exchange":   "https://bitcoin.me/",
+		"Github":     "https://github.com/klever-io",
+		"Instagram":  "https://instagram.com/klever.io",
+		"Twitter":    "https://x.com/klever_org",
+		"Wallet":     "https://klever.io/",
+		"Website":    "https://klever.org/",
+	}
+
+	staleURIs := map[string]string{
+		"Website": "https://stale.example/",
+	}
+
+	tests := []struct {
+		name         string
+		assetID      string
+		mockHandler  func(assetID string) (*kapps.KDAData, error)
+		expectedCode int
+		expectedLogo string
+		expectedURIs map[string]string
+		expectedErr  string
+	}{
+		{
+			name:    "Success with non-native asset returns asset unchanged",
+			assetID: "ABC-1234",
+			mockHandler: func(assetID string) (*kapps.KDAData, error) {
+				return &kapps.KDAData{
+					ID:   []byte(assetID),
+					Logo: "https://example.com/abc.png",
+					URIs: map[string]string{"Website": "https://abc.example/"},
+				}, nil
+			},
+			expectedCode: http.StatusOK,
+			expectedLogo: "https://example.com/abc.png",
+			expectedURIs: map[string]string{"Website": "https://abc.example/"},
+		},
+		{
+			name:    "Success with KLV overrides logo and URIs",
+			assetID: "KLV",
+			mockHandler: func(assetID string) (*kapps.KDAData, error) {
+				return &kapps.KDAData{
+					ID:   []byte(assetID),
+					Logo: "https://stale.example/klv.png",
+					URIs: staleURIs,
+				}, nil
+			},
+			expectedCode: http.StatusOK,
+			expectedLogo: klvLogo,
+			expectedURIs: expectedOverriddenURIs,
+		},
+		{
+			name:    "Success with KFI overrides logo and URIs",
+			assetID: "KFI",
+			mockHandler: func(assetID string) (*kapps.KDAData, error) {
+				return &kapps.KDAData{
+					ID:   []byte(assetID),
+					Logo: "https://stale.example/kfi.png",
+					URIs: staleURIs,
+				}, nil
+			},
+			expectedCode: http.StatusOK,
+			expectedLogo: kfiLogo,
+			expectedURIs: expectedOverriddenURIs,
+		},
+		{
+			name:    "Facade returns error",
+			assetID: "KLV",
+			mockHandler: func(assetID string) (*kapps.KDAData, error) {
+				return nil, fmt.Errorf("facade error")
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedErr:  "could not get requested asset: facade error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			facade := mock.Facade{}
+			facade.GetAssetHandler = tc.mockHandler
+
+			ws := startNodeServer(&facade)
+
+			req, _ := http.NewRequest("GET", fmt.Sprintf("/asset/%s", tc.assetID), nil)
+			resp := httptest.NewRecorder()
+			ws.ServeHTTP(resp, req)
+
+			assert.Equal(t, tc.expectedCode, resp.Code)
+
+			var response shared.GenericAPIResponse
+			err := json.Unmarshal(resp.Body.Bytes(), &response)
+			assert.NoError(t, err)
+
+			if tc.expectedErr != "" {
+				assert.Contains(t, response.Error, tc.expectedErr)
+				assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+				return
+			}
+
+			assert.Empty(t, response.Error)
+			assert.Equal(t, shared.ReturnCodeSuccess, response.Code)
+
+			data, ok := response.Data.(map[string]any)
+			assert.True(t, ok, "response data should be an object")
+
+			assetData, ok := data["asset"].(map[string]any)
+			assert.True(t, ok, "response data should contain asset object")
+
+			assert.Equal(t, tc.expectedLogo, assetData["Logo"])
+
+			uris, ok := assetData["URIs"].(map[string]any)
+			assert.True(t, ok, "URIs should be a map")
+			assert.Len(t, uris, len(tc.expectedURIs))
+			for k, v := range tc.expectedURIs {
+				assert.Equal(t, v, uris[k])
+			}
+		})
+	}
+}
+
+func TestGetAsset_InvalidFacade(t *testing.T) {
+	t.Parallel()
+
+	ws := gin.New()
+	ws.Use(cors.Default())
+	assetRoutes := ws.Group("/asset")
+	assetRoutes.Use(func(c *gin.Context) {
+		c.Set("facade", "not a facade")
+		c.Next()
+	})
+	assetRoute, _ := wrapper.NewRouterWrapper("asset", assetRoutes, getRoutesConfig())
+	asset.Routes(assetRoute)
+
+	req, _ := http.NewRequest("GET", "/asset/KLV", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	var response shared.GenericAPIResponse
+	err := json.Unmarshal(resp.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+}
+
 func startNodeServer(handler asset.FacadeHandler) *gin.Engine {
 	ws := gin.New()
 	ws.Use(cors.Default())
@@ -39,7 +195,7 @@ func startNodeServer(handler asset.FacadeHandler) *gin.Engine {
 		assetRoutes.Use(middleware.WithFacade(handler))
 	}
 	assetRoute, _ := wrapper.NewRouterWrapper("asset", assetRoutes, getRoutesConfig())
-	address.Routes(assetRoute)
+	asset.Routes(assetRoute)
 	return ws
 }
 
@@ -49,6 +205,8 @@ func getRoutesConfig() config.APIRoutesConfig {
 			"asset": {
 				Routes: []config.RouteConfig{
 					{Name: "/:id", Open: true},
+					{Name: "/nft/:owner/*id", Open: true},
+					{Name: "/pool/:id/", Open: true},
 				},
 			},
 		},

--- a/network/api/asset/routes_test.go
+++ b/network/api/asset/routes_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/klever-io/klever-go/network/api/shared"
 	"github.com/klever-io/klever-go/network/api/wrapper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -26,7 +27,7 @@ func init() {
 func TestAssetRoute_EmptyTrailReturns404(t *testing.T) {
 	t.Parallel()
 	facade := mock.Facade{}
-	ws := startNodeServer(&facade)
+	ws := startNodeServer(t, &facade)
 
 	req, _ := http.NewRequest("GET", "/asset", nil)
 	resp := httptest.NewRecorder()
@@ -123,7 +124,7 @@ func TestGetAsset(t *testing.T) {
 			facade := mock.Facade{}
 			facade.GetAssetHandler = tc.mockHandler
 
-			ws := startNodeServer(&facade)
+			ws := startNodeServer(t, &facade)
 
 			req, _ := http.NewRequest("GET", fmt.Sprintf("/asset/%s", tc.assetID), nil)
 			resp := httptest.NewRecorder()
@@ -172,7 +173,8 @@ func TestGetAsset_InvalidFacade(t *testing.T) {
 		c.Set("facade", "not a facade")
 		c.Next()
 	})
-	assetRoute, _ := wrapper.NewRouterWrapper("asset", assetRoutes, getRoutesConfig())
+	assetRoute, err := wrapper.NewRouterWrapper("asset", assetRoutes, getRoutesConfig())
+	require.NoError(t, err)
 	asset.Routes(assetRoute)
 
 	req, _ := http.NewRequest("GET", "/asset/KLV", nil)
@@ -182,19 +184,21 @@ func TestGetAsset_InvalidFacade(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, resp.Code)
 
 	var response shared.GenericAPIResponse
-	err := json.Unmarshal(resp.Body.Bytes(), &response)
+	err = json.Unmarshal(resp.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
 }
 
-func startNodeServer(handler asset.FacadeHandler) *gin.Engine {
+func startNodeServer(t *testing.T, handler asset.FacadeHandler) *gin.Engine {
+	t.Helper()
 	ws := gin.New()
 	ws.Use(cors.Default())
 	assetRoutes := ws.Group("/asset")
 	if handler != nil {
 		assetRoutes.Use(middleware.WithFacade(handler))
 	}
-	assetRoute, _ := wrapper.NewRouterWrapper("asset", assetRoutes, getRoutesConfig())
+	assetRoute, err := wrapper.NewRouterWrapper("asset", assetRoutes, getRoutesConfig())
+	require.NoError(t, err)
 	asset.Routes(assetRoute)
 	return ws
 }

--- a/network/api/asset/routes_test.go
+++ b/network/api/asset/routes_test.go
@@ -126,14 +126,15 @@ func TestGetAsset(t *testing.T) {
 
 			ws := startNodeServer(t, &facade)
 
-			req, _ := http.NewRequest("GET", fmt.Sprintf("/asset/%s", tc.assetID), nil)
+			req, err := http.NewRequest("GET", fmt.Sprintf("/asset/%s", tc.assetID), nil)
+			require.NoError(t, err)
 			resp := httptest.NewRecorder()
 			ws.ServeHTTP(resp, req)
 
 			assert.Equal(t, tc.expectedCode, resp.Code)
 
 			var response shared.GenericAPIResponse
-			err := json.Unmarshal(resp.Body.Bytes(), &response)
+			err = json.Unmarshal(resp.Body.Bytes(), &response)
 			assert.NoError(t, err)
 
 			if tc.expectedErr != "" {
@@ -177,7 +178,8 @@ func TestGetAsset_InvalidFacade(t *testing.T) {
 	require.NoError(t, err)
 	asset.Routes(assetRoute)
 
-	req, _ := http.NewRequest("GET", "/asset/KLV", nil)
+	req, err := http.NewRequest("GET", "/asset/KLV", nil)
+	require.NoError(t, err)
 	resp := httptest.NewRecorder()
 	ws.ServeHTTP(resp, req)
 


### PR DESCRIPTION
## Summary                                      
  Override the KLV and KFI asset metadata in the `GetAsset` node  
  API response so clients receive up-to-date logo and URI values  
  instead of the stale ones registered at genesis.
                                                                  
  ## Problem      
  The KLV and KFI assets had their `Logo` and `URIs` registered at
   genesis and have since become outdated. Updating those fields  
  on-chain would require a hard fork, so the `GET /asset/:id`
  endpoint kept returning incorrect metadata for the two native   
  assets.         

  ## Solution
  Patch the response in the API layer: after fetching the asset,
  if the ID is `KLV` or `KFI`, replace the `Logo` and `URIs` with 
  the current canonical values before serializing the response.
  All other assets are returned untouched.                        
                  
  ## Key Changes
  - **New:**
    - `replaceKDAInfo` helper in `network/api/asset/routes.go`
  that overrides `Logo` and `URIs` for `KLV` and `KFI`.           
    - `KLVAssetID` and `KFIAssetID` constants in
  `network/api/asset/routes.go`.                                  
  - **Updated:**  
    - `GetAsset` in `network/api/asset/routes.go` now calls       
  `replaceKDAInfo` before returning the response.                 
  - **Removed:**
    - None.                                                       
                                                                  
  ## Testing
  - [x] All existing tests pass (`make tests`)                    
  - [ ] New tests added for new functionality
  - [x] Manual testing performed:
    - Hit `GET /asset/KLV` and `GET /asset/KFI` against a local   
  node and confirmed the logo URL and URIs match the expected     
  values.                                                         
    - Hit `GET /asset/<other-asset>` and confirmed the response is
   unchanged.                                                     
  
  ## Configuration Changes                                        
  None.           

  ## Breaking Changes
  None. The override is response-only and applies to two
  well-known asset IDs; the data shape is unchanged.              
  
  ## Related Issues                                               
  Fixes # KLC-2332
  Related to #                                                    
  
  ## Checklist                                                    
  - [x] Code follows project style guidelines (`make goimports`)
  - [ ] Tests added/updated and passing
  - [ ] Documentation updated (README, CLAUDE.md, code comments)
  - [x] Commit messages follow [Conventional                      
  Commits](https://www.conventionalcommits.org/)
  - [x] No unnecessary files included                             
  - [x] Breaking changes documented above                         
  - [x] Configuration changes documented above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Scope and Impact Assessment

This change is non-consensus and strictly API-layer. It patches HTTP responses for two well-known native asset IDs (KLV, KFI) by replacing Logo and URIs after the asset is fetched and before JSON serialization. It does not modify on-chain state, transaction processing, consensus, KVM, or peer networking. Node stability and data integrity are not impacted because the mutation is local to the request-scoped response object.

## Changes

- Added unexported constants klvAssetID and kfiAssetID in network/api/asset/routes.go.
- Added replaceKDAInfo(asset *kapps.KDAData) helper in network/api/asset/routes.go which:
  - no-ops on nil asset,
  - checks asset.ID and only applies when ID == "KLV" or "KFI",
  - overwrites asset.Logo with a canonical URL and replaces asset.URIs with a fixed mapping.
- Updated GetAsset handler in network/api/asset/routes.go to call replaceKDAInfo before returning the response.
- Tests: expanded network/api/asset/routes_test.go with TestGetAsset (table-driven) to assert KLV/KFI overrides and that non-native assets pass through unchanged, plus TestGetAsset_InvalidFacade and route setup changes (startNodeServer signature updated and extra open routes in test config).

## Implementation details relevant to safety and cross-cutting concerns

- Scope and mutation: The helper mutates only the in-memory KDAData returned by the facade within the request handler; there is no persistence or global/shared state modification.
- Guards: replaceKDAInfo guards against nil assets and only runs for the two explicit IDs.
- Error handling: Existing error paths are unchanged — facade retrieval errors still return internal-server-error responses. The change does not introduce new error codes.
- Concurrency: No concurrency primitives or shared runtime components are altered; mutation is confined to the request lifecycle.
- Surface area: Only GET /asset/:id responses for KLV and KFI are affected.

## Blockchain-critical impact

- Consensus: none.
- Transaction processing / KVM / state management: none.
- Networking / peer sync: none.
- Data integrity: on-chain data remains unchanged; this is a presentation-layer override.
- Node stability: unaffected.

## Testing

- Existing test suite passes; tests were updated/added to validate:
  - Non-native assets remain unchanged,
  - KLV and KFI return the overridden Logo and URIs,
  - Facade error and invalid-facade context produce internal error responses.
- Manual verification reported for GET /asset/KLV and GET /asset/KFI.

## Configuration / Breaking changes

- None; response-only override limited to two known IDs.

## Related issue

- Fixes KLC-2332
<!-- end of auto-generated comment: release notes by coderabbit.ai -->