### PR TITLE
perf(kapp): zero-copy GetAndClearReturnData + pre-size receipt filters

### DIFF
--- a/core/kapp/context.go
+++ b/core/kapp/context.go
@@ -46,7 +46,7 @@ func (r *ReceiptSlice) Get() []*transaction.Transaction_Receipt {
 }
 
 func (r *ReceiptSlice) GetByType(receiptType int8) []*transaction.Transaction_Receipt {
-	var filtered []*transaction.Transaction_Receipt
+	filtered := make([]*transaction.Transaction_Receipt, 0, len(*r))
 	for _, receipt := range *r {
 		if len(receipt.Data) > 0 && len(receipt.Data[0]) > 0 && int8(receipt.Data[0][0]) == receiptType {
 			filtered = append(filtered, receipt)
@@ -56,7 +56,7 @@ func (r *ReceiptSlice) GetByType(receiptType int8) []*transaction.Transaction_Re
 }
 
 func (r *ReceiptSlice) GetPreserved() []*transaction.Transaction_Receipt {
-	var filtered []*transaction.Transaction_Receipt
+	filtered := make([]*transaction.Transaction_Receipt, 0, len(*r))
 	for _, receipt := range *r {
 		if len(receipt.Data) > 0 && len(receipt.Data[0]) > 0 && receipt.Data[0][0] >= SystemReceiptTypeStart {
 			filtered = append(filtered, receipt)
@@ -150,19 +150,22 @@ func (k *kappContext) AddReturnData(data []byte) {
 }
 
 func (k *kappContext) GetAndClearReturnData() [][]byte {
-	// Create a new outer slice with the same length as src
-	dst := make([][]byte, len(k.returnData))
-
-	// Iterate over each inner slice
-	for i, s := range k.returnData {
-		// Create a new inner slice with the same length as s
-		dst[i] = make([]byte, len(s))
-		// Copy the bytes from s to dst[i]
-		copy(dst[i], s)
+	// Move semantics: ownership of returnData transfers to the caller and
+	// the context resets to a fresh empty slice. SetReturnData and
+	// AddReturnData both allocate fresh storage on every write, so no
+	// aliasing of the returned slice remains via this struct.
+	//
+	// Preserve the original guarantee that this method never returns nil
+	// and that the field is non-nil-empty after the call: VMOutputApi
+	// carries a json:"returnData" tag, where nil JSON-renders to null
+	// while []byte{} renders to []. Downstream API consumers may
+	// distinguish.
+	out := k.returnData
+	if out == nil {
+		out = [][]byte{}
 	}
-
 	k.returnData = make([][]byte, 0)
-	return dst
+	return out
 }
 
 func (k *kappContext) GetExecData() []byte {

--- a/core/kapp/context_returndata_bench_test.go
+++ b/core/kapp/context_returndata_bench_test.go
@@ -1,0 +1,98 @@
+package kapp_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/klever-io/klever-go/core/kapp"
+	"github.com/klever-io/klever-go/data/block"
+)
+
+// genReturnData returns n byte slices of size bytes each, populated with
+// random data so the compiler can't constant-fold the copies away.
+func genReturnData(n, size int) [][]byte {
+	out := make([][]byte, n)
+	for i := range out {
+		out[i] = make([]byte, size)
+		_, _ = rand.Read(out[i])
+	}
+	return out
+}
+
+func newCtxWithReturnData(n, size int) kapp.KappContext {
+	ctx := kapp.NewKappContext(kapp.ArgsNewKAppContext{
+		OriginalSender: []byte("sender"),
+		ContractID:     0,
+		Block:          &block.Block{},
+	})
+	ctx.SetReturnData(genReturnData(n, size))
+	return ctx
+}
+
+// BenchmarkGetAndClearReturnData measures the per-call cost of pulling
+// return data out of the context. Sweep across realistic SC return shapes:
+//
+//   - (1, 32)     — single small item (typical: assetID, proposalID, orderID)
+//   - (5, 32)     — small array of small items (typical: minted-token IDs)
+//   - (10, 64)    — moderate array of moderate items (e.g., transfer batch IDs)
+//   - (50, 256)   — large array (uncommon but plausible for view fns)
+//   - (1, 4096)   — single large item (e.g., serialized struct)
+func BenchmarkGetAndClearReturnData(b *testing.B) {
+	cases := []struct{ n, size int }{
+		{1, 32},
+		{5, 32},
+		{10, 64},
+		{50, 256},
+		{1, 4096},
+	}
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("n=%d/size=%d", c.n, c.size), func(b *testing.B) {
+			// Refill the context every call so each iteration has data
+			// to drain. We measure GetAndClearReturnData *plus* the refill
+			// (SetReturnData), then subtract the refill cost separately.
+			data := genReturnData(c.n, c.size)
+			ctx := kapp.NewKappContext(kapp.ArgsNewKAppContext{
+				OriginalSender: []byte("sender"),
+				ContractID:     0,
+				Block:          &block.Block{},
+			})
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ctx.SetReturnData(data)
+				_ = ctx.GetAndClearReturnData()
+			}
+		})
+	}
+}
+
+// BenchmarkSetReturnData_Only isolates the refill cost so the
+// GetAndClearReturnData number above can be interpreted (subtract this
+// from the combined number to get the Get cost alone).
+func BenchmarkSetReturnData_Only(b *testing.B) {
+	cases := []struct{ n, size int }{
+		{1, 32},
+		{5, 32},
+		{10, 64},
+		{50, 256},
+		{1, 4096},
+	}
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("n=%d/size=%d", c.n, c.size), func(b *testing.B) {
+			data := genReturnData(c.n, c.size)
+			ctx := kapp.NewKappContext(kapp.ArgsNewKAppContext{
+				OriginalSender: []byte("sender"),
+				ContractID:     0,
+				Block:          &block.Block{},
+			})
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ctx.SetReturnData(data)
+			}
+		})
+	}
+}

