### PR TITLE
perf(dataValidators): drop per-tx goroutine fan-out in CheckTxValidity

### DIFF
--- a/core/process/dataValidators/txValidator.go
+++ b/core/process/dataValidators/txValidator.go
@@ -2,7 +2,6 @@ package dataValidators
 
 import (
 	"fmt"
-	"sync"
 
 	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common"
@@ -184,29 +183,13 @@ func (txv *txValidator) CheckTxValidity(interceptedTx process.TxValidatorHandler
 		}
 	}
 
-	signersPub := make(map[string]crypto.PublicKey)
-	wait := sync.WaitGroup{}
-	var mu sync.Mutex
-	var loadErr error
+	signersPub := make(map[string]crypto.PublicKey, len(permission.Signers))
 	for _, signer := range permission.Signers {
-		wait.Add(1)
-		go func(addrPub string, wg *sync.WaitGroup, sig map[string]crypto.PublicKey, mut *sync.Mutex) {
-			defer wg.Done()
-			senderPubKey, err := txv.keyGen.PublicKeyFromByteArray([]byte(addrPub))
-			if err != nil {
-				// signer address is invalid
-				loadErr = err
-				return
-			}
-			mut.Lock()
-			sig[addrPub] = senderPubKey
-			mut.Unlock()
-		}(string(signer.Address), &wait, signersPub, &mu)
-	}
-
-	wait.Wait()
-	if loadErr != nil {
-		return loadErr
+		senderPubKey, err := txv.keyGen.PublicKeyFromByteArray(signer.Address)
+		if err != nil {
+			return err
+		}
+		signersPub[string(signer.Address)] = senderPubKey
 	}
 
 	signWeight := int64(0)

