### PR TITLE
[KLC-2349] Adopt -trimpath -s -w -buildid= -buildvcs=false for release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,9 +56,9 @@ jobs:
 
       - name: Build
         run: |
-          make build-operator
-          make build-validator
-          make build-benchmark
+          make build-operator RELEASE=1
+          make build-validator RELEASE=1
+          make build-benchmark RELEASE=1
 
       - name: Create tarball
         run: |

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ldflags := -X 'main.appVersion=${VERSION}'
 # machines. Panic stack traces and pprof remain readable on RELEASE=1 builds
 # because Go's runtime symbol table (pclntab) is independent of DWARF.
 GO_BUILD_FLAGS :=
-ifdef RELEASE
+ifeq ($(RELEASE),1)
 ldflags += -s -w -buildid=
 GO_BUILD_FLAGS := -trimpath -buildvcs=false
 endif

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,17 @@ VERSION := $(shell git describe --always --long --dirty --tag)
 endif
 ldflags := -X 'main.appVersion=${VERSION}'
 
+# Release builds strip DWARF, build IDs, and trim source paths for smaller,
+# reproducible binaries. Set RELEASE=1 in CI / docker release builds.
+# Local `make build` keeps DWARF + symbols so delve still works on developer
+# machines. Panic stack traces and pprof remain readable on RELEASE=1 builds
+# because Go's runtime symbol table (pclntab) is independent of DWARF.
+GO_BUILD_FLAGS :=
+ifdef RELEASE
+ldflags += -s -w -buildid=
+GO_BUILD_FLAGS := -trimpath -buildvcs=false
+endif
+
 ifdef FOR_TESTNET
 FOR_TESTNET := -testnet
 endif
@@ -50,7 +61,7 @@ endif
 
 GOCMD=go
 GORUN=$(ENV_FLAG) $(GOCMD) run -ldflags="$(ldflags)"