--- a/core/kapp/context_returndata_bench_test.go
+++ b/core/kapp/context_returndata_bench_test.go
@@ -20,16 +20,6 @@ func genReturnData(n, size int) [][]byte {
 	return out
 }
 
-func newCtxWithReturnData(n, size int) kapp.KappContext {
-	ctx := kapp.NewKappContext(kapp.ArgsNewKAppContext{
-		OriginalSender: []byte("sender"),
-		ContractID:     0,
-		Block:          &block.Block{},
-	})
-	ctx.SetReturnData(genReturnData(n, size))
-	return ctx
-}
-
 // BenchmarkGetAndClearReturnData measures the per-call cost of pulling
 // return data out of the context. Sweep across realistic SC return shapes:
 //

--- a/core/kapp/context_test.go
+++ b/core/kapp/context_test.go
@@ -1,6 +1,7 @@
 package kapp_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -74,6 +75,99 @@ func TestKappContext_ExecutionTimeStorage(t *testing.T) {
 	// Verify it can be retrieved for validation (txProcess.go:337)
 	retrieved := ctx.GetExecutionTime()
 	assert.Equal(t, executionTime, retrieved)
+}
+
+// TestKappContext_ReturnData_RoundTrip exercises the returnData lifecycle:
+// SetReturnData -> GetAndClearReturnData empties the context, the returned
+// slice exposes the stored payload, and re-using the context after a Get
+// works (Add/Set on a freshly cleared context behave identically to a
+// brand-new context).
+func TestKappContext_ReturnData_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := kapp.NewKappContext(kapp.ArgsNewKAppContext{
+		OriginalSender: []byte("sender"),
+		ContractID:     0,
+		Block:          &block.Block{},
+	})
+
+	// initial Get on empty context returns an empty slice
+	first := ctx.GetAndClearReturnData()
+	assert.Empty(t, first, "fresh context has no return data")
+
+	payload := [][]byte{
+		[]byte("alpha"),
+		[]byte("beta"),
+		[]byte("gamma"),
+	}
+	ctx.SetReturnData(payload)
+
+	out := ctx.GetAndClearReturnData()
+	assert.Equal(t, payload, out, "Get returns the previously Set payload")
+
+	// context is empty after Get
+	again := ctx.GetAndClearReturnData()
+	assert.Empty(t, again, "context cleared after Get")
+
+	// reuse: Add after a Get works
+	ctx.AddReturnData([]byte("delta"))
+	ctx.AddReturnData([]byte("epsilon"))
+	out2 := ctx.GetAndClearReturnData()
+	assert.Equal(t, [][]byte{[]byte("delta"), []byte("epsilon")}, out2)
+}
+
+// TestKappContext_ReturnData_GetNeverReturnsNil pins the invariant that
+// GetAndClearReturnData always returns a non-nil slice — matching the
+// original implementation's `make([][]byte, 0)` reset. VMOutputApi carries
+// a `json:"returnData"` tag, so a nil slice would JSON-render as null
+// while an empty slice renders as []; downstream API consumers can
+// distinguish.
+func TestKappContext_ReturnData_GetNeverReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := kapp.NewKappContext(kapp.ArgsNewKAppContext{
+		OriginalSender: []byte("sender"),
+		ContractID:     0,
+		Block:          &block.Block{},
+	})
+
+	first := ctx.GetAndClearReturnData()
+	assert.NotNil(t, first, "Get on a fresh context returns non-nil")
+	assert.Empty(t, first)
+
+	ctx.SetReturnData([][]byte{[]byte("payload")})
+	_ = ctx.GetAndClearReturnData() // drain
+
+	second := ctx.GetAndClearReturnData()
+	assert.NotNil(t, second, "Get on a drained context returns non-nil")
+	assert.Empty(t, second)
+}
+
+// TestKappContext_ReturnData_GetIsolatesFromFutureWrites guards against a
+// regression of the move-semantics optimization: the slice returned to the
+// caller must not be observably mutated by subsequent Set/Add on the same
+// context (the context allocates fresh storage on each Set/Add, so the
+// returned slice keeps pointing at the prior payload).
+func TestKappContext_ReturnData_GetIsolatesFromFutureWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx := kapp.NewKappContext(kapp.ArgsNewKAppContext{
+		OriginalSender: []byte("sender"),
+		ContractID:     0,
+		Block:          &block.Block{},
+	})
+
+	ctx.SetReturnData([][]byte{[]byte("first")})
+	out := ctx.GetAndClearReturnData()
+
+	// Subsequent context writes must not bleed into the previously
+	// returned slice.
+	ctx.SetReturnData([][]byte{[]byte("second"), []byte("third")})
+	ctx.AddReturnData([]byte("fourth"))
+
+	assert.Equal(t, 1, len(out), "previously returned slice length is stable")
+	assert.True(t, bytes.Equal(out[0], []byte("first")),
+		"previously returned bytes are stable")
 }
 
 // TestReceiptSlice_GetByType tests filtering receipts by type


