### PR TITLE
[KLC-2395] fix parallel subtest data race in HonestyScore test

### DIFF
--- a/core/consensus/slot/bls/subslotSignature_test.go
+++ b/core/consensus/slot/bls/subslotSignature_test.go
@@ -346,14 +346,9 @@ func TestSubslotSignature_ReceivedSignature(t *testing.T) {
 func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 	t.Parallel()
 
-	container := mock.InitConsensusCore()
-	sr := *initSubslotSignatureWithContainer(container)
-	// Set self as leader, validating other nodes
-	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
-
 	var testCases = []struct {
 		name              string
-		pubKey            string
+		pubKeyIndex       int // index into ConsensusGroup() of the validator under test
 		signature         string
 		shouldJobBeDone   bool
 		shouldBeAccepted  bool
@@ -362,7 +357,7 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 	}{
 		{
 			name:              "valid signature",
-			pubKey:            sr.ConsensusGroup()[1],
+			pubKeyIndex:       1,
 			signature:         "i am valid!",
 			shouldBeAccepted:  true,
 			shouldJobBeDone:   true,
@@ -371,7 +366,7 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 		},
 		{
 			name:              "invalid signature",
-			pubKey:            sr.ConsensusGroup()[2],
+			pubKeyIndex:       2,
 			signature:         "signature share", // mocked to be invalid
 			shouldBeAccepted:  false,
 			shouldJobBeDone:   false,
@@ -384,12 +379,22 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// setup
+			// Each parallel subtest needs its own container + subslotSignature.
+			// SetPeerHonestyHandler below mutates the container; sharing it across
+			// parallel subtests races and lets one subtest's handler closure run
+			// inside the other's sr.ReceivedSignature call, which then panics
+			// with "Fail in goroutine after [subtest] has completed".
+			container := mock.InitConsensusCore()
+			sr := *initSubslotSignatureWithContainer(container)
+			// Set self as leader, validating other nodes
+			sr.SetSelfPubKey(sr.ConsensusGroup()[0])
+
+			pubKey := sr.ConsensusGroup()[tc.pubKeyIndex]
 			called := false
 			container.SetPeerHonestyHandler(&cMock.PeerHonestyHandlerStub{
 				ChangeScoreCalled: func(pk string, topic string, units int) {
 					called = true
-					assert.Equal(t, tc.pubKey, pk)
+					assert.Equal(t, pubKey, pk)
 					assert.Equal(t, "consensus", topic)
 					assert.Equal(t, tc.expectedUnits, units)
 				},
@@ -399,7 +404,7 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 				sr.Data,
 				[]byte(tc.signature),
 				nil,
-				[]byte(tc.pubKey),
+				[]byte(pubKey),
 				[]byte("sig"),
 				int(bls.MtSignature),
 				0,
@@ -413,7 +418,7 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 			// assert
 			accepted := sr.ReceivedSignature(cnsMsg)
 			assert.Equal(t, tc.shouldBeAccepted, accepted)
-			assert.Equal(t, tc.shouldJobBeDone, sr.IsJobDone(tc.pubKey, bls.SrSignature))
+			assert.Equal(t, tc.shouldJobBeDone, sr.IsJobDone(pubKey, bls.SrSignature))
 			assert.Equal(t, tc.shouldChangeScore, called)
 		})
 	}


### PR DESCRIPTION
## Summary

`TestSubslotSignature_ReceivedSignature_HonestyScore`
(`core/consensus/slot/bls/subslotSignature_test.go`) failed intermittently
in CI. The parent test calls `t.Parallel()` and both of its table-driven
subtests also call `t.Parallel()` while sharing the outer-scope `container`
and `subslotSignature`. Each subtest re-registers the container's
`PeerHonestyHandler` with a closure that asserts against its own table row,
so when the subtests run concurrently one subtest's handler fires inside
the other's `sr.ReceivedSignature` call — the wrong-row assertions trip and
the eventual `t.Fail` on a `*testing.T` whose subtest has already returned
produces `panic: Fail in goroutine after [subtest] has completed`. That
recovered panic shows up in CI as the unnamed `null` FAIL.

The fix constructs `container` and `subslotSignature` **inside** each
subtest so the parallel runs no longer share mutable state. The table now
stores a `ConsensusGroup()` index instead of a pre-resolved pubKey, since
the pubKey is derived from each subtest's own fresh `sr`.

## Verification

Reliably reproduced on `develop`:

```sh
go test -run TestSubslotSignature_ReceivedSignature_HonestyScore \
  ./core/consensus/slot/bls/... -count=500 -timeout 5m              # fails within ~200 iters
go test -run TestSubslotSignature_ReceivedSignature_HonestyScore \
  ./core/consensus/slot/bls/... -count=200 -race -timeout 5m         # WARNING: DATA RACE + panic
```

Post-fix on this branch:

```sh
go test -run TestSubslotSignature_ReceivedSignature_HonestyScore \
  ./core/consensus/slot/bls/... -count=1000 -timeout 5m              # ok, 0.344s
go test -run TestSubslotSignature_ReceivedSignature_HonestyScore \
  ./core/consensus/slot/bls/... -count=500  -race -timeout 5m        # ok, 1.512s
```

No panics, no race-detector warnings.

## Related

- KLC-2382 (similar flake class in `integrationTest/consensus`; same `null`
  CI artifact pattern from a recovered `panic` during test teardown).

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./core/consensus/slot/bls/...` — 0 issues
- [x] 1000-iteration stress (plain): pass
- [x] 500-iteration stress (`-race`): pass
- [ ] CI pipeline green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a critical data race in the `TestSubslotSignature_ReceivedSignature_HonestyScore` test within the BLS (Boneh-Lynn-Shacham) consensus slot signature verification component. The fix ensures proper test isolation for parallel execution and restores reliable validation of peer honesty score updates.

### Blockchain-Critical Components Affected

The test validates the **BLS subslot signature consensus component** (`core/consensus/slot/bls/subslotSignature.go`), which is responsible for:
- Verifying signatures from consensus nodes
- Updating peer honesty scores via `PeerHonestyHandler` callbacks (defined in `core/consensus/interface.go`)
- Determining when consensus signature collection is complete

These are core to consensus stability and validator reputation tracking, which affects node peer selection and consensus reliability.

### Issue & Resolution

**The Problem:** The test and its subtests both called `t.Parallel()` while sharing mutable state (a `container` and `subslotSignature` instance) across parallel test cases. Each subtest registered a `PeerHonestyHandler` closure that captured test case-specific assertions. When subtests ran concurrently, a handler registered by one subtest could execute during another subtest's `sr.ReceivedSignature()` call, triggering assertion failures against wrong test data and causing panics like "Fail in goroutine after [subtest] has completed."

**The Fix:** Each parallel subtest now creates its own fresh `container` and `subslotSignature` instance, eliminating shared mutable state. The test cases now store a `pubKeyIndex` (index into the consensus group) instead of a precomputed `pubKey` string; each subtest derives its public key dynamically from its isolated instance.

### Impact on Node Stability & Data Integrity

- **Stability:** Fixes intermittent CI test failures that masked potential bugs in consensus signature handling and honesty scoring
- **Data Integrity:** Ensures the honesty scoring mechanism (peer reputation tracking) is properly validated with clean test isolation
- **Concurrency:** Resolves a concurrency anti-pattern in the test harness itself; verified with stress runs (1000 iterations plain, 500 with `-race` flag) showing no panics or race detector warnings

### Testing Validation

- Reproduced original failures on develop with `go test -count=500` and `-race -count=200`
- Verified fix passes stress tests with no concurrent execution issues
- Related to KLC-2382 (similar test flake class)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->