--- a/core/process/dataValidators/txValidator_bench_test.go
+++ b/core/process/dataValidators/txValidator_bench_test.go
@@ -1,0 +1,326 @@
+package dataValidators_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/core/process/dataValidators"
+	"github.com/klever-io/klever-go/crypto"
+	cryptoMock "github.com/klever-io/klever-go/crypto/mock"
+	"github.com/klever-io/klever-go/crypto/signing"
+	"github.com/klever-io/klever-go/crypto/signing/ed25519"
+	"github.com/klever-io/klever-go/data/state"
+)
+
+var errBenchInvalidPubKey = errors.New("bench: invalid pubkey")
+
+// benchKeyGen returns a KeyGenMock whose PublicKeyFromByteArray simulates
+// `cost` rounds of sha256 work per call. cost=0 measures pure overhead;
+// cost>0 approximates real elliptic-curve point decoding.
+func benchKeyGen(cost int) *cryptoMock.KeyGenMock {
+	return &cryptoMock.KeyGenMock{
+		PublicKeyFromByteArrayMock: func(b []byte) (crypto.PublicKey, error) {
+			h := sha256.Sum256(b)
+			for range cost {
+				h = sha256.Sum256(h[:])
+			}
+			_ = h
+			return &cryptoMock.PublicKeyMock{}, nil
+		},
+	}
+}
+
+// buildBenchValidator creates a tx validator whose account has `numSigners`
+// signers, all sharing the same address. Threshold=1, each weight=1, so
+// any one valid Verify clears the threshold check.
+func buildBenchValidator(numSigners int, keygenCost int) (process.TxValidator, []byte) {
+	addressMock := bytes.Repeat([]byte{0xAB}, 32)
+
+	signers := make([]*state.Key, numSigners)
+	for i := range signers {
+		signers[i] = &state.Key{Address: addressMock, Weight: 1}
+	}
+
+	adb := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			acc, _ := state.NewUserAccount(addressMock)
+			acc.Permissions = []*state.Permission{
+				{
+					Type:      state.Permission_Owner,
+					Threshold: 1,
+					Signers:   signers,
+				},
+			}
+			return acc, nil
+		},
+	}
+
+	v, _ := dataValidators.NewTxValidator(
+		adb,
+		storageTest,
+		getTxPoolsHolder(),
+		&mock.WhiteListHandlerStub{},
+		mock.NewPubkeyConverterMock(32),
+		&cryptoMock.SingleSignerStub{
+			VerifyCalled: func(_ crypto.PublicKey, _, _ []byte) error { return nil },
+		},
+		benchKeyGen(keygenCost),
+		getKAppController(),
+		core.MaxTxNonceDeltaAllowed,
+	)
+	return v, addressMock
+}
+
+// makeBenchInterceptedTx wraps the validator handler + intercepted-data stub
+// into the anonymous struct CheckTxValidity expects.
+func makeBenchInterceptedTx(addr []byte) interface {
+	process.InterceptedData
+	process.TxValidatorHandler
+} {
+	return struct {
+		process.InterceptedData
+		process.TxValidatorHandler
+	}{
+		InterceptedData:    &mock.InterceptedDataStub{},
+		TxValidatorHandler: getTxValidatorHandler(addr, 0, 0),
+	}
+}
+
+// BenchmarkCheckTxValidity_Signers measures end-to-end CheckTxValidity time
+// across signer counts. The keygen cost is 0 (mock returns immediately) so
+// the result isolates the signer-loop overhead from real EC point decode.
+func BenchmarkCheckTxValidity_Signers(b *testing.B) {
+	for _, n := range []int{1, 2, 3, 5, 10, 20} {
+		b.Run(fmt.Sprintf("signers=%d", n), func(b *testing.B) {
+			v, addr := buildBenchValidator(n, 0)
+			tx := makeBenchInterceptedTx(addr)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := v.CheckTxValidity(tx); err != nil {
+					b.Fatalf("unexpected err: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCheckTxValidity_SignersWithCost measures the same path with a
+// realistic per-signer cost (50 sha256 iterations ~= a few µs of CPU work
+// per pubkey decode), which is the regime where parallelism could help.
+func BenchmarkCheckTxValidity_SignersWithCost(b *testing.B) {
+	for _, n := range []int{1, 3, 10} {
+		b.Run(fmt.Sprintf("signers=%d", n), func(b *testing.B) {
+			v, addr := buildBenchValidator(n, 50)
+			tx := makeBenchInterceptedTx(addr)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := v.CheckTxValidity(tx); err != nil {
+					b.Fatalf("unexpected err: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// loadSignerKeysSerial replicates the new production loop body in isolation,
+// for direct head-to-head benching against the parallel variant.
+func loadSignerKeysSerial(signers []*state.Key, kg crypto.KeyGenerator) (map[string]crypto.PublicKey, error) {
+	out := make(map[string]crypto.PublicKey, len(signers))
+	for _, s := range signers {
+		pk, err := kg.PublicKeyFromByteArray(s.Address)
+		if err != nil {
+			return nil, err
+		}
+		out[string(s.Address)] = pk
+	}
+	return out, nil
+}
+
+// loadSignerKeysParallel replicates the OLD production loop body (goroutine
+// per signer + WaitGroup + Mutex). Kept here so we can bench both
+// implementations against real ed25519 keygen and pick a breakeven.
+func loadSignerKeysParallel(signers []*state.Key, kg crypto.KeyGenerator) (map[string]crypto.PublicKey, error) {
+	out := make(map[string]crypto.PublicKey)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var loadErr error
+	var errMu sync.Mutex
+	for _, s := range signers {
+		wg.Add(1)
+		go func(addrPub string) {
+			defer wg.Done()
+			pk, err := kg.PublicKeyFromByteArray([]byte(addrPub))
+			if err != nil {
+				errMu.Lock()
+				if loadErr == nil {
+					loadErr = err
+				}
+				errMu.Unlock()
+				return
+			}
+			mu.Lock()
+			out[addrPub] = pk
+			mu.Unlock()
+		}(string(s.Address))
+	}
+	wg.Wait()
+	if loadErr != nil {
+		return nil, loadErr
+	}
+	return out, nil
+}
+
+// realKeyGenAndAddrs returns a real ed25519 KeyGenerator plus n valid 32-byte
+// public-key addresses (so PublicKeyFromByteArray actually does the EC point
+// decode work — random bytes would either fail decoding or take a degenerate
+// fast-path).
+func realKeyGenAndAddrs(n int) (crypto.KeyGenerator, [][]byte) {
+	kg := signing.NewKeyGenerator(ed25519.NewEd25519())
+	addrs := make([][]byte, n)
+	for i := range addrs {
+		_, pub := kg.GeneratePair()
+		raw, err := pub.ToByteArray()
+		if err != nil {
+			panic(err)
+		}
+		addrs[i] = raw
+	}
+	return kg, addrs
+}
+
+func makeSigners(addrs [][]byte) []*state.Key {
+	signers := make([]*state.Key, len(addrs))
+	for i, a := range addrs {
+		signers[i] = &state.Key{Address: a, Weight: 1}
+	}
+	return signers
+}
+
+// BenchmarkLoadSignerKeys_RealEd25519 measures the signer-key-decode loop in
+// isolation, with the real ed25519 keygen used in production. Reports both
+// implementations side-by-side so we can pin the breakeven for a possible
+// `len(signers) > N` conditional.
+func BenchmarkLoadSignerKeys_RealEd25519(b *testing.B) {
+	for _, n := range []int{1, 2, 3, 4, 5, 6, 8, 10, 16, 20} {
+		kg, addrs := realKeyGenAndAddrs(n)
+		signers := makeSigners(addrs)
+
+		b.Run(fmt.Sprintf("serial/signers=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := loadSignerKeysSerial(signers, kg); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("parallel/signers=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := loadSignerKeysParallel(signers, kg); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCheckTxValidity_RealEd25519 covers the end-to-end CheckTxValidity
+// path with real ed25519 keygen, varying signer count. Confirms the
+// loop-isolation result holds when the rest of CheckTxValidity is included.
+func BenchmarkCheckTxValidity_RealEd25519(b *testing.B) {
+	for _, n := range []int{1, 2, 3, 5, 10, 20} {
+		b.Run(fmt.Sprintf("signers=%d", n), func(b *testing.B) {
+			kg, addrs := realKeyGenAndAddrs(n)
+			// All signers share the first address so the signature loop
+			// finds a match immediately (we're measuring the keygen loop,
+			// not signature verification cost).
+			sharedAddr := addrs[0]
+			signers := make([]*state.Key, n)
+			for i := range signers {
+				signers[i] = &state.Key{Address: sharedAddr, Weight: 1}
+			}
+			adb := &mock.AccountsStub{
+				GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+					acc, _ := state.NewUserAccount(sharedAddr)
+					acc.Permissions = []*state.Permission{
+						{Type: state.Permission_Owner, Threshold: 1, Signers: signers},
+					}
+					return acc, nil
+				},
+			}
+			v, _ := dataValidators.NewTxValidator(
+				adb, storageTest, getTxPoolsHolder(), &mock.WhiteListHandlerStub{},
+				mock.NewPubkeyConverterMock(32),
+				&cryptoMock.SingleSignerStub{
+					VerifyCalled: func(_ crypto.PublicKey, _, _ []byte) error { return nil },
+				},
+				kg, getKAppController(), core.MaxTxNonceDeltaAllowed,
+			)
+			tx := makeBenchInterceptedTx(sharedAddr)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := v.CheckTxValidity(tx); err != nil {
+					b.Fatalf("unexpected err: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// Smoke test: ensure the bench scaffolding actually exercises the multi-signer
+// path. Catches breakage in the helper before the bench reports misleading
+// numbers (e.g., short-circuit returning early because of mock misconfig).
+func TestBenchScaffolding_MultiSignerPathExecutes(t *testing.T) {
+	t.Parallel()
+	for _, n := range []int{1, 3, 10} {
+		v, addr := buildBenchValidator(n, 0)
+		tx := makeBenchInterceptedTx(addr)
+		if err := v.CheckTxValidity(tx); err != nil {
+			t.Fatalf("signers=%d: %v", n, err)
+		}
+	}
+	// also verify error path: invalid pubkey decode propagates
+	addressMock := bytes.Repeat([]byte{0xAB}, 32)
+	signers := []*state.Key{{Address: addressMock, Weight: 1}, {Address: addressMock, Weight: 1}}
+	adb := &mock.AccountsStub{
+		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			acc, _ := state.NewUserAccount(addressMock)
+			acc.Permissions = []*state.Permission{{Type: state.Permission_Owner, Threshold: 1, Signers: signers}}
+			return acc, nil
+		},
+	}
+	v, _ := dataValidators.NewTxValidator(
+		adb,
+		storageTest,
+		getTxPoolsHolder(),
+		&mock.WhiteListHandlerStub{},
+		mock.NewPubkeyConverterMock(32),
+		&cryptoMock.SingleSignerStub{},
+		&cryptoMock.KeyGenMock{
+			PublicKeyFromByteArrayMock: func(_ []byte) (crypto.PublicKey, error) {
+				return nil, errBenchInvalidPubKey
+			},
+		},
+		getKAppController(),
+		core.MaxTxNonceDeltaAllowed,
+	)
+	tx := makeBenchInterceptedTx(addressMock)
+	if err := v.CheckTxValidity(tx); err == nil {
+		t.Fatal("expected error from invalid keygen, got nil")
+	}
+}

--- a/core/process/dataValidators/txValidator_bench_test.go
+++ b/core/process/dataValidators/txValidator_bench_test.go
@@ -22,13 +22,17 @@ import (
 var errBenchInvalidPubKey = errors.New("bench: invalid pubkey")
 
 // benchKeyGen returns a KeyGenMock whose PublicKeyFromByteArray simulates
-// `cost` rounds of sha256 work per call. cost=0 measures pure overhead;
-// cost>0 approximates real elliptic-curve point decoding.
+// `cost` rounds of sha256 work per call. cost=0 returns immediately and
+// measures pure scaffolding overhead; cost>0 performs exactly `cost`
+// sha256 rounds to approximate real elliptic-curve point decoding.
 func benchKeyGen(cost int) *cryptoMock.KeyGenMock {
 	return &cryptoMock.KeyGenMock{
 		PublicKeyFromByteArrayMock: func(b []byte) (crypto.PublicKey, error) {
+			if cost == 0 {
+				return &cryptoMock.PublicKeyMock{}, nil
+			}
 			h := sha256.Sum256(b)
-			for range cost {
+			for i := 1; i < cost; i++ {
 				h = sha256.Sum256(h[:])
 			}
 			_ = h
@@ -40,7 +44,8 @@ func benchKeyGen(cost int) *cryptoMock.KeyGenMock {
 // buildBenchValidator creates a tx validator whose account has `numSigners`
 // signers, all sharing the same address. Threshold=1, each weight=1, so
 // any one valid Verify clears the threshold check.
-func buildBenchValidator(numSigners int, keygenCost int) (process.TxValidator, []byte) {
+func buildBenchValidator(tb testing.TB, numSigners int, keygenCost int) (process.TxValidator, []byte) {
+	tb.Helper()
 	addressMock := bytes.Repeat([]byte{0xAB}, 32)
 
 	signers := make([]*state.Key, numSigners)
@@ -62,7 +67,7 @@ func buildBenchValidator(numSigners int, keygenCost int) (process.TxValidator, [
 		},
 	}
 
-	v, _ := dataValidators.NewTxValidator(
+	v, err := dataValidators.NewTxValidator(
 		adb,
 		storageTest,
 		getTxPoolsHolder(),
@@ -75,6 +80,9 @@ func buildBenchValidator(numSigners int, keygenCost int) (process.TxValidator, [
 		getKAppController(),
 		core.MaxTxNonceDeltaAllowed,
 	)
+	if err != nil {
+		tb.Fatalf("NewTxValidator: %v", err)
+	}
 	return v, addressMock
 }
 
@@ -99,7 +107,7 @@ func makeBenchInterceptedTx(addr []byte) interface {
 func BenchmarkCheckTxValidity_Signers(b *testing.B) {
 	for _, n := range []int{1, 2, 3, 5, 10, 20} {
 		b.Run(fmt.Sprintf("signers=%d", n), func(b *testing.B) {
-			v, addr := buildBenchValidator(n, 0)
+			v, addr := buildBenchValidator(b, n, 0)
 			tx := makeBenchInterceptedTx(addr)
 
 			b.ReportAllocs()
@@ -119,7 +127,7 @@ func BenchmarkCheckTxValidity_Signers(b *testing.B) {
 func BenchmarkCheckTxValidity_SignersWithCost(b *testing.B) {
 	for _, n := range []int{1, 3, 10} {
 		b.Run(fmt.Sprintf("signers=%d", n), func(b *testing.B) {
-			v, addr := buildBenchValidator(n, 50)
+			v, addr := buildBenchValidator(b, n, 50)
 			tx := makeBenchInterceptedTx(addr)
 
 			b.ReportAllocs()
@@ -261,7 +269,7 @@ func BenchmarkCheckTxValidity_RealEd25519(b *testing.B) {
 					return acc, nil
 				},
 			}
-			v, _ := dataValidators.NewTxValidator(
+			v, err := dataValidators.NewTxValidator(
 				adb, storageTest, getTxPoolsHolder(), &mock.WhiteListHandlerStub{},
 				mock.NewPubkeyConverterMock(32),
 				&cryptoMock.SingleSignerStub{
@@ -269,6 +277,9 @@ func BenchmarkCheckTxValidity_RealEd25519(b *testing.B) {
 				},
 				kg, getKAppController(), core.MaxTxNonceDeltaAllowed,
 			)
+			if err != nil {
+				b.Fatalf("NewTxValidator: %v", err)
+			}
 			tx := makeBenchInterceptedTx(sharedAddr)
 
 			b.ReportAllocs()
@@ -288,7 +299,7 @@ func BenchmarkCheckTxValidity_RealEd25519(b *testing.B) {
 func TestBenchScaffolding_MultiSignerPathExecutes(t *testing.T) {
 	t.Parallel()
 	for _, n := range []int{1, 3, 10} {
-		v, addr := buildBenchValidator(n, 0)
+		v, addr := buildBenchValidator(t, n, 0)
 		tx := makeBenchInterceptedTx(addr)
 		if err := v.CheckTxValidity(tx); err != nil {
 			t.Fatalf("signers=%d: %v", n, err)
@@ -304,7 +315,7 @@ func TestBenchScaffolding_MultiSignerPathExecutes(t *testing.T) {
 			return acc, nil
 		},
 	}
-	v, _ := dataValidators.NewTxValidator(
+	v, err := dataValidators.NewTxValidator(
 		adb,
 		storageTest,
 		getTxPoolsHolder(),
@@ -319,8 +330,11 @@ func TestBenchScaffolding_MultiSignerPathExecutes(t *testing.T) {
 		getKAppController(),
 		core.MaxTxNonceDeltaAllowed,
 	)
+	if err != nil {
+		t.Fatalf("NewTxValidator: %v", err)
+	}
 	tx := makeBenchInterceptedTx(addressMock)
-	if err := v.CheckTxValidity(tx); err == nil {
-		t.Fatal("expected error from invalid keygen, got nil")
+	if err := v.CheckTxValidity(tx); !errors.Is(err, errBenchInvalidPubKey) {
+		t.Fatalf("expected %v, got %v", errBenchInvalidPubKey, err)
 	}
 }

--- a/core/process/dataValidators/txValidator_bench_test.go
+++ b/core/process/dataValidators/txValidator_bench_test.go
@@ -55,7 +55,10 @@ func buildBenchValidator(tb testing.TB, numSigners int, keygenCost int) (process
 
 	adb := &mock.AccountsStub{
 		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
-			acc, _ := state.NewUserAccount(addressMock)
+			acc, err := state.NewUserAccount(addressMock)
+			if err != nil {
+				return nil, err
+			}
 			acc.Permissions = []*state.Permission{
 				{
 					Type:      state.Permission_Owner,
@@ -262,7 +265,10 @@ func BenchmarkCheckTxValidity_RealEd25519(b *testing.B) {
 			}
 			adb := &mock.AccountsStub{
 				GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
-					acc, _ := state.NewUserAccount(sharedAddr)
+					acc, err := state.NewUserAccount(sharedAddr)
+					if err != nil {
+						return nil, err
+					}
 					acc.Permissions = []*state.Permission{
 						{Type: state.Permission_Owner, Threshold: 1, Signers: signers},
 					}
@@ -310,7 +316,10 @@ func TestBenchScaffolding_MultiSignerPathExecutes(t *testing.T) {
 	signers := []*state.Key{{Address: addressMock, Weight: 1}, {Address: addressMock, Weight: 1}}
 	adb := &mock.AccountsStub{
 		GetExistingAccountCalled: func(_ []byte) (state.AccountHandler, error) {
-			acc, _ := state.NewUserAccount(addressMock)
+			acc, err := state.NewUserAccount(addressMock)
+			if err != nil {
+				return nil, err
+			}
 			acc.Permissions = []*state.Permission{{Type: state.Permission_Owner, Threshold: 1, Signers: signers}}
 			return acc, nil
 		},


### PR DESCRIPTION
## Summary
Replace the per-signer goroutine fan-out in `CheckTxValidity`'s pubkey-decode loop with a serial loop. Real-ed25519 benchmarks show the parallel implementation is **5–8× slower than serial at every signer count from 1 to 20** because goroutine spawn (~400–500 ns) dwarfs `PublicKeyFromByteArray` work (~40–90 ns).

## Problem
`CheckTxValidity` (`core/process/dataValidators/txValidator.go`) decoded each permission signer's public key in its own goroutine, joining via `WaitGroup` with a `Mutex` around the shared `signersPub` map and an unsynchronized `loadErr` write.

Two issues:

1. **Performance.** The fan-out is unconditionally pessimal for the production keygen — there is no signer count at which it wins. Every transaction passing through the interceptor pays this overhead.
2. **Correctness.** `loadErr` was written by multiple goroutines without synchronization. Existing tests don't exercise multi-signer + invalid-key, so `go test -race` never tripped, but it was a latent data race.

## Solution
Serial loop, pre-sized map, no `sync` package. Pass `signer.Address` directly instead of `string(...) → []byte(...)` round-trip.

```go
signersPub := make(map[string]crypto.PublicKey, len(permission.Signers))
for _, signer := range permission.Signers {
    senderPubKey, err := txv.keyGen.PublicKeyFromByteArray(signer.Address)
    if err != nil {
        return err
    }
    signersPub[string(signer.Address)] = senderPubKey
}
```

A `len(Signers) > N` conditional was considered and rejected — see benchmark table below; no breakeven exists for the production ed25519 keygen.

## Key Changes
- **Updated:** `core/process/dataValidators/txValidator.go` — 22 lines → 7 lines, removed `sync` import.
- **New:** `core/process/dataValidators/txValidator_bench_test.go` — head-to-head bench of serial vs parallel implementations against the production ed25519 keygen, plus end-to-end `CheckTxValidity` benches and a scaffolding smoke test.

## Benchmarks
Apple M4 Max, darwin/arm64, real `signing.NewKeyGenerator(ed25519.NewEd25519())`. The signature-Verify step lives in a separate untouched loop and is mocked in the bench (it would shift absolute numbers up but not affect the serial-vs-parallel delta).

**Loop in isolation (`BenchmarkLoadSignerKeys_RealEd25519`):**

| signers | serial | parallel | serial wins by |
|--:|--:|--:|--:|
| 1 | 96.6 ns | 507 ns | 5.25× |
| 2 | 134.5 ns | 940 ns | 6.99× |
| 3 | 181.6 ns | 1250 ns | 6.88× |
| 4 | 223.4 ns | 1573 ns | 7.04× |
| 5 | 268.4 ns | 1906 ns | 7.10× |
| 6 | 313.3 ns | 2193 ns | 7.00× |
| 8 | 395.5 ns | 2813 ns | 7.11× |
| 10 | 563.5 ns | 4129 ns | 7.33× |
| 16 | 886.9 ns | 7329 ns | 8.27× |
| 20 | 1067 ns | 9396 ns | 8.81× |

**End-to-end `CheckTxValidity` (after change):** 227 ns @ 1 signer, 1264 ns @ 20 signers. Allocations roughly halved across all signer counts (no `WaitGroup`, no `Mutex`, no closure escape, no `string ↔ []byte` round-trip on `signer.Address`).

## Testing
- [x] `go vet ./core/process/dataValidators/` clean
- [x] `go test -race -count=1 ./core/process/dataValidators/ ./core/process/interceptors/processor/` passes
- [x] New benchmark (`BenchmarkLoadSignerKeys_RealEd25519`, `BenchmarkCheckTxValidity_RealEd25519`, `BenchmarkCheckTxValidity_Signers`, `BenchmarkCheckTxValidity_SignersWithCost`) exercises serial vs parallel side-by-side
- [x] New scaffolding smoke test (`TestBenchScaffolding_MultiSignerPathExecutes`) prevents the bench from silently short-circuiting

To reproduce:
```
go test -count=1 -bench='BenchmarkLoadSignerKeys_RealEd25519' -benchmem -benchtime=2s -run='^$' ./core/process/dataValidators/
```

## Breaking Changes
None. The function's public contract (signature, error semantics, return value) is unchanged. Errors now return on first invalid signer instead of the last (the original returned whichever invalid signer's goroutine wrote to `loadErr` last, which was nondeterministic due to the data race).

## Related Issues
None.

## Checklist
- [x] Code follows project style guidelines (`gofmt` / `goimports` clean)
- [x] Tests added/updated and passing
- [x] No documentation updates needed (no public API change)
- [x] Commit messages follow Conventional Commits
- [x] No unnecessary files included
- [x] No breaking changes
- [x] No configuration changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Performance optimization: serial public-key loading in transaction validation

**Affected components:** Transaction processing — CheckTxValidity in core/process/dataValidators (signature validation path). This affects transaction validation prior to consensus and state application; it does not change consensus/state formats, networking, or on-disk data.

**Change summary:**
- Replace per-signer goroutine fan-out (goroutine per signer + sync.WaitGroup + mutex + unsafely-written loadErr) with a serial loop that decodes each permission signer’s Address via txv.keyGen.PublicKeyFromByteArray and builds a pre-sized signersPub map in txValidator.CheckTxValidity (core/process/dataValidators/txValidator.go).
- Remove sync import and associated concurrency scaffolding; avoid an unnecessary string/[]byte round-trip when indexing the map.
- Add comprehensive benchmarks and a smoke test in core/process/dataValidators/txValidator_bench_test.go: serial vs parallel key-load microbenchmarks, end-to-end CheckTxValidity benches (mock and real ed25519 keygen), and a scaffolding test for multi-signer path.

**Stability and data integrity:**
- Removes a real data race (unsynchronized loadErr write and concurrent map population), eliminating nondeterministic behavior and potential panics or corrupted state during validation.
- Error handling becomes deterministic: CheckTxValidity now returns immediately on the first encountered invalid signer (previous parallel code could produce nondeterministic error ordering).
- No changes to exported APIs, persisted state formats, or consensus semantics.

**Concurrency and cross-cutting concerns:**
- Concurrency for signer public-key loading is removed; overall transaction validation remains serial with unchanged signature verification logic.
- Simplification reduces synchronization complexity and the surface for subtle race bugs; parallelism removed where its overhead dominated work.

**Performance impact:**
- Benchmarks using real ed25519 key decoding show the serial approach is substantially faster for practical signer counts (1–20). Goroutine spawn overhead (~400–500 ns) dominated per-key decode (~40–90 ns), making the previous parallel approach ~5–8× slower in common cases.
- Measured end-to-end CheckTxValidity after the change: ~227 ns at 1 signer and ~1,264 ns at 20 signers; allocations roughly halved.

**Testing and validation:**
- go vet clean; relevant packages pass go test -race -count=1.
- New benchmarks verify serial vs parallel tradeoffs and end-to-end cost with real key decoding; a smoke test ensures the multi-signer path executes and that key-decoding errors propagate.

**Backward compatibility / Breaking changes:**
- No breaking API changes. Semantic change: deterministic early return on the first invalid signer (removes prior nondeterminism due to concurrent error races).

**Code review pointers:**
- The production code change is small and focused (txValidator.go simplification); most additions are benchmarking and test scaffolding (~+349 lines). Review should focus on correctness of the deterministic error-return behavior, the correctness of signer map keys (string(byte[]) indexing), and validity of the new benchmarks/tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/44)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->