### PR DESCRIPTION
## Summary
Two related allocation reductions in `core/kapp/context.go`. The headline win is making `GetAndClearReturnData` O(1) via move semantics — bench shows the deep copy was a pure waste, the only callers immediately reset the source. The bundled tweak pre-sizes the filtered slice in `GetByType` / `GetPreserved` to bound their allocation count.

## Problem
1. `GetAndClearReturnData` deep-copied `k.returnData` element-by-element into a fresh slice and then immediately reset the field to empty. Both call sites (`blockChainHook.ProcessBuiltInFunction`, the kvm world wrapper) take the result and assign it straight into `vmOutput.ReturnData` — they never touch the context's slice afterward, and the writers (`SetReturnData`, `AddReturnData`) always allocate fresh storage. The deep copy was guarding against an aliasing scenario that cannot occur.
2. `ReceiptSlice.GetByType` / `GetPreserved` started with `var filtered []*X`, so the first append allocated and subsequent grows reallocated (log₂(N) backing arrays).

## Solution
1. **Move semantics** for `GetAndClearReturnData`:
   ```go
   out := k.returnData
   if out == nil {
       out = [][]byte{}
   }
   k.returnData = make([][]byte, 0)
   return out
   ```
   The nil-guard preserves the prior `make([][]byte, 0)` invariant — `VMOutputApi` carries a `json:\"returnData\"` tag, so `nil` would JSON-render as `null` while `[]` renders as `[]`; downstream API consumers can distinguish.