-GOBUILD=$(GOCMD) build -ldflags="$(ldflags) -extldflags '-Wl,-rpath,\$$ORIGIN,-rpath,@executable_path'"
+GOBUILD=$(GOCMD) build $(GO_BUILD_FLAGS) -ldflags="$(ldflags) -extldflags '-Wl,-rpath,\$$ORIGIN,-rpath,@executable_path'"
 
 .DEFAULT_GOAL := help
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ ENV VERSION=$arg_version
 # Use cache mounts for faster incremental builds
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    make build
+    make build RELEASE=1
 
 FROM debian:trixie-slim
 

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -32,7 +32,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 # Force clean build to ensure Go 1.25 binaries
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    rm -rf ./bin/* && make build
+    rm -rf ./bin/* && make build RELEASE=1
 
 FROM alpine:3.19
 

--- a/docker/Dockerfile.alpine.validator
+++ b/docker/Dockerfile.alpine.validator
@@ -32,7 +32,7 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 # Force clean build to ensure Go 1.25 binaries
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    rm -rf ./bin/* && make build-validator
+    rm -rf ./bin/* && make build-validator RELEASE=1
 
 FROM alpine:3.19
 

--- a/docker/Dockerfile.validator
+++ b/docker/Dockerfile.validator
@@ -12,7 +12,7 @@ ENV VERSION=$arg_version
 # Use cache mounts for faster incremental builds
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    make build-validator
+    make build-validator RELEASE=1
 
 FROM debian:trixie-slim
 


### PR DESCRIPTION
## Summary

Add a `RELEASE=1` Makefile switch that opts release builds (Docker images and the GitHub release workflow) into standard Go release-hygiene flags. Local `make build` is unchanged so `delve` keeps working for developers.

## Problem

Release binaries currently ship with full DWARF debug info, the full symbol table, embedded build-machine path prefixes (e.g. `/go/src/github.com/klever-io/klever-go/...`), and non-deterministic build IDs / VCS metadata. Most production Go projects (geth, prometheus, kubernetes, hashicorp tools) strip these for release builds — adopting the same standard hygiene gives smaller binaries, no leaked filesystem paths, and slightly more reproducible artefacts.

## Solution

Gate the release flags behind a new `RELEASE=1` Make variable and have all release consumers (4 Dockerfiles + `release.yaml` workflow) opt in. The default `make build` path is untouched, so local debugging with `delve` / `gdb` continues to work.

Why panic traces and `pprof` still work on `RELEASE=1` builds: Go's runtime symbol table (`pclntab`) is independent of DWARF — `-s -w` strips DWARF + the standard symbol table, but function names + line numbers used by panics, `runtime.Stack()`, and `pprof` come from `pclntab` and survive.

## Key Changes

- **Updated:**
  - `Makefile` — new `ifdef RELEASE` block sets `ldflags += -s -w -buildid=` and `GO_BUILD_FLAGS := -trimpath -buildvcs=false`; `GOBUILD` now interpolates `$(GO_BUILD_FLAGS)`. Default build flags unchanged.
  - `docker/Dockerfile`, `docker/Dockerfile.alpine`, `docker/Dockerfile.validator`, `docker/Dockerfile.alpine.validator` — `make build`/`make build-validator` → same with `RELEASE=1`.
  - `.github/workflows/release.yaml` — `make build-operator`/`build-validator`/`build-benchmark` now passed `RELEASE=1`.

## Testing

- [x] Default build still works: `make build-validator` → 85M binary, DWARF + symbols intact.
- [x] Release build works: `make build-validator RELEASE=1` → 60M binary (~29% smaller, matches predicted 25–35%).
- [x] Release binary boots and loads wasmer2: `./bin/validator --version` reports `v1.7.16-14-g6f423a5e-dirty/go1.25.1/darwin-arm64/...`.
- [x] `go version -m bin/validator` confirms `-trimpath=true` set, no `vcs.*` metadata present.
- [x] Symbol table stripped: `nm` reports 1543 symbols (Mach-O dyld minimum) vs ~150k+ on default.
- [x] `go tool buildid bin/validator` is empty (confirms `-buildid=`).
- [x] Panic-trace smoke test on a minimal program built with the same flags: function names + `:line` numbers preserved; only difference is absolute build path → module-relative path.

## Configuration Changes

None at runtime. Build-time only: CI/Docker pipelines now invoke `make ... RELEASE=1`. Local development is unaffected.

## Breaking Changes

None. Default `make build` behavior is preserved exactly.

## Related Issues

Fixes KLC-2349

## Checklist

- [x] Code follows project style guidelines
- [x] Manual testing performed (build sizes, panic trace, version output, symbol/buildid/buildvcs verification)
- [x] No unnecessary files included
- [x] Breaking changes documented above
- [x] Configuration changes documented above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR only changes build and CI/Docker packaging: Makefile, Dockerfiles (docker/*), and .github/workflows/release.yaml. It introduces an explicit RELEASE=1 opt-in that sets GO build flags (-trimpath -buildvcs=false) and ldflags (-s -w -buildid=) for release builds, and updates GOBUILD to include GO_BUILD_FLAGS. The workflow and Dockerfile builder stages now invoke make targets with RELEASE=1. The Makefile uses ifeq ($(RELEASE),1) so release mode activates only when RELEASE is explicitly set to 1.

Impact on blockchain-critical areas
- Consensus, transaction processing, state management, KVM (WASM runtime), networking, concurrency, and error-handling code: unaffected. No source code or API changes were made.
- Node stability and data integrity: unaffected. Runtime behavior and configuration are unchanged.
- Cross-cutting concerns (concurrency, error handling, panic traces, profiling): preserved — pclntab remains so panic stack traces and pprof information (function names/line numbers) are retained despite DWARF/symbol stripping.

Other effects
- Release binaries (when built with RELEASE=1) are smaller (~29% observed), have stripped symbol tables, empty buildid and no VCS metadata, and are more reproducible.
- Default local make builds remain unchanged to preserve developer debugging (delve, full DWARF).
- No runtime/breaking changes introduced.

Conclusion: Safe build/packaging-only change improving binary size and reproducibility with no impact on node correctness, stability, or blockchain-critical functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->