2. **Pre-size** `filtered` to `make([]*Receipt, 0, len(*r))` in both filter methods. Bounds total allocations to one regardless of match count.

## Key Changes
- **Updated:** `core/kapp/context.go` — `GetAndClearReturnData` move semantics; `GetByType`/`GetPreserved` pre-sizing.
- **New:** `core/kapp/context_returndata_bench_test.go` — benchmarks for `GetAndClearReturnData` and `SetReturnData` across realistic SC return shapes.
- **Updated:** `core/kapp/context_test.go` — three new unit tests pinning the lifecycle invariants.

## Benchmarks
Apple M4 Max, darwin/arm64. Reported as combined `Set + Get` minus `Set` only, so the column shows the **Get-only** delta:

| Shape | Get cost before | Get cost after | Allocs (before → after) |
|---|---:|---:|---:|
| 1 × 32 B | 22.5 ns | ~0 | 2 → 0 |
| 5 × 32 B | 75.3 ns | ~0 | 6 → 0 |
| 10 × 64 B | 175 ns | ~0 | 11 → 0 |
| **50 × 256 B** | **1686 ns** | **~0** | **51 → 0** |
| 1 × 4096 B | 434 ns | ~0 | 2 → 0 |

The savings scale with payload. Hot for SC TX paths that emit many or large return values (view functions, batch ops, mint/transfer arrays).

To reproduce:
```
go test -count=1 -bench='BenchmarkGetAndClearReturnData|BenchmarkSetReturnData_Only' -benchmem -benchtime=2s -run='^\$' ./core/kapp/
```

## Testing
- [x] `go vet ./core/kapp/` clean
- [x] `go test -race -count=1 ./core/kapp/... ./core/process/smartContract/...` passes
- [x] New benchmark `BenchmarkGetAndClearReturnData` reproduces the numbers above
- [x] Three new unit tests:
  - `TestKappContext_ReturnData_RoundTrip` — Set → Get → empty → Add → Get on a single context
  - `TestKappContext_ReturnData_GetNeverReturnsNil` — pins the JSON-visible non-nil invariant
  - `TestKappContext_ReturnData_GetIsolatesFromFutureWrites` — guards the move-semantics optimization against future writers

## What is NOT in this PR
The audit surfaced several adjacent optimizations that need their own focused PRs:

- **`Receipts().Get()` defensive copy + `blockChainHook.go:464,480,481` calling pattern** — `Get()` deep-copies the receipt-pointer slice; the caller invokes it three times per loop iteration. Highest-leverage remaining win in this area; cleanest fix is at the caller, not in `context.go`.
- **`OriginalSender()` / `TxHash()` / `GetExecData()` defensive copies on read** — same family of redundant defensive copies, very high call frequency, but each needs its own caller-audit PR.
- **`SetReturnData` / `AddReturnData` input-side defensive copies** — left in place. Removing them would flip the caller contract from \"after passing, you can keep mutating\" to \"context now aliases your slice\". Too risky for the gain.

The constructor also has a curious asymmetry — it copies `args.OriginalSender` but stores `args.TxHash` raw, both of which are then defensive-copied again on read. A proper unification belongs with the `OriginalSender`/`TxHash` follow-up.

## Side finding (not for this PR)
`ArgsNewKAppContext.ContractType` (`context.go:31`) is accepted by the constructor but never stored on `kappContext`. Either a dead arg or a latent bug — worth a separate ticket.

## Breaking Changes
None. The function's externally observable contract is preserved (still returns a non-nil slice, still resets the context to non-nil-empty). Only the *implementation strategy* changed.

## Related Issues
None.

## Checklist
- [x] Code follows project style guidelines (`gofmt` clean)
- [x] Tests added/updated and passing
- [x] No documentation updates needed (no public API change)
- [x] Commit messages follow Conventional Commits
- [x] No unnecessary files included
- [x] No breaking changes
- [x] No configuration changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Zero-copy return-data handling and pre-sized receipt filtering for smart contract execution

### Impacted blockchain components
- Transaction processing & state management: core/kapp/context.go (kappContext returnData) — affects how smart contract return data is surfaced during execution and attached to transaction/VM outputs.
- KVM / VM output plumbing: kvm/mock/world/builtinFunctionsWrapper.go and core/process/smartContract/hooks/blockChainHook.go call GetAndClearReturnData to populate vmOutput.ReturnData sent to the API layer.
- Transaction-level receipts handling: ReceiptSlice.GetByType and GetPreserved are used in core/process/transaction/txProcess.go to filter/append receipts when assembling tx.Receipts (including preserved system receipts used during error handling).
- Various kapp code paths set return data (multiple core/kapp/* files: accounts, kda, proposal, market, etc.), so the change touches many smart-contract-invoking flows.

### What changed
1. GetAndClearReturnData: move semantics
   - Returns ownership of the internal [][]byte slice directly (guarded to return non-nil empty slice when internal field is nil), then resets k.returnData to a fresh empty slice.
   - Eliminates deep-copy on Get, reducing complexity from O(n) to O(1) and avoiding allocations on common call shapes.
   - SetReturnData and AddReturnData still allocate fresh storage (they deep-copy inputs), preserving isolation between the context and returned payload.

2. ReceiptSlice.GetByType and GetPreserved: pre-sized result slices
   - Filtered slices are constructed with capacity len(*r) to bound allocations to a single allocation regardless of match count.

3. Tests & benchmarks
   - Added unit tests ensuring lifecycle semantics, non-nil JSON-visible invariant, and isolation from future writes.
   - Benchmarks show GetAndClearReturnData cost and allocations drop to near-zero for typical payload shapes (example reported: 50×256B: 1686 ns → ~0 ns and 51 allocs → 0).

### Data integrity, node stability, and safety
- Data integrity: preserved. SetReturnData/AddReturnData perform defensive deep copies on write, so the moved-out return slice cannot be mutated by subsequent writes on the context. Unit test TestKappContext_ReturnData_GetIsolatesFromFutureWrites verifies this.
- API contract (JSON semantics): preserved. GetAndClearReturnData guarantees non-nil-empty result (empty slice vs nil) to avoid changing JSON semantics (null vs []) that API consumers rely on; unit test verifies this.
- Consensus safety & state rollback: unchanged. Receipt filtering change is purely allocation/efficiency; GetPreserved still selects system receipts (>= SystemReceiptTypeStart) which txProcess uses to preserve diagnostic receipts across rollbacks. No state-modifying behavior was altered.
- Concurrency: no public API signatures changed; concurrency model unchanged. Tests were run with -race in PR description. The move avoids copies but does not introduce aliasing to external mutable state because writes allocate new buffers; therefore no new concurrency hazards are introduced by this change.

### Cross-cutting concerns
- Performance: significant reduction in allocation and CPU cost when reading return data from kapp contexts — relevant for high-throughput smart contract workloads and VM output serialization.
- Backwards compatibility: no exported signatures changed; behavior preserved for callers (including nil-vs-empty semantics).
- Remaining work: PR notes other possible allocation optimizations left for separate changes.

### Bottom line
This PR safely improves performance in critical execution paths (KVM/VM output and transaction assembly) by making GetAndClearReturnData zero-copy and bounding allocations when filtering receipts, while preserving data integrity, JSON API semantics, receipt preservation on failure, and existing concurrency semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/45)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->