### PR TITLE
[KLC-2382] fix data races in consensus, sharding, and libp2p layers

### DIFF
--- a/core/consensus/broadcast/delayedBroadcast.go
+++ b/core/consensus/broadcast/delayedBroadcast.go
@@ -201,12 +201,6 @@ func (d *delayedBlockBroadcaster) SetHeaderForValidator(vData *validatorHeaderBr
 		return common.ErrNilHeaderHash
 	}
 
-	log.Trace("delayedBlockBroadcaster.SetHeaderForValidator",
-		"nbDelayedBroadcastData", len(d.delayedBroadcastData),
-		"nbValBroadcastData", len(d.valBroadcastData),
-		"nbValHeaderBroadcastData", len(d.valHeaderBroadcastData),
-	)
-
 	// skip alarm if the block was not finalized yet
 	if len(vData.header.GetSignature()) == 0 {
 		log.Trace("delayedBlockBroadcaster.SetHeaderForValidator: header alarm has not been set",
@@ -221,9 +215,23 @@ func (d *delayedBlockBroadcaster) SetHeaderForValidator(vData *validatorHeaderBr
 		return nil
 	}
 
+	// Take mutDataForBroadcast around all reads / writes of the broadcast
+	// slices. Without this, the append on valHeaderBroadcastData races with
+	// the locked iteration in interceptedHeader, which can corrupt the slice
+	// and cause interceptedHeader to cancel the wrong header alarm —
+	// validators then miss the leader header, fail to sign within the slot,
+	// and the cluster stalls below quorum.
+	d.mutDataForBroadcast.Lock()
+	log.Trace("delayedBlockBroadcaster.SetHeaderForValidator",
+		"nbDelayedBroadcastData", len(d.delayedBroadcastData),
+		"nbValBroadcastData", len(d.valBroadcastData),
+		"nbValHeaderBroadcastData", len(d.valHeaderBroadcastData),
+	)
 	duration := validatorDelayPerOrder * time.Duration(vData.order)
 	d.valHeaderBroadcastData = append(d.valHeaderBroadcastData, vData)
 	alarmID := prefixHeaderAlarm + hex.EncodeToString(vData.headerHash)
+	d.mutDataForBroadcast.Unlock()
+
 	// set an callback to execute after X seconds
 	d.alarm.Add(d.headerAlarmExpired, duration, alarmID)
 	log.Trace("delayedBlockBroadcaster.SetHeaderForValidator: header alarm has been set",

--- a/core/consensus/slot/bls/export_test.go
+++ b/core/consensus/slot/bls/export_test.go
@@ -250,8 +250,8 @@ func (sr *subslotEndSlot) HaveConsensusHeaderWithFullInfo(cnsDta *consensus.Mess
 	return sr.haveConsensusHeaderWithFullInfo(cnsDta)
 }
 
-func (sr *subslotEndSlot) CreateAndBroadcastHeaderFinalInfo() {
-	sr.createAndBroadcastHeaderFinalInfo()
+func (sr *subslotEndSlot) CreateAndBroadcastHeaderFinalInfo(header data.HeaderHandler) {
+	sr.createAndBroadcastHeaderFinalInfo(header)
 }
 
 func (sr *subslotEndSlot) ReceivedBlockHeaderFinalInfo(cnsDta *consensus.Message) bool {

--- a/core/consensus/slot/bls/subslotBlock.go
+++ b/core/consensus/slot/bls/subslotBlock.go
@@ -140,7 +140,9 @@ func (sr *subslotBlock) sendBlock(header data.HeaderHandler) bool {
 }
 
 func (sr *subslotBlock) createBlock(header data.HeaderHandler) (data.HeaderHandler, error) {
+	sr.RLockSlotState()
 	startTime := sr.SlotTimestamp
+	sr.RUnlockSlotState()
 	maxTime := time.Duration(sr.EndTime())
 	haveTimeInCurrentSubslot := func() bool {
 		return sr.SlotManager().RemainingTime(startTime, maxTime) > 0
@@ -189,8 +191,10 @@ func (sr *subslotBlock) sendBlockHeader(
 		"nonce", headerHandler.GetNonce(),
 		"hash", headerHash)
 
+	sr.LockSlotState()
 	sr.Data = headerHash
 	sr.Header = headerHandler
+	sr.UnlockSlotState()
 
 	return true
 }
@@ -262,16 +266,21 @@ func (sr *subslotBlock) receivedBlockHeader(cnsDta *consensus.Message) bool {
 		return false
 	}
 
-	sr.Data = cnsDta.BlockHeaderHash
-	sr.Header = sr.BlockProcessor().DecodeBlockHeader(cnsDta.Header)
+	headerHash := cnsDta.BlockHeaderHash
+	decodedHeader := sr.BlockProcessor().DecodeBlockHeader(cnsDta.Header)
 
-	if sr.Data == nil || check.IfNil(sr.Header) {
+	if headerHash == nil || check.IfNil(decodedHeader) {
 		return false
 	}
 
+	sr.LockSlotState()
+	sr.Data = headerHash
+	sr.Header = decodedHeader
+	sr.UnlockSlotState()
+
 	log.Debug("step 1: block header have been received",
-		"nonce", sr.Header.GetNonce(),
-		"hash", cnsDta.BlockHeaderHash)
+		"nonce", decodedHeader.GetNonce(),
+		"hash", headerHash)
 
 	sw.Start("processReceivedBlock")
 	blockProcessedWithSuccess := sr.processReceivedBlock(cnsDta)
@@ -287,7 +296,12 @@ func (sr *subslotBlock) receivedBlockHeader(cnsDta *consensus.Message) bool {
 }
 
 func (sr *subslotBlock) processReceivedBlock(cnsDta *consensus.Message) bool {
-	if check.IfNil(sr.Header) {
+	sr.RLockSlotState()
+	header := sr.Header
+	startTime := sr.SlotTimestamp
+	sr.RUnlockSlotState()
+
+	if check.IfNil(header) {
 		return false
 	}
 
@@ -297,20 +311,33 @@ func (sr *subslotBlock) processReceivedBlock(cnsDta *consensus.Message) bool {
 
 	sr.SetProcessingBlock(true)
 
-	shouldNotProcessBlock := sr.ExtendedCalled || cnsDta.SlotIndex < sr.SlotManager().Index()
+	// Read ExtendedCalled AFTER SetProcessingBlock(true). Worker.Extend sets
+	// ExtendedCalled=true and only then waits for ProcessingBlock to clear,
+	// so our SetProcessingBlock(true) creates the happens-before that guarantees
+	// either (a) Extend sees our ProcessingBlock and waits — in which case our
+	// later snapshot of extendedCalled may still be false but it doesn't matter
+	// because Extend's revert is blocked until we finish, or (b) Extend already
+	// flipped ExtendedCalled before our SetProcessingBlock — in which case the
+	// post-snapshot read sees true and we bail. Snapshotting extendedCalled
+	// BEFORE SetProcessingBlock would let Extend slip in between, set the flag,
+	// see ProcessingBlock=false, and start reverting state under us.
+	sr.RLockSlotState()
+	extendedCalled := sr.ExtendedCalled
+	sr.RUnlockSlotState()
+
+	shouldNotProcessBlock := extendedCalled || cnsDta.SlotIndex < sr.SlotManager().Index()
 	if shouldNotProcessBlock {
 		log.Debug("canceled slot, extended has been called or slot index has been changed",
 			"slot", sr.SlotManager().Index(),
 			"subslot", sr.Name(),
 			"cnsDta slot", cnsDta.SlotIndex,
-			"extended called", sr.ExtendedCalled,
+			"extended called", extendedCalled,
 		)
 		return false
 	}
 
 	node := string(cnsDta.PubKey)
 
-	startTime := sr.SlotTimestamp
 	maxTime := sr.SlotManager().TimeDuration() * time.Duration(sr.processingThresholdPercentage) / 100
 	remainingTimeInCurrentSlot := func() time.Duration {
 		return sr.SlotManager().RemainingTime(startTime, maxTime)
@@ -320,7 +347,7 @@ func (sr *subslotBlock) processReceivedBlock(cnsDta *consensus.Message) bool {
 	defer sr.computeSubslotProcessingMetric(metricStatTime, core.MetricProcessedProposedBlock)
 
 	err := sr.BlockProcessor().ProcessBlock(
-		sr.Header,
+		header,
 		remainingTimeInCurrentSlot,
 	)
 
@@ -339,7 +366,7 @@ func (sr *subslotBlock) processReceivedBlock(cnsDta *consensus.Message) bool {
 			"subslot", sr.Name(),
 			"error", err.Error())
 
-		sr.SlotCanceled = true
+		sr.SetSlotCanceled(true)
 
 		return false
 	}
@@ -369,7 +396,10 @@ func (sr *subslotBlock) computeSubslotProcessingMetric(startTime time.Time, metr
 
 // doBlockConsensusCheck method checks if the consensus in the subslot Block is achieved
 func (sr *subslotBlock) doBlockConsensusCheck() bool {
-	if sr.SlotCanceled {
+	sr.RLockSlotState()
+	canceled := sr.SlotCanceled
+	sr.RUnlockSlotState()
+	if canceled {
 		return false
 	}
 

--- a/core/consensus/slot/bls/subslotEndSlot.go
+++ b/core/consensus/slot/bls/subslotEndSlot.go
@@ -127,11 +127,15 @@ func (sr *subslotEndSlot) receivedBlockHeaderFinalInfo(cnsDta *consensus.Message
 }
 
 func (sr *subslotEndSlot) isBlockHeaderFinalInfoValid(cnsDta *consensus.Message) bool {
-	if check.IfNil(sr.Header) {
+	sr.RLockSlotState()
+	currentHeader := sr.Header
+	sr.RUnlockSlotState()
+
+	if check.IfNil(currentHeader) {
 		return false
 	}
 
-	header := sr.Header.Clone()
+	header := currentHeader.Clone()
 	header.SetPubKeysBitmap(cnsDta.PubKeysBitmap)
 	header.SetSignature(cnsDta.AggregateSignature)
 	header.SetProducerSignature(cnsDta.LeaderSignature)
@@ -193,25 +197,40 @@ func (sr *subslotEndSlot) doEndSlotJobByLeader() bool {
 		return false
 	}
 
-	sr.Header.SetPubKeysBitmap(bitmap)
-	sr.Header.SetSignature(sig)
+	// Snapshot the consensus header pointer once. The invariant this relies on:
+	// from this point until the leader finishes endSlot, the leader's chronology
+	// goroutine is the SOLE mutator of the underlying header object — the
+	// interceptor path (subslotBlock.receivedBlockHeader) does not write
+	// sr.Header for the self-leader case, and ResetConsensusState runs only at
+	// the next slot boundary, which is sequenced after this endSlot completes on
+	// the same chronology goroutine. We pass this snapshot explicitly to every
+	// downstream call (signBlockHeader, createAndBroadcastHeaderFinalInfo,
+	// BroadcastBlock, CommitBlock, broadcastBlockDataLeader) so the
+	// "leader-owned" guarantee is encoded in the call signatures rather than
+	// the implicit field aliasing on sr.Header.
+	sr.RLockSlotState()
+	header := sr.Header
+	sr.RUnlockSlotState()
+
+	header.SetPubKeysBitmap(bitmap)
+	header.SetSignature(sig)
 
 	// Header is complete so the leader can sign it
-	leaderSignature, err := sr.signBlockHeader()
+	leaderSignature, err := sr.signBlockHeader(header)
 	if err != nil {
 		log.Error(err.Error())
 		return false
 	}
-	sr.Header.SetProducerSignature(leaderSignature)
+	header.SetProducerSignature(leaderSignature)
 
 	// validate has block signature prior commit
-	if len(sr.Header.GetSignature()) == 0 ||
-		len(sr.Header.GetProducerSignature()) == 0 ||
-		len(sr.Header.GetPubKeysBitmap()) == 0 {
+	if len(header.GetSignature()) == 0 ||
+		len(header.GetProducerSignature()) == 0 ||
+		len(header.GetPubKeysBitmap()) == 0 {
 		log.Error("doEndSlotJobByLeader invalid block",
-			"signature", sr.Header.GetSignature(),
-			"producerSignature", sr.Header.GetProducerSignature(),
-			"pubKeysBitmap", sr.Header.GetPubKeysBitmap(),
+			"signature", header.GetSignature(),
+			"producerSignature", header.GetProducerSignature(),
+			"pubKeysBitmap", header.GetPubKeysBitmap(),
 		)
 		return false
 	}
@@ -224,14 +243,18 @@ func (sr *subslotEndSlot) doEndSlotJobByLeader() bool {
 
 	sr.SetProcessingBlock(true)
 
-	shouldNotCommitBlock := sr.ExtendedCalled ||
-		sr.Header.GetSlot() < tools.SafeI64ToU64(sr.SlotManager().Index())
+	sr.RLockSlotState()
+	extendedCalled := sr.ExtendedCalled
+	sr.RUnlockSlotState()
+
+	shouldNotCommitBlock := extendedCalled ||
+		header.GetSlot() < tools.SafeI64ToU64(sr.SlotManager().Index())
 	if shouldNotCommitBlock {
 		log.Debug("canceled slot, extended has been called or slot index has been changed",
 			"slot", sr.SlotManager().Index(),
 			"subslot", sr.Name(),
-			"header slot", sr.Header.GetSlot(),
-			"extended called", sr.ExtendedCalled,
+			"header slot", header.GetSlot(),
+			"extended called", extendedCalled,
 		)
 		return false
 	}
@@ -241,16 +264,16 @@ func (sr *subslotEndSlot) doEndSlotJobByLeader() bool {
 	}
 
 	// create and broadcast header final info
-	sr.createAndBroadcastHeaderFinalInfo()
+	sr.createAndBroadcastHeaderFinalInfo(header)
 
 	// broadcast header
-	err = sr.BroadcastMessenger().BroadcastBlock(sr.Header)
+	err = sr.BroadcastMessenger().BroadcastBlock(header)
 	if err != nil {
 		log.Debug("doEndSlotJob.BroadcastHeader", "error", err.Error())
 	}
 
 	startTime := time.Now()
-	err = sr.BlockProcessor().CommitBlock(sr.Header)
+	err = sr.BlockProcessor().CommitBlock(header)
 	elapsedTime := time.Since(startTime)
 	if elapsedTime >= core.CommitMaxTime {
 		log.Warn("doEndSlotJobByLeader.CommitBlock", "elapsed time", elapsedTime)
@@ -270,12 +293,12 @@ func (sr *subslotEndSlot) doEndSlotJobByLeader() bool {
 
 	log.Debug("step 3: Header have been committed and header has been broadcast")
 
-	err = sr.broadcastBlockDataLeader()
+	err = sr.broadcastBlockDataLeader(header)
 	if err != nil {
 		log.Debug("doEndRoundJobByLeader.broadcastBlockDataLeader", "error", err.Error())
 	}
 
-	msg := fmt.Sprintf("Added proposed block with nonce  %d  in blockchain", sr.Header.GetNonce())
+	msg := fmt.Sprintf("Added proposed block with nonce  %d  in blockchain", header.GetNonce())
 	log.Debug(display.Headline(msg, sr.SyncTimer().FormattedCurrentTime(), "+"))
 
 	sr.updateMetricsForLeader()
@@ -283,7 +306,7 @@ func (sr *subslotEndSlot) doEndSlotJobByLeader() bool {
 	return true
 }
 
-func (sr *subslotEndSlot) createAndBroadcastHeaderFinalInfo() {
+func (sr *subslotEndSlot) createAndBroadcastHeaderFinalInfo(header data.HeaderHandler) {
 	cnsMsg := consensus.NewConsensusMessage(
 		sr.GetData(),
 		nil,
@@ -292,11 +315,11 @@ func (sr *subslotEndSlot) createAndBroadcastHeaderFinalInfo() {
 		nil,
 		int(MtBlockHeaderFinalInfo),
 		sr.SlotManager().Index(),
-		sr.Header.GetNonce(),
+		header.GetNonce(),
 		sr.ChainID(),
-		sr.Header.GetPubKeysBitmap(),
-		sr.Header.GetSignature(),
-		sr.Header.GetProducerSignature(),
+		header.GetPubKeysBitmap(),
+		header.GetSignature(),
+		header.GetProducerSignature(),
 		sr.CurrentPid(),
 	)
 
@@ -307,19 +330,24 @@ func (sr *subslotEndSlot) createAndBroadcastHeaderFinalInfo() {
 	}
 
 	log.Debug("step 3: block header final info has been sent",
-		"PubKeysBitmap", sr.Header.GetPubKeysBitmap(),
-		"AggregateSignature", sr.Header.GetSignature(),
-		"LeaderSignature", sr.Header.GetProducerSignature())
+		"PubKeysBitmap", header.GetPubKeysBitmap(),
+		"AggregateSignature", header.GetSignature(),
+		"LeaderSignature", header.GetProducerSignature())
 }
 
 func (sr *subslotEndSlot) doEndSlotJobByParticipant(cnsDta *consensus.Message) bool {
 	sr.mutProcessingEndSlot.Lock()
 	defer sr.mutProcessingEndSlot.Unlock()
 
-	if sr.SlotCanceled {
+	sr.RLockSlotState()
+	canceled := sr.SlotCanceled
+	dataSet := sr.Data != nil
+	sr.RUnlockSlotState()
+
+	if canceled {
 		return false
 	}
-	if !sr.IsConsensusDataSet() {
+	if !dataSet {
 		return false
 	}
 	if !sr.IsSubslotFinished(sr.Previous()) {
@@ -340,13 +368,17 @@ func (sr *subslotEndSlot) doEndSlotJobByParticipant(cnsDta *consensus.Message) b
 
 	sr.SetProcessingBlock(true)
 
-	shouldNotCommitBlock := sr.ExtendedCalled || header.GetSlot() < tools.SafeI64ToU64(sr.SlotManager().Index())
+	sr.RLockSlotState()
+	extendedCalled := sr.ExtendedCalled
+	sr.RUnlockSlotState()
+
+	shouldNotCommitBlock := extendedCalled || header.GetSlot() < tools.SafeI64ToU64(sr.SlotManager().Index())
 	if shouldNotCommitBlock {
 		log.Debug("canceled slot, extended has been called or slot index has been changed",
 			"slot", sr.SlotManager().Index(),
 			"subslot", sr.Name(),
 			"header slot", header.GetSlot(),
-			"extended called", sr.ExtendedCalled,
+			"extended called", extendedCalled,
 		)
 		return false
 	}
@@ -398,11 +430,15 @@ func (sr *subslotEndSlot) haveConsensusHeaderWithFullInfo(cnsDta *consensus.Mess
 		return sr.isConsensusHeaderReceived()
 	}
 
-	if check.IfNil(sr.Header) {
+	sr.RLockSlotState()
+	currentHeader := sr.Header
+	sr.RUnlockSlotState()
+
+	if check.IfNil(currentHeader) {
 		return false, nil
 	}
 
-	header := sr.Header.Clone()
+	header := currentHeader.Clone()
 	header.SetPubKeysBitmap(cnsDta.PubKeysBitmap)
 	header.SetSignature(cnsDta.AggregateSignature)
 	header.SetProducerSignature(cnsDta.LeaderSignature)
@@ -411,11 +447,15 @@ func (sr *subslotEndSlot) haveConsensusHeaderWithFullInfo(cnsDta *consensus.Mess
 }
 
 func (sr *subslotEndSlot) isConsensusHeaderReceived() (bool, data.HeaderHandler) {
-	if check.IfNil(sr.Header) {
+	sr.RLockSlotState()
+	currentHeader := sr.Header
+	sr.RUnlockSlotState()
+
+	if check.IfNil(currentHeader) {
 		return false, nil
 	}
 
-	consensusHeaderHash, err := tools.CalculateHash(sr.Marshalizer(), sr.Hasher(), sr.Header.GetBlockHeader())
+	consensusHeaderHash, err := tools.CalculateHash(sr.Marshalizer(), sr.Hasher(), currentHeader.GetBlockHeader())
 	if err != nil {
 		log.Debug("isConsensusHeaderReceived: calculate consensus header hash", "error", err.Error())
 		return false, nil
@@ -441,8 +481,8 @@ func (sr *subslotEndSlot) isConsensusHeaderReceived() (bool, data.HeaderHandler)
 	return false, nil
 }
 
-func (sr *subslotEndSlot) signBlockHeader() ([]byte, error) {
-	marshalizedHdr, err := sr.Marshalizer().Marshal(sr.Header.GetBlockHeader())
+func (sr *subslotEndSlot) signBlockHeader(header data.HeaderHandler) ([]byte, error) {
+	marshalizedHdr, err := sr.Marshalizer().Marshal(header.GetBlockHeader())
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +497,11 @@ func (sr *subslotEndSlot) updateMetricsForLeader() {
 
 // doEndSlotConsensusCheck method checks if the consensus is achieved
 func (sr *subslotEndSlot) doEndSlotConsensusCheck() bool {
-	if sr.SlotCanceled {
+	sr.RLockSlotState()
+	canceled := sr.SlotCanceled
+	sr.RUnlockSlotState()
+
+	if canceled {
 		return false
 	}
 
@@ -509,14 +553,16 @@ func (sr *subslotEndSlot) checkSignaturesValidity(bitmap []byte) error {
 }
 
 func (sr *subslotEndSlot) isOutOfTime() bool {
+	sr.RLockSlotState()
 	startTime := sr.SlotTimestamp
+	sr.RUnlockSlotState()
 	maxTime := sr.SlotManager().TimeDuration() * time.Duration(sr.processingThresholdPercentage) / 100
 	if sr.SlotManager().RemainingTime(startTime, maxTime) < 0 {
 		log.Debug("canceled slot, time is out",
 			"slot", sr.SyncTimer().FormattedCurrentTime(), sr.SlotManager().Index(),
 			"subslot", sr.Name())
 
-		sr.SlotCanceled = true
+		sr.SetSlotCanceled(true)
 		return true
 	}
 
@@ -529,7 +575,11 @@ func (sr *subslotEndSlot) getIndexPkAndDataToBroadcast() (int, []byte, []byte, [
 		return -1, nil, nil, nil, err
 	}
 
-	blockBuffer, transactions, err := sr.BlockProcessor().MarshalizedDataToBroadcast(sr.Header)
+	sr.RLockSlotState()
+	header := sr.Header
+	sr.RUnlockSlotState()
+
+	blockBuffer, transactions, err := sr.BlockProcessor().MarshalizedDataToBroadcast(header)
 	if err != nil {
 		return -1, nil, nil, nil, err
 	}
@@ -541,13 +591,13 @@ func (sr *subslotEndSlot) getIndexPkAndDataToBroadcast() (int, []byte, []byte, [
 
 }
 
-func (sr *subslotEndSlot) broadcastBlockDataLeader() error {
-	data, transactions, err := sr.BlockProcessor().MarshalizedDataToBroadcast(sr.Header)
+func (sr *subslotEndSlot) broadcastBlockDataLeader(header data.HeaderHandler) error {
+	data, transactions, err := sr.BlockProcessor().MarshalizedDataToBroadcast(header)
 	if err != nil {
 		return err
 	}
 
-	return sr.BroadcastMessenger().BroadcastBlockDataLeader(sr.Header, data, transactions)
+	return sr.BroadcastMessenger().BroadcastBlockDataLeader(header, data, transactions)
 }
 
 func (sr *subslotEndSlot) setHeaderForValidator(header data.HeaderHandler) error {
@@ -567,7 +617,11 @@ func (sr *subslotEndSlot) prepareBroadcastBlockDataForValidator() error {
 		return err
 	}
 
-	go sr.BroadcastMessenger().PrepareBroadcastBlockDataValidator(sr.Header, transactions, index, pk)
+	sr.RLockSlotState()
+	header := sr.Header
+	sr.RUnlockSlotState()
+
+	go sr.BroadcastMessenger().PrepareBroadcastBlockDataValidator(header, transactions, index, pk)
 
 	return nil
 }

--- a/core/consensus/slot/bls/subslotEndSlot_test.go
+++ b/core/consensus/slot/bls/subslotEndSlot_test.go
@@ -760,9 +760,10 @@ func TestSubslotEndSlot_CreateAndBroadcastHeaderFinalInfoBroadcastShouldBeCalled
 	}
 	container.SetBroadcastMessenger(messenger)
 	sr := *initSubslotEndSlotWithContainer(container)
-	sr.Header = &block.Block{ProducerSignature: leaderSigInHdr}
+	header := &block.Block{ProducerSignature: leaderSigInHdr}
+	sr.Header = header
 
-	sr.CreateAndBroadcastHeaderFinalInfo()
+	sr.CreateAndBroadcastHeaderFinalInfo(header)
 
 	select {
 	case <-chanRcv:

--- a/core/consensus/slot/bls/subslotSignature.go
+++ b/core/consensus/slot/bls/subslotSignature.go
@@ -327,21 +327,14 @@ func (sr *subslotSignature) waitAllSignatures(spawnSlot int64) {
 		// All signatures collected (100%), exit immediately
 		return
 	case <-timeout.C:
-		sr.RLockSlotState()
-		currentSlot := sr.SlotIndex
-		sr.RUnlockSlotState()
-		if currentSlot != spawnSlot {
-			// Slot has advanced — this goroutine belongs to a stale slot. Do
-			// not touch shared state; the current slot has its own goroutine.
-			return
-		}
-
 		// Timeout reached, check if subslot is already finished by threshold signatures
 		if sr.IsSubslotFinished(sr.Current()) {
 			return
 		}
 
-		sr.SetWaitingAllSignaturesTimeOut(true)
+		if !sr.SetWaitingAllSignaturesTimeOutIfSlot(spawnSlot, true) {
+			return
+		}
 		select {
 		case sr.ConsensusChannel() <- true:
 		default:

--- a/core/consensus/slot/bls/subslotSignature.go
+++ b/core/consensus/slot/bls/subslotSignature.go
@@ -75,7 +75,12 @@ func (sr *subslotSignature) doSignatureJob() bool {
 		return false
 	}
 
-	signatureShare, err := sr.MultiSigner().CreateSignatureShare(sr.GetData(), nil)
+	sr.RLockSlotState()
+	data := sr.Data
+	header := sr.Header
+	sr.RUnlockSlotState()
+
+	signatureShare, err := sr.MultiSigner().CreateSignatureShare(data, nil)
 	if err != nil {
 		log.Debug("doSignatureJob.CreateSignatureShare", "error", err.Error())
 		return false
@@ -86,14 +91,14 @@ func (sr *subslotSignature) doSignatureJob() bool {
 	if !isSelfLeader {
 		//TODO: Analyze it is possible to send message only to leader with O(1) instead of O(n)
 		cnsMsg := consensus.NewConsensusMessage(
-			sr.GetData(),
+			data,
 			signatureShare,
 			nil,
 			[]byte(sr.SelfPubKey()),
 			nil,
 			int(MtSignature),
 			sr.SlotManager().Index(),
-			sr.Header.GetNonce(),
+			header.GetNonce(),
 			sr.ChainID(),
 			nil,
 			nil,
@@ -120,7 +125,10 @@ func (sr *subslotSignature) doSignatureJob() bool {
 
 	if isSelfLeader {
 		sr.resetSignatureCompleteChan()
-		go sr.waitAllSignatures()
+		sr.RLockSlotState()
+		spawnSlot := sr.SlotIndex
+		sr.RUnlockSlotState()
+		go sr.waitAllSignatures(spawnSlot)
 	}
 
 	return true
@@ -204,7 +212,13 @@ func (sr *subslotSignature) receivedSignature(cnsDta *consensus.Message) bool {
 
 // doSignatureConsensusCheck method checks if the consensus in the subslot Signature is achieved
 func (sr *subslotSignature) doSignatureConsensusCheck() bool {
-	if sr.SlotCanceled {
+	sr.RLockSlotState()
+	canceled := sr.SlotCanceled
+	header := sr.Header
+	timedOut := sr.WaitingAllSignaturesTimeOut
+	sr.RUnlockSlotState()
+
+	if canceled {
 		return false
 	}
 
@@ -218,7 +232,7 @@ func (sr *subslotSignature) doSignatureConsensusCheck() bool {
 	isSelfInConsensusGroup := sr.IsNodeInConsensusGroup(sr.SelfPubKey())
 
 	threshold := sr.Threshold(sr.Current())
-	if sr.FallbackHeaderValidator().ShouldApplyFallbackValidation(sr.Header) {
+	if sr.FallbackHeaderValidator().ShouldApplyFallbackValidation(header) {
 		threshold = sr.FallbackThreshold(sr.Current())
 		log.Warn("subslotSignature.doSignatureConsensusCheck: fallback validation has been applied",
 			"minimum number of signatures required", threshold,
@@ -229,7 +243,7 @@ func (sr *subslotSignature) doSignatureConsensusCheck() bool {
 	areSignaturesCollected, numSigs := sr.areSignaturesCollected(threshold)
 	areAllSignaturesCollected := numSigs == sr.ConsensusGroupSize()
 
-	isJobDoneByLeader := isSelfLeader && (areAllSignaturesCollected || (areSignaturesCollected && sr.WaitingAllSignaturesTimeOut))
+	isJobDoneByLeader := isSelfLeader && (areAllSignaturesCollected || (areSignaturesCollected && timedOut))
 	isJobDoneByConsensusNode := !isSelfLeader && isSelfInConsensusGroup && sr.IsSelfJobDone(sr.Current())
 
 	isSubslotFinished := !isSelfInConsensusGroup || isJobDoneByConsensusNode || isJobDoneByLeader
@@ -291,7 +305,19 @@ func (sr *subslotSignature) getNumOfSignaturesCollected() int {
 	return n
 }
 
-func (sr *subslotSignature) waitAllSignatures() {
+// waitAllSignatures runs in a goroutine spawned per leader-slot. It signals
+// WaitingAllSignaturesTimeOut on the shared ConsensusState if neither the
+// full-signature-set channel fires nor the subslot finishes within the
+// threshold window.
+//
+// spawnSlot pins the goroutine to the slot that spawned it. Slot duration is
+// real-time; the timer can outlive the slot when downstream slots run very
+// fast (e.g., test rigs with mocked SlotManager.RemainingTime). Without the
+// pin, a stale goroutine would set WaitingAllSignaturesTimeOut=true on a
+// LATER slot's ConsensusState, causing that slot's leader to commit with
+// minimum quorum well before its own threshold expires. Verify the slot
+// hasn't advanced before mutating state.
+func (sr *subslotSignature) waitAllSignatures(spawnSlot int64) {
 	remainingTime := sr.remainingTime()
 	timeout := time.NewTimer(remainingTime)
 	defer timeout.Stop()
@@ -301,12 +327,21 @@ func (sr *subslotSignature) waitAllSignatures() {
 		// All signatures collected (100%), exit immediately
 		return
 	case <-timeout.C:
+		sr.RLockSlotState()
+		currentSlot := sr.SlotIndex
+		sr.RUnlockSlotState()
+		if currentSlot != spawnSlot {
+			// Slot has advanced — this goroutine belongs to a stale slot. Do
+			// not touch shared state; the current slot has its own goroutine.
+			return
+		}
+
 		// Timeout reached, check if subslot is already finished by threshold signatures
 		if sr.IsSubslotFinished(sr.Current()) {
 			return
 		}
 
-		sr.WaitingAllSignaturesTimeOut = true
+		sr.SetWaitingAllSignaturesTimeOut(true)
 		select {
 		case sr.ConsensusChannel() <- true:
 		default:

--- a/core/consensus/slot/bls/subslotSignature_test.go
+++ b/core/consensus/slot/bls/subslotSignature_test.go
@@ -346,14 +346,9 @@ func TestSubslotSignature_ReceivedSignature(t *testing.T) {
 func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 	t.Parallel()
 
-	container := mock.InitConsensusCore()
-	sr := *initSubslotSignatureWithContainer(container)
-	// Set self as leader, validating other nodes
-	sr.SetSelfPubKey(sr.ConsensusGroup()[0])
-
 	var testCases = []struct {
 		name              string
-		pubKey            string
+		pubKeyIndex       int
 		signature         string
 		shouldJobBeDone   bool
 		shouldBeAccepted  bool
@@ -362,7 +357,7 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 	}{
 		{
 			name:              "valid signature",
-			pubKey:            sr.ConsensusGroup()[1],
+			pubKeyIndex:       1,
 			signature:         "i am valid!",
 			shouldBeAccepted:  true,
 			shouldJobBeDone:   true,
@@ -371,7 +366,7 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 		},
 		{
 			name:              "invalid signature",
-			pubKey:            sr.ConsensusGroup()[2],
+			pubKeyIndex:       2,
 			signature:         "signature share", // mocked to be invalid
 			shouldBeAccepted:  false,
 			shouldJobBeDone:   false,
@@ -384,22 +379,29 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// setup
+			// Build a fresh container + subslot per subtest. Sharing one
+			// container across t.Parallel() subtests races on the mock's
+			// peerHonestyHandler slot via SetPeerHonestyHandler below.
+			container := mock.InitConsensusCore()
+			sr := *initSubslotSignatureWithContainer(container)
+			sr.SetSelfPubKey(sr.ConsensusGroup()[0])
+			pubKey := sr.ConsensusGroup()[tc.pubKeyIndex]
+
 			called := false
 			container.SetPeerHonestyHandler(&cMock.PeerHonestyHandlerStub{
 				ChangeScoreCalled: func(pk string, topic string, units int) {
 					called = true
-					assert.Equal(t, tc.pubKey, pk)
+					assert.Equal(t, pubKey, pk)
 					assert.Equal(t, "consensus", topic)
 					assert.Equal(t, tc.expectedUnits, units)
 				},
 			})
 
 			cnsMsg := consensus.NewConsensusMessage(
-				sr.Data,
+				sr.GetData(),
 				[]byte(tc.signature),
 				nil,
-				[]byte(tc.pubKey),
+				[]byte(pubKey),
 				[]byte("sig"),
 				int(bls.MtSignature),
 				0,
@@ -410,10 +412,9 @@ func TestSubslotSignature_ReceivedSignature_HonestyScore(t *testing.T) {
 				nil,
 				currentPid,
 			)
-			// assert
 			accepted := sr.ReceivedSignature(cnsMsg)
 			assert.Equal(t, tc.shouldBeAccepted, accepted)
-			assert.Equal(t, tc.shouldJobBeDone, sr.IsJobDone(tc.pubKey, bls.SrSignature))
+			assert.Equal(t, tc.shouldJobBeDone, sr.IsJobDone(pubKey, bls.SrSignature))
 			assert.Equal(t, tc.shouldChangeScore, called)
 		})
 	}

--- a/core/consensus/slot/bls/subslotStartSlot.go
+++ b/core/consensus/slot/bls/subslotStartSlot.go
@@ -76,9 +76,8 @@ func (sr *subslotStartSlot) SetIndexer(indexer slot.ConsensusDataIndexer) {
 
 // doStartSlotJob method does the job of the subslot StartSlot
 func (sr *subslotStartSlot) doStartSlotJob() bool {
-	sr.ResetConsensusState()
-	sr.SlotIndex = sr.SlotManager().Index()
-	sr.SlotTimestamp = sr.SlotManager().Timestamp()
+	sr.BeginNewSlot(sr.SlotManager().Index(), sr.SlotManager().Timestamp())
+
 	sr.GetAntiFloodHandler().ResetForTopic(common.ConsensusTopic)
 	sr.resetConsensusMessages()
 	return true
@@ -86,7 +85,10 @@ func (sr *subslotStartSlot) doStartSlotJob() bool {
 
 // doStartSlotConsensusCheck method checks if the consensus is achieved in the subslot StartSlot
 func (sr *subslotStartSlot) doStartSlotConsensusCheck() bool {
-	if sr.SlotCanceled {
+	sr.RLockSlotState()
+	canceled := sr.SlotCanceled
+	sr.RUnlockSlotState()
+	if canceled {
 		return false
 	}
 
@@ -111,7 +113,7 @@ func (sr *subslotStartSlot) initCurrentSlot() bool {
 			"slot index", sr.SlotManager().Index(),
 			"error", err.Error())
 
-		sr.SlotCanceled = true
+		sr.SetSlotCanceled(true)
 
 		return false
 	}
@@ -131,7 +133,7 @@ func (sr *subslotStartSlot) initCurrentSlot() bool {
 	if err != nil {
 		log.Debug("initCurrentSlot.GetLeader", "error", err.Error())
 
-		sr.SlotCanceled = true
+		sr.SetSlotCanceled(true)
 
 		return false
 	}
@@ -164,20 +166,22 @@ func (sr *subslotStartSlot) initCurrentSlot() bool {
 		if err != nil {
 			log.Debug("initCurrentSlot.Reset", "error", err.Error())
 
-			sr.SlotCanceled = true
+			sr.SetSlotCanceled(true)
 
 			return false
 		}
 	}
 
+	sr.RLockSlotState()
 	startTime := sr.SlotTimestamp
+	sr.RUnlockSlotState()
 	maxTime := sr.SlotManager().TimeDuration() * time.Duration(sr.processingThresholdPercentage) / 100
 	if sr.SlotManager().RemainingTime(startTime, maxTime) < 0 {
 		log.Debug("canceled slot, time is out",
 			"slot", sr.SyncTimer().FormattedCurrentTime(), sr.SlotManager().Index(),
 			"subslot", sr.Name())
 
-		sr.SlotCanceled = true
+		sr.SetSlotCanceled(true)
 
 		return false
 	}
@@ -204,9 +208,12 @@ func (sr *subslotStartSlot) generateNextConsensusGroup(slotIndex int64) error {
 	log.Debug("random source for the next consensus group",
 		"rand", randomSeed)
 
+	sr.RLockSlotState()
+	currentSlotIndex := sr.SlotIndex
+	sr.RUnlockSlotState()
 	nextConsensusGroup, err := sr.GetNextConsensusGroup(
 		randomSeed,
-		tools.SafeI64ToU64(sr.SlotIndex),
+		tools.SafeI64ToU64(currentSlotIndex),
 		sr.NodesCoordinator(),
 		currentHeader.GetEpoch(),
 	)

--- a/core/consensus/slot/consensusMessageValidator.go
+++ b/core/consensus/slot/consensusMessageValidator.go
@@ -106,13 +106,17 @@ func (cmv *consensusMessageValidator) checkConsensusMessageValidity(cnsMsg *cons
 
 	msgType := consensus.MessageType(cnsMsg.MsgType)
 
-	if cmv.consensusState.SlotIndex+1 < cnsMsg.SlotIndex {
+	cmv.consensusState.RLockSlotState()
+	currentSlotIndex := cmv.consensusState.SlotIndex
+	cmv.consensusState.RUnlockSlotState()
+
+	if currentSlotIndex+1 < cnsMsg.SlotIndex {
 		log.Trace("received message from consensus topic has a future slot",
 			"msg type", cmv.consensusService.GetStringValue(msgType),
 			"from", cnsMsg.PubKey,
 			"header hash", cnsMsg.BlockHeaderHash,
 			"msg slot", cnsMsg.SlotIndex,
-			"slot", cmv.consensusState.SlotIndex,
+			"slot", currentSlotIndex,
 		)
 
 		return fmt.Errorf("%w : received message from consensus topic has a future slot: %d",
@@ -120,13 +124,13 @@ func (cmv *consensusMessageValidator) checkConsensusMessageValidity(cnsMsg *cons
 			cnsMsg.SlotIndex)
 	}
 
-	if cmv.consensusState.SlotIndex > cnsMsg.SlotIndex {
+	if currentSlotIndex > cnsMsg.SlotIndex {
 		log.Trace("received message from consensus topic has a past slot",
 			"msg type", cmv.consensusService.GetStringValue(msgType),
 			"from", cnsMsg.PubKey,
 			"header hash", cnsMsg.BlockHeaderHash,
 			"msg slot", cnsMsg.SlotIndex,
-			"slot", cmv.consensusState.SlotIndex,
+			"slot", currentSlotIndex,
 		)
 
 		return fmt.Errorf("%w : received message from consensus topic has a past slot: %d",

--- a/core/consensus/slot/consensusState.go
+++ b/core/consensus/slot/consensusState.go
@@ -13,21 +13,26 @@ import (
 
 var log = logger.GetOrCreate("consensus/slot")
 
-// ConsensusState defines the data needed by slot to do the consensus in each slot
+// ConsensusState defines the data needed by slot to do the consensus in each slot.
+//
+// mutSlotState guards the slot-scoped fields. Fields stay public; callers
+// Lock/RLock at handler boundaries. Even chronology must hold the lock —
+// interceptor goroutines write Data/Header for followers.
 type ConsensusState struct {
+	// mutSlotState guards every field in this block.
+	mutSlotState sync.RWMutex
 	// hold the data on which validators do the consensus (could be for example a hash of the block header
 	// proposed by the leader)
-	Data   []byte
-	Header data.HeaderHandler
-
-	receivedHeaders    []data.HeaderHandler
-	mutReceivedHeaders sync.RWMutex
-
+	Data                        []byte
+	Header                      data.HeaderHandler
 	SlotIndex                   int64
 	SlotTimestamp               time.Time
 	SlotCanceled                bool
 	ExtendedCalled              bool
 	WaitingAllSignaturesTimeOut bool
+
+	receivedHeaders    []data.HeaderHandler
+	mutReceivedHeaders sync.RWMutex
 
 	processingBlock    bool
 	mutProcessingBlock sync.RWMutex
@@ -35,6 +40,39 @@ type ConsensusState struct {
 	*slotConsensus
 	*slotThreshold
 	*slotStatus
+}
+
+// LockSlotState locks mutSlotState for writing.
+func (cns *ConsensusState) LockSlotState() { cns.mutSlotState.Lock() }
+
+// UnlockSlotState unlocks mutSlotState.
+func (cns *ConsensusState) UnlockSlotState() { cns.mutSlotState.Unlock() }
+
+// RLockSlotState locks mutSlotState for reading.
+func (cns *ConsensusState) RLockSlotState() { cns.mutSlotState.RLock() }
+
+// RUnlockSlotState releases the read lock on mutSlotState.
+func (cns *ConsensusState) RUnlockSlotState() { cns.mutSlotState.RUnlock() }
+
+// SetSlotCanceled writes SlotCanceled under mutSlotState.
+func (cns *ConsensusState) SetSlotCanceled(canceled bool) {
+	cns.mutSlotState.Lock()
+	cns.SlotCanceled = canceled
+	cns.mutSlotState.Unlock()
+}
+
+// SetExtendedCalled writes ExtendedCalled under mutSlotState.
+func (cns *ConsensusState) SetExtendedCalled(extended bool) {
+	cns.mutSlotState.Lock()
+	cns.ExtendedCalled = extended
+	cns.mutSlotState.Unlock()
+}
+
+// SetWaitingAllSignaturesTimeOut writes WaitingAllSignaturesTimeOut under mutSlotState.
+func (cns *ConsensusState) SetWaitingAllSignaturesTimeOut(timedOut bool) {
+	cns.mutSlotState.Lock()
+	cns.WaitingAllSignaturesTimeOut = timedOut
+	cns.mutSlotState.Unlock()
 }
 
 // NewConsensusState creates a new ConsensusState object
@@ -55,17 +93,45 @@ func NewConsensusState(
 	return &cns
 }
 
-// ResetConsensusState method resets all the consensus data
-func (cns *ConsensusState) ResetConsensusState() {
+// resetSlotStateLocked clears slot-scoped consensus fields.
+// Caller must hold mutSlotState for writing.
+func (cns *ConsensusState) resetSlotStateLocked() {
 	cns.Header = nil
 	cns.Data = nil
-
-	cns.initReceivedHeaders()
-
 	cns.SlotCanceled = false
 	cns.ExtendedCalled = false
 	cns.WaitingAllSignaturesTimeOut = false
+}
 
+// ResetConsensusState clears slot-scoped state without touching SlotIndex or
+// SlotTimestamp. Use at construction only; for slot transitions in the
+// chronology, use BeginNewSlot.
+func (cns *ConsensusState) ResetConsensusState() {
+	cns.mutSlotState.Lock()
+	cns.resetSlotStateLocked()
+	cns.mutSlotState.Unlock()
+
+	cns.initReceivedHeaders()
+	cns.ResetSlotStatus()
+	cns.ResetSlotState()
+}
+
+// BeginNewSlot atomically transitions ConsensusState into the next slot,
+// updating SlotIndex + SlotTimestamp and clearing slot-scoped flags under a
+// single mutSlotState write. The atomicity guards waitAllSignatures: if
+// SlotIndex were updated separately from the flag reset, a stale goroutine
+// from the prior slot could fire in the gap, observe SlotIndex still equal
+// to its spawnSlot, and set WaitingAllSignaturesTimeOut on the freshly-cleared
+// state — causing the next slot's leader to commit with minimum quorum
+// prematurely.
+func (cns *ConsensusState) BeginNewSlot(slotIndex int64, slotTimestamp time.Time) {
+	cns.mutSlotState.Lock()
+	cns.resetSlotStateLocked()
+	cns.SlotIndex = slotIndex
+	cns.SlotTimestamp = slotTimestamp
+	cns.mutSlotState.Unlock()
+
+	cns.initReceivedHeaders()
 	cns.ResetSlotStatus()
 	cns.ResetSlotState()
 }
@@ -110,15 +176,16 @@ func (cns *ConsensusState) IsSelfLeaderInCurrentSlot() bool {
 
 // GetLeader method gets the leader of the current slot
 func (cns *ConsensusState) GetLeader() (string, error) {
-	if cns.consensusGroup == nil {
+	cg := cns.ConsensusGroup()
+	if cg == nil {
 		return "", ErrNilConsensusGroup
 	}
 
-	if len(cns.consensusGroup) == 0 {
+	if len(cg) == 0 {
 		return "", ErrEmptyConsensusGroup
 	}
 
-	return cns.consensusGroup[0], nil
+	return cg[0], nil
 }
 
 // GetNextConsensusGroup gets the new consensus group for the current slot based on current eligible list and a random
@@ -151,17 +218,21 @@ func (cns *ConsensusState) GetNextConsensusGroup(
 	return newConsensusGroup, nil
 }
 
-// IsConsensusDataSet method returns true if the consensus data for the current slot is set and false otherwise
+// IsConsensusDataSet method returns true if the consensus data for the current slot is set and false otherwise.
 func (cns *ConsensusState) IsConsensusDataSet() bool {
+	cns.mutSlotState.RLock()
 	isConsensusDataSet := cns.Data != nil
+	cns.mutSlotState.RUnlock()
 
 	return isConsensusDataSet
 }
 
 // IsConsensusDataEqual method returns true if the consensus data for the current slot is the same with the given
-// one and false otherwise
+// one and false otherwise.
 func (cns *ConsensusState) IsConsensusDataEqual(data []byte) bool {
+	cns.mutSlotState.RLock()
 	isConsensusDataEqual := bytes.Equal(cns.Data, data)
+	cns.mutSlotState.RUnlock()
 
 	return isConsensusDataEqual
 }
@@ -196,9 +267,11 @@ func (cns *ConsensusState) IsNodeSelf(node string) bool {
 	return isNodeSelf
 }
 
-// IsHeaderAlreadyReceived method returns true if header is already received and false otherwise
+// IsHeaderAlreadyReceived method returns true if header is already received and false otherwise.
 func (cns *ConsensusState) IsHeaderAlreadyReceived() bool {
+	cns.mutSlotState.RLock()
 	isHeaderAlreadyReceived := cns.Header != nil
+	cns.mutSlotState.RUnlock()
 
 	return isHeaderAlreadyReceived
 }
@@ -286,7 +359,10 @@ func (cns *ConsensusState) SetProcessingBlock(processingBlock bool) {
 	cns.mutProcessingBlock.Unlock()
 }
 
-// GetData gets the Data of the consensusState
+// GetData returns the consensus data slice header. The slice contents must not be mutated by callers.
 func (cns *ConsensusState) GetData() []byte {
-	return cns.Data
+	cns.mutSlotState.RLock()
+	data := cns.Data
+	cns.mutSlotState.RUnlock()
+	return data
 }

--- a/core/consensus/slot/consensusState.go
+++ b/core/consensus/slot/consensusState.go
@@ -75,6 +75,20 @@ func (cns *ConsensusState) SetWaitingAllSignaturesTimeOut(timedOut bool) {
 	cns.mutSlotState.Unlock()
 }
 
+// SetWaitingAllSignaturesTimeOutIfSlot atomically sets WaitingAllSignaturesTimeOut
+// only when SlotIndex still equals spawnSlot. Returns true when the write was
+// applied. Used by waitAllSignatures to ensure a stale goroutine cannot set the
+// flag after BeginNewSlot has already advanced the slot and cleared state.
+func (cns *ConsensusState) SetWaitingAllSignaturesTimeOutIfSlot(spawnSlot int64, timedOut bool) bool {
+	cns.mutSlotState.Lock()
+	defer cns.mutSlotState.Unlock()
+	if cns.SlotIndex != spawnSlot {
+		return false
+	}
+	cns.WaitingAllSignaturesTimeOut = timedOut
+	return true
+}
+
 // NewConsensusState creates a new ConsensusState object
 func NewConsensusState(
 	slotConsensus *slotConsensus,

--- a/core/consensus/slot/consensusState_test.go
+++ b/core/consensus/slot/consensusState_test.go
@@ -554,6 +554,7 @@ func TestConsensusState_BeginNewSlotResetsFlagsAndUpdatesIndex(t *testing.T) {
 	cns.SetWaitingAllSignaturesTimeOut(true)
 	cns.LockSlotState()
 	cns.Data = []byte("stale")
+	cns.Header = &block.Block{}
 	cns.UnlockSlotState()
 
 	ts := time.Unix(1700000000, 0)

--- a/core/consensus/slot/consensusState_test.go
+++ b/core/consensus/slot/consensusState_test.go
@@ -3,6 +3,7 @@ package slot_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core/consensus"
@@ -459,4 +460,117 @@ func TestConsensusState_SetAndGetProcessingBlockShouldWork(t *testing.T) {
 	cns.SetProcessingBlock(true)
 
 	assert.Equal(t, true, cns.ProcessingBlock())
+}
+
+func TestConsensusState_LockUnlockSlotStateAllowsReentryAfterRelease(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+
+	cns.LockSlotState()
+	cns.SlotIndex = 7
+	cns.UnlockSlotState()
+
+	cns.RLockSlotState()
+	got := cns.SlotIndex
+	cns.RUnlockSlotState()
+
+	assert.Equal(t, int64(7), got)
+}
+
+func TestConsensusState_SetSlotCanceledTogglesFlag(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+	cns.SetSlotCanceled(true)
+	assert.True(t, cns.SlotCanceled)
+
+	cns.SetSlotCanceled(false)
+	assert.False(t, cns.SlotCanceled)
+}
+
+func TestConsensusState_SetExtendedCalledTogglesFlag(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+	cns.SetExtendedCalled(true)
+	assert.True(t, cns.ExtendedCalled)
+
+	cns.SetExtendedCalled(false)
+	assert.False(t, cns.ExtendedCalled)
+}
+
+func TestConsensusState_SetWaitingAllSignaturesTimeOutTogglesFlag(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+	cns.SetWaitingAllSignaturesTimeOut(true)
+	assert.True(t, cns.WaitingAllSignaturesTimeOut)
+
+	cns.SetWaitingAllSignaturesTimeOut(false)
+	assert.False(t, cns.WaitingAllSignaturesTimeOut)
+}
+
+func TestConsensusState_SetWaitingAllSignaturesTimeOutIfSlot_AppliesOnSameSlot(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+	cns.BeginNewSlot(42, time.Unix(1700000000, 0))
+
+	applied := cns.SetWaitingAllSignaturesTimeOutIfSlot(42, true)
+	assert.True(t, applied)
+	assert.True(t, cns.WaitingAllSignaturesTimeOut)
+}
+
+func TestConsensusState_SetWaitingAllSignaturesTimeOutIfSlot_SkipsOnSlotMismatch(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+	cns.BeginNewSlot(42, time.Unix(1700000000, 0))
+
+	applied := cns.SetWaitingAllSignaturesTimeOutIfSlot(41, true)
+	assert.False(t, applied)
+	assert.False(t, cns.WaitingAllSignaturesTimeOut)
+}
+
+func TestConsensusState_GetDataReadsUnderLock(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+
+	cns.LockSlotState()
+	cns.Data = []byte("payload")
+	cns.UnlockSlotState()
+
+	assert.Equal(t, []byte("payload"), cns.GetData())
+}
+
+func TestConsensusState_BeginNewSlotResetsFlagsAndUpdatesIndex(t *testing.T) {
+	t.Parallel()
+
+	cns := internalInitConsensusState()
+	cns.SetSlotCanceled(true)
+	cns.SetExtendedCalled(true)
+	cns.SetWaitingAllSignaturesTimeOut(true)
+	cns.LockSlotState()
+	cns.Data = []byte("stale")
+	cns.UnlockSlotState()
+
+	ts := time.Unix(1700000000, 0)
+	cns.BeginNewSlot(99, ts)
+
+	cns.RLockSlotState()
+	idx := cns.SlotIndex
+	stamp := cns.SlotTimestamp
+	data := cns.Data
+	header := cns.Header
+	cns.RUnlockSlotState()
+
+	assert.Equal(t, int64(99), idx)
+	assert.Equal(t, ts, stamp)
+	assert.Nil(t, data)
+	assert.Nil(t, header)
+	assert.False(t, cns.SlotCanceled)
+	assert.False(t, cns.ExtendedCalled)
+	assert.False(t, cns.WaitingAllSignaturesTimeOut)
 }

--- a/core/consensus/slot/slotConsensus.go
+++ b/core/consensus/slot/slotConsensus.go
@@ -4,11 +4,22 @@ import (
 	"sync"
 )
 
-// slotConsensus defines the data needed by spos to do the consensus in each slot
+// slotConsensus defines the data needed by spos to do the consensus in each slot.
+//
+// Locking layout — three independent mutexes, intentionally separate to keep
+// the hot signature-collection path (JobDone / SetJobDone) from contending
+// against ConsensusGroup() reads called from every consensus check:
+//   - mutElected protects electedNodes
+//   - mutConsensusGroup protects consensusGroup
+//   - mut           protects validatorSlotStates
+//
+// SetConsensusGroup acquires mutConsensusGroup and mut in that order to swap
+// both atomically with respect to combined readers; never the reverse order.
 type slotConsensus struct {
 	electedNodes        map[string]struct{}
 	mutElected          sync.RWMutex
 	consensusGroup      []string
+	mutConsensusGroup   sync.RWMutex
 	consensusGroupSize  int
 	selfPubKey          string
 	validatorSlotStates map[string]*slotState
@@ -36,6 +47,8 @@ func NewSlotConsensus(
 
 // ConsensusGroupIndex returns the index of given public key in the current consensus group
 func (rcns *slotConsensus) ConsensusGroupIndex(pubKey string) (int, error) {
+	rcns.mutConsensusGroup.RLock()
+	defer rcns.mutConsensusGroup.RUnlock()
 	for i, pk := range rcns.consensusGroup {
 		if pk == pubKey {
 			return i, nil
@@ -49,9 +62,15 @@ func (rcns *slotConsensus) SelfConsensusGroupIndex() (int, error) {
 	return rcns.ConsensusGroupIndex(rcns.selfPubKey)
 }
 
-// ConsensusGroup returns the consensus group ID's
+// ConsensusGroup returns the consensus group ID's. The slice header is captured
+// under mutConsensusGroup.RLock so callers see a stable view even while
+// SetConsensusGroup is installing a new group. The returned slice is not
+// deep-copied; callers must treat the elements as read-only.
 func (rcns *slotConsensus) ConsensusGroup() []string {
-	return rcns.consensusGroup
+	rcns.mutConsensusGroup.RLock()
+	cg := rcns.consensusGroup
+	rcns.mutConsensusGroup.RUnlock()
+	return cg
 }
 
 // SetConsensusGroup sets the consensus group ID's
@@ -64,16 +83,27 @@ func (rcns *slotConsensus) SetConsensusGroup(consensusGroup []string) {
 	}
 	rcns.mutElected.Unlock()
 
+	// Acquire mutConsensusGroup then mut, with each section released before
+	// the next is taken. The two writes are NOT atomic against combined
+	// readers: a concurrent ComputeSize call can briefly observe the new
+	// consensusGroup against the old validatorSlotStates map, which causes
+	// JobDone lookups to return ErrInvalidKey and ComputeSize to undercount
+	// for one poll cycle. This is benign — the next poll sees consistent
+	// state. Holding both locks simultaneously would prevent that window
+	// but forces the same lock-order discipline on every reader, which we
+	// avoid here so JobDone (hot path) does not contend with ConsensusGroup
+	// reads. Lock order is fixed (mutConsensusGroup before mut) so that
+	// callers holding mut.RLock can safely call ConsensusGroup() afterward
+	// without deadlock; never reverse.
+	rcns.mutConsensusGroup.Lock()
 	rcns.consensusGroup = consensusGroup
+	rcns.mutConsensusGroup.Unlock()
 
 	rcns.mut.Lock()
-
 	rcns.validatorSlotStates = make(map[string]*slotState)
-
-	for i := 0; i < len(consensusGroup); i++ {
-		rcns.validatorSlotStates[rcns.consensusGroup[i]] = NewSlotState()
+	for i := range consensusGroup {
+		rcns.validatorSlotStates[consensusGroup[i]] = NewSlotState()
 	}
-
 	rcns.mut.Unlock()
 }
 
@@ -156,8 +186,9 @@ func (rcns *slotConsensus) IsNodeInConsensusGroup(node string) bool {
 func (rcns *slotConsensus) ComputeSize(subslotId int) int {
 	n := 0
 
-	for i := 0; i < len(rcns.consensusGroup); i++ {
-		isJobDone, err := rcns.JobDone(rcns.consensusGroup[i], subslotId)
+	cg := rcns.ConsensusGroup()
+	for i := range cg {
+		isJobDone, err := rcns.JobDone(cg[i], subslotId)
 		if err != nil {
 			log.Debug("JobDone", "error", err.Error())
 			continue
@@ -174,11 +205,16 @@ func (rcns *slotConsensus) ComputeSize(subslotId int) int {
 // ResetSlotState method resets the state of each node from the current jobDone group, regarding to the
 // consensus validatorSlotStates
 func (rcns *slotConsensus) ResetSlotState() {
-	rcns.mut.Lock()
+	// Snapshot consensusGroup via the getter so we never nest
+	// mutConsensusGroup inside mut (which would deadlock against
+	// SetConsensusGroup's acquire order).
+	cg := rcns.ConsensusGroup()
 
-	var currentSlotState *slotState
-	for i := 0; i < len(rcns.consensusGroup); i++ {
-		currentSlotState = rcns.validatorSlotStates[rcns.consensusGroup[i]]
+	rcns.mut.Lock()
+	defer rcns.mut.Unlock()
+
+	for _, pk := range cg {
+		currentSlotState := rcns.validatorSlotStates[pk]
 		if currentSlotState == nil {
 			log.Debug("validatorSlotStates", "error", ErrNilSlotState.Error())
 			continue
@@ -186,6 +222,4 @@ func (rcns *slotConsensus) ResetSlotState() {
 
 		currentSlotState.ResetJobsDone()
 	}
-
-	rcns.mut.Unlock()
 }

--- a/core/consensus/slot/slotConsensus.go
+++ b/core/consensus/slot/slotConsensus.go
@@ -13,8 +13,12 @@ import (
 //   - mutConsensusGroup protects consensusGroup
 //   - mut           protects validatorSlotStates
 //
-// SetConsensusGroup acquires mutConsensusGroup and mut in that order to swap
-// both atomically with respect to combined readers; never the reverse order.
+// SetConsensusGroup installs consensusGroup and validatorSlotStates in two
+// separate critical sections (mutConsensusGroup, then mut); the writes are
+// intentionally not atomic against combined readers, and a concurrent
+// ComputeSize can undercount for one poll cycle before self-healing on the
+// next poll. Lock order is fixed: mutConsensusGroup before mut, never the
+// reverse, so readers holding mut.RLock can safely call ConsensusGroup().
 type slotConsensus struct {
 	electedNodes        map[string]struct{}
 	mutElected          sync.RWMutex

--- a/core/consensus/slot/slotConsensus_test.go
+++ b/core/consensus/slot/slotConsensus_test.go
@@ -229,8 +229,6 @@ func TestSlotConsensus_ResetValidationMap(t *testing.T) {
 	jobDone, _ := rcns.JobDone("1", bls.SrBlock)
 	assert.Equal(t, true, jobDone)
 
-	rcns.ConsensusGroup()[1] = "X"
-
 	rcns.ResetSlotState()
 
 	jobDone, err := rcns.JobDone("1", bls.SrBlock)

--- a/core/consensus/slot/subslot.go
+++ b/core/consensus/slot/subslot.go
@@ -160,7 +160,7 @@ func (sr *Subslot) DoWork(slotManager consensus.SlotManager) bool {
 			}
 		case <-timer.C:
 			if sr.Extend != nil {
-				sr.SlotCanceled = true
+				sr.SetSlotCanceled(true)
 				sr.Extend(sr.current)
 			}
 

--- a/core/consensus/slot/worker.go
+++ b/core/consensus/slot/worker.go
@@ -387,9 +387,13 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		return err
 	}
 
-	if cnsMsg.SlotIndex > wrk.consensusState.SlotIndex {
+	wrk.consensusState.RLockSlotState()
+	currentSlotIndex := wrk.consensusState.SlotIndex
+	wrk.consensusState.RUnlockSlotState()
+
+	if cnsMsg.SlotIndex > currentSlotIndex {
 		log.Trace("storing consensus message due to slot mismatch",
-			"wrk.consensusState.SlotIndex", wrk.consensusState.SlotIndex,
+			"wrk.consensusState.SlotIndex", currentSlotIndex,
 			"cnsDta.SlotIndex", cnsMsg.SlotIndex,
 		)
 		wrk.storeMessage(cnsMsg)
@@ -552,7 +556,12 @@ func (wrk *Worker) checkSelfState(cnsDta *consensus.Message) error {
 		return ErrMessageFromItself
 	}
 
-	if wrk.consensusState.SlotCanceled && wrk.consensusState.SlotIndex == cnsDta.SlotIndex {
+	wrk.consensusState.RLockSlotState()
+	canceled := wrk.consensusState.SlotCanceled
+	currentSlotIndex := wrk.consensusState.SlotIndex
+	wrk.consensusState.RUnlockSlotState()
+
+	if canceled && currentSlotIndex == cnsDta.SlotIndex {
 		return ErrSlotCanceled
 	}
 
@@ -584,11 +593,14 @@ func (wrk *Worker) executeStoredMessages() {
 }
 
 func (wrk *Worker) executeMessage(cnsDtaList []*consensus.Message) {
+	wrk.consensusState.RLockSlotState()
+	currentSlotIndex := wrk.consensusState.SlotIndex
+	wrk.consensusState.RUnlockSlotState()
 	for i, cnsDta := range cnsDtaList {
 		if cnsDta == nil {
 			continue
 		}
-		if wrk.consensusState.SlotIndex != cnsDta.SlotIndex {
+		if currentSlotIndex != cnsDta.SlotIndex {
 			continue
 		}
 
@@ -636,7 +648,7 @@ func (wrk *Worker) checkChannels(ctx context.Context) {
 
 // Extend does an extension for the subslot with subslotId
 func (wrk *Worker) Extend(subslotId int) {
-	wrk.consensusState.ExtendedCalled = true
+	wrk.consensusState.SetExtendedCalled(true)
 	log.Debug("extend function is called",
 		"subslot", wrk.consensusService.GetSubslotName(subslotId))
 
@@ -668,10 +680,14 @@ func (wrk *Worker) Extend(subslotId int) {
 			}})
 	}
 
-	wrk.blockProcessor.RevertStateToSnapshot(wrk.consensusState.Header)
+	wrk.consensusState.RLockSlotState()
+	header := wrk.consensusState.Header
+	wrk.consensusState.RUnlockSlotState()
 
-	if wrk.consensusState.Header != nil &&
-		wrk.consensusState.Header.GetNonce() == wrk.forkDetector.ProbableHighestNonce() {
+	wrk.blockProcessor.RevertStateToSnapshot(header)
+
+	if header != nil &&
+		header.GetNonce() == wrk.forkDetector.ProbableHighestNonce() {
 		wrk.forkDetector.ResetProbableHighestNonce()
 	}
 }

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -123,16 +123,8 @@ func (mp *metaProcessor) ProcessBlock(
 		return process.ErrNilHaveTimeHandler
 	}
 
-	err := mp.checkBlockValidity(headerHandler)
+	err := mp.validateBlockAndRequestMissing(headerHandler)
 	if err != nil {
-		if err == process.ErrBlockHashDoesNotMatch {
-			log.Debug("requested missing header",
-				"hash", headerHandler.GetParentHash(),
-			)
-
-			go mp.requestHandler.RequestHeader(headerHandler.GetParentHash())
-		}
-
 		return err
 	}
 
@@ -153,24 +145,7 @@ func (mp *metaProcessor) ProcessBlock(
 		return common.ErrWrongTypeAssertion
 	}
 
-	txCounts := mp.txCounter.getPoolCounts(mp.dataPool)
-	log.Debug("total txs in pool", "counts", txCounts.String())
-
-	// Clone the header before handing it to the async metrics goroutine —
-	// ProcessBlock's main path keeps mutating the same pointer (e.g.,
-	// epochStartNativeStakingKapps -> SetBurnedUnclaimed), so a shared
-	// reference races on every field read inside getMetricsFromHeader.
-	metricsHeader, ok := header.Clone().(*block.Block)
-	if ok {
-		go getMetricsFromHeader(
-			metricsHeader,
-			tools.SafeI64ToU64(txCounts.GetTotal()),
-			mp.marshalizer,
-			mp.appStatusHandler,
-		)
-	} else {
-		log.Error("ProcessBlock: cloned header has unexpected type, skipping async metrics")
-	}
+	mp.dispatchAsyncHeaderMetrics(header)
 
 	defer func() {
 		if err != nil {
@@ -212,17 +187,7 @@ func (mp *metaProcessor) ProcessBlock(
 	}
 
 	if header.GetIsEpochStart() {
-		err = mp.processEpochStartBlock(header)
-		if err != nil {
-			_ = bugsnag.Notify(fmt.Errorf("process epoch start block: %w", err), bugsnag.MetaData{"data": {"header": header}})
-			return err
-		}
-
-		err = mp.verifyFees(header)
-		if err != nil {
-			_ = bugsnag.Notify(fmt.Errorf("process verify fees: %w", err), bugsnag.MetaData{"data": {"header": header}})
-		}
-		return err
+		return mp.handleEpochStartBlock(header)
 	}
 
 	err = mp.verifyFees(header)
@@ -248,14 +213,85 @@ func (mp *metaProcessor) ProcessBlock(
 		mp.appStatusHandler,
 	)
 
+	err = mp.verifyBlockTrieRoots(header)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateBlockAndRequestMissing wraps checkBlockValidity and, on an
+// ErrBlockHashDoesNotMatch result, fires an async request for the missing
+// parent header before returning the error to the caller.
+func (mp *metaProcessor) validateBlockAndRequestMissing(headerHandler data.HeaderHandler) error {
+	err := mp.checkBlockValidity(headerHandler)
+	if err == nil {
+		return nil
+	}
+
+	if err == process.ErrBlockHashDoesNotMatch {
+		log.Debug("requested missing header",
+			"hash", headerHandler.GetParentHash(),
+		)
+		go mp.requestHandler.RequestHeader(headerHandler.GetParentHash())
+	}
+
+	return err
+}
+
+// dispatchAsyncHeaderMetrics clones the header and emits per-block metrics in
+// a goroutine. ProcessBlock keeps mutating the original header pointer (e.g.,
+// epochStartNativeStakingKapps -> SetBurnedUnclaimed), so handing the same
+// reference to a background reader races on every field access.
+func (mp *metaProcessor) dispatchAsyncHeaderMetrics(header *block.Block) {
+	txCounts := mp.txCounter.getPoolCounts(mp.dataPool)
+	log.Debug("total txs in pool", "counts", txCounts.String())
+
+	metricsHeader, ok := header.Clone().(*block.Block)
+	if !ok {
+		log.Error("ProcessBlock: cloned header has unexpected type, skipping async metrics")
+		return
+	}
+
+	go getMetricsFromHeader(
+		metricsHeader,
+		tools.SafeI64ToU64(txCounts.GetTotal()),
+		mp.marshalizer,
+		mp.appStatusHandler,
+	)
+}
+
+// handleEpochStartBlock runs the epoch-start branch of ProcessBlock: process
+// the epoch-start block, then verify fees. The fees error is reported and
+// returned, but does not skip the bugsnag notification.
+func (mp *metaProcessor) handleEpochStartBlock(header *block.Block) error {
+	err := mp.processEpochStartBlock(header)
+	if err != nil {
+		_ = bugsnag.Notify(fmt.Errorf("process epoch start block: %w", err), bugsnag.MetaData{"data": {"header": header}})
+		return err
+	}
+
+	err = mp.verifyFees(header)
+	if err != nil {
+		_ = bugsnag.Notify(fmt.Errorf("process verify fees: %w", err), bugsnag.MetaData{"data": {"header": header}})
+	}
+
+	return nil
+}
+
+// verifyBlockTrieRoots runs the three post-transaction trie-root checks
+// (account, validator-statistics, kapp). Each failure is reported via bugsnag
+// before being returned to the caller.
+func (mp *metaProcessor) verifyBlockTrieRoots(header *block.Block) error {
 	if !mp.verifyStateRootAccount(header.GetTrieRoot()) {
 		log.Debug("processBlock.verifyStateRootAccount", "blockTrieRoot", logger.DisplayByteSlice(header.GetTrieRoot()))
-		err = process.ErrRootStateDoesNotMatch
+		err := process.ErrRootStateDoesNotMatch
 		_ = bugsnag.Notify(fmt.Errorf("process account state: %w", err), bugsnag.MetaData{"data": {"header": header}})
 		return err
 	}
 
-	err = mp.verifyValidatorStatisticsRootHash(header)
+	err := mp.verifyValidatorStatisticsRootHash(header)
 	if err != nil {
 		_ = bugsnag.Notify(fmt.Errorf("process epoch valdiator state: %w", err), bugsnag.MetaData{"data": {"header": header}})
 		return err

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -156,12 +156,21 @@ func (mp *metaProcessor) ProcessBlock(
 	txCounts := mp.txCounter.getPoolCounts(mp.dataPool)
 	log.Debug("total txs in pool", "counts", txCounts.String())
 
-	go getMetricsFromHeader(
-		header,
-		tools.SafeI64ToU64(txCounts.GetTotal()),
-		mp.marshalizer,
-		mp.appStatusHandler,
-	)
+	// Clone the header before handing it to the async metrics goroutine —
+	// ProcessBlock's main path keeps mutating the same pointer (e.g.,
+	// epochStartNativeStakingKapps -> SetBurnedUnclaimed), so a shared
+	// reference races on every field read inside getMetricsFromHeader.
+	metricsHeader, ok := header.Clone().(*block.Block)
+	if ok {
+		go getMetricsFromHeader(
+			metricsHeader,
+			tools.SafeI64ToU64(txCounts.GetTotal()),
+			mp.marshalizer,
+			mp.appStatusHandler,
+		)
+	} else {
+		log.Error("ProcessBlock: cloned header has unexpected type, skipping async metrics")
+	}
 
 	defer func() {
 		if err != nil {

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -230,7 +231,7 @@ func (mp *metaProcessor) validateBlockAndRequestMissing(headerHandler data.Heade
 		return nil
 	}
 
-	if err == process.ErrBlockHashDoesNotMatch {
+	if errors.Is(err, process.ErrBlockHashDoesNotMatch) {
 		log.Debug("requested missing header",
 			"hash", headerHandler.GetParentHash(),
 		)
@@ -277,7 +278,7 @@ func (mp *metaProcessor) handleEpochStartBlock(header *block.Block) error {
 		_ = bugsnag.Notify(fmt.Errorf("process verify fees: %w", err), bugsnag.MetaData{"data": {"header": header}})
 	}
 
-	return nil
+	return err
 }
 
 // verifyBlockTrieRoots runs the three post-transaction trie-root checks
@@ -293,7 +294,7 @@ func (mp *metaProcessor) verifyBlockTrieRoots(header *block.Block) error {
 
 	err := mp.verifyValidatorStatisticsRootHash(header)
 	if err != nil {
-		_ = bugsnag.Notify(fmt.Errorf("process epoch valdiator state: %w", err), bugsnag.MetaData{"data": {"header": header}})
+		_ = bugsnag.Notify(fmt.Errorf("process epoch validator state: %w", err), bugsnag.MetaData{"data": {"header": header}})
 		return err
 	}
 

--- a/integrationTest/consensus/consensus_test.go
+++ b/integrationTest/consensus/consensus_test.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +15,19 @@ import (
 )
 
 var log = logger.GetOrCreate("integrationTest/consensus")
+
+// simulatedSlotDuration is the per-slot interval baked into the synthetic
+// timestamps these tests feed to consensus via TimestampCalled. It matches
+// the 4-second slot used on mainnet, and the tests are deliberately bounded
+// by the same budget — if consensus cannot commit a block within one slot
+// duration on a healthy 7-node cluster, that is a real regression, not a
+// flake, and the test should surface it.
+const simulatedSlotDuration = 4 * time.Second
+
+// blockWaitTimeoutSeconds is the per-step wait used by these tests. Pinned
+// to the mainnet slot duration so the test also validates that consensus
+// keeps up with the production cadence.
+const blockWaitTimeoutSeconds = int(simulatedSlotDuration / time.Second)
 
 func initTest(t *testing.T, numOfNodes int) ([]*processorNode.ProcessorNode, []*processorNode.NodeAccount, error) {
 	initialBalance := int64(1_000_000_000_000)
@@ -42,19 +56,23 @@ func TestConsensus_RevertBlockAndTransactions(t *testing.T) {
 	require.Nil(t, err)
 	assert.Len(t, wallets, 2)
 
-	currentSlot := int64(0)
+	// currentSlot is mutated by the test goroutine (via Add) and read by the
+	// per-node UpdateSlot/Timestamp closures invoked from the chronology
+	// goroutine, so it must be accessed atomically.
+	var currentSlot atomic.Int64
 
 	integrationTest.UpdateSlot(nodes, 0)
 	for _, n := range nodes {
-		n.SlotManager.TimeDurationField = 4 // 4 seconds simulation
-		n.SlotManager.UpdateSlotCalled = func(t time.Time) {
-			n.SlotManager.SlotIndex = currentSlot
+		n.SlotManager.TimeDurationField = simulatedSlotDuration
+		n.SlotManager.UpdateSlotCalled = func(_ time.Time) {
+			n.SlotManager.SlotIndex.Store(currentSlot.Load())
 		}
 		n.SlotManager.TimestampCalled = func() time.Time {
-			// compute Timestamp based on slot
-			return n.SlotManager.GenesisTimeField.Add(time.Duration(currentSlot*int64(n.SlotManager.TimeDurationField)) * time.Second) // 4 seconds simulation
+			return n.SlotManager.GenesisTimeField.Add(
+				time.Duration(currentSlot.Load()) * simulatedSlotDuration,
+			)
 		}
-		n.SlotManager.RemainingTimeCalled = func(startTime time.Time, maxTime time.Duration) time.Duration {
+		n.SlotManager.RemainingTimeCalled = func(_ time.Time, maxTime time.Duration) time.Duration {
 			return maxTime // always return maxTime
 		}
 
@@ -62,13 +80,13 @@ func TestConsensus_RevertBlockAndTransactions(t *testing.T) {
 	}
 
 	// inc slot and wait for block proposal
-	currentSlot++
+	slot := currentSlot.Add(1)
 	// wait for block proposal
-	WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
+	WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
 
 	// create another block
-	currentSlot++
-	WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
+	slot = currentSlot.Add(1)
+	WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
 
 	log.Info("*********************** SEND TX ***********************")
 	// send transaction
@@ -76,15 +94,15 @@ func TestConsensus_RevertBlockAndTransactions(t *testing.T) {
 	log.Info("TX Sent", "hash", txHash, "sender", tx.GetSender(), "nonce", tx.GetNonce())
 
 	// create another block
-	currentSlot++
-	WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
+	slot = currentSlot.Add(1)
+	WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
 
 	// check tx in block
-	err = commonTxTest.CheckTXInBlock(nodes, txHash, uint64(currentSlot))
+	err = commonTxTest.CheckTXInBlock(nodes, txHash, uint64(slot))
 	require.Nil(t, err)
 
 	// revert last block
-	err = integrationTest.RevertOneBlock(nodes, uint64(currentSlot))
+	err = integrationTest.RevertOneBlock(nodes, uint64(slot))
 	require.Nil(t, err)
 
 	// check tx in block
@@ -92,12 +110,12 @@ func TestConsensus_RevertBlockAndTransactions(t *testing.T) {
 	require.Nil(t, err)
 
 	// create another block
-	currentSlot++
-	WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
+	slot = currentSlot.Add(1)
+	WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
 
 	// TX should be processed on next blok after revert
-	txBlockNonce := uint64(currentSlot) - 1
-	txBlockSlot := uint64(currentSlot)
+	txBlockNonce := uint64(slot) - 1
+	txBlockSlot := uint64(slot)
 
 	// check TX in block again
 	err = commonTxTest.CheckTXInBlock(nodes, txHash, txBlockNonce)
@@ -105,8 +123,8 @@ func TestConsensus_RevertBlockAndTransactions(t *testing.T) {
 
 	// produce 12 should create 2 epochs (6 slots each)
 	for i := 0; i < 12; i++ {
-		currentSlot++
-		WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
+		slot = currentSlot.Add(1)
+		WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
 	}
 
 	// wait for block sync
@@ -123,16 +141,18 @@ func TestConsensus_RevertBlockAndTransactions(t *testing.T) {
 	assert.Equal(t, txHash, b.TxHashes[0])
 
 	// get current block header and check slot/nonce/epoch
+	finalSlot := currentSlot.Load()
 	header, _ := nodes[0].GetCurrentBlockHeaderAndHash()
-	assert.Equal(t, uint64(currentSlot), header.GetSlot())
-	assert.Equal(t, uint64(currentSlot-1), header.GetNonce())
+	assert.Equal(t, uint64(finalSlot), header.GetSlot())
+	assert.Equal(t, uint64(finalSlot-1), header.GetNonce())
 	// Since slots start at 1, we subtract 1 to align with zero-based indexing.
 	// in this tests we have 6 slots per epoch
-	assert.Equal(t, uint32(currentSlot-1)/uint32(6), header.GetEpoch())
+	assert.Equal(t, uint32(finalSlot-1)/uint32(6), header.GetEpoch())
 }
 
-func WaitForBlockNonceOrTimeOut(nodes []*processorNode.ProcessorNode, nonce uint64, timeout int) {
-	waitForBlockConditionOrTimeOut(nodes, blockWaitCondition{
+func WaitForBlockNonceOrTimeOut(t *testing.T, nodes []*processorNode.ProcessorNode, nonce uint64, timeout int) {
+	t.Helper()
+	waitForBlockConditionOrTimeOut(t, nodes, blockWaitCondition{
 		check: func(n *processorNode.ProcessorNode) bool {
 			// get current block header, check if slot is in
 			header, _ := n.GetCurrentBlockHeaderAndHash()
@@ -143,8 +163,9 @@ func WaitForBlockNonceOrTimeOut(nodes []*processorNode.ProcessorNode, nonce uint
 	}, timeout)
 }
 
-func WaitForBlockSlotOrTimeOut(nodes []*processorNode.ProcessorNode, slot uint64, timeout int) {
-	waitForBlockConditionOrTimeOut(nodes, blockWaitCondition{
+func WaitForBlockSlotOrTimeOut(t *testing.T, nodes []*processorNode.ProcessorNode, slot uint64, timeout int) {
+	t.Helper()
+	waitForBlockConditionOrTimeOut(t, nodes, blockWaitCondition{
 		check: func(n *processorNode.ProcessorNode) bool {
 			header, _ := n.GetCurrentBlockHeaderAndHash()
 			return header != nil && header.GetSlot() == slot
@@ -160,7 +181,8 @@ type blockWaitCondition struct {
 	value    uint64
 }
 
-func waitForBlockConditionOrTimeOut(nodes []*processorNode.ProcessorNode, condition blockWaitCondition, timeout int) {
+func waitForBlockConditionOrTimeOut(t *testing.T, nodes []*processorNode.ProcessorNode, condition blockWaitCondition, timeout int) {
+	t.Helper()
 	nodesComplete := make([]bool, len(nodes))
 	maxTime := time.After(time.Duration(timeout) * time.Second)
 	backoff := 100 * time.Millisecond
@@ -168,7 +190,10 @@ func waitForBlockConditionOrTimeOut(nodes []*processorNode.ProcessorNode, condit
 	for {
 		select {
 		case <-maxTime:
-			log.Error(condition.errorMsg, condition.value, "recMap", nodesComplete)
+			// Timeouts used to be silently logged, which made later assertions
+			// fire against an out-of-sync cluster and surface the flake far
+			// from its origin. Fail at the source instead.
+			t.Fatalf("%s: value=%d nodesComplete=%v", condition.errorMsg, condition.value, nodesComplete)
 			return
 		default:
 			for i, n := range nodes {

--- a/integrationTest/consensus/consensus_test.go
+++ b/integrationTest/consensus/consensus_test.go
@@ -187,34 +187,42 @@ func waitForBlockConditionOrTimeOut(t *testing.T, nodes []*processorNode.Process
 	maxTime := time.After(time.Duration(timeout) * time.Second)
 	backoff := 100 * time.Millisecond
 	maxBackoff := time.Second
+
+	check := func() bool {
+		for i, n := range nodes {
+			if nodesComplete[i] {
+				continue
+			}
+			if condition.check(n) {
+				nodesComplete[i] = true
+			}
+		}
+		for _, c := range nodesComplete {
+			if !c {
+				return false
+			}
+		}
+		return true
+	}
+
 	for {
+		if check() {
+			return
+		}
 		select {
 		case <-maxTime:
-			// Timeouts used to be silently logged, which made later assertions
-			// fire against an out-of-sync cluster and surface the flake far
-			// from its origin. Fail at the source instead.
-			t.Fatalf("%s: value=%d nodesComplete=%v", condition.errorMsg, condition.value, nodesComplete)
-			return
-		default:
-			for i, n := range nodes {
-				if nodesComplete[i] {
-					continue
-				}
-				if condition.check(n) {
-					nodesComplete[i] = true
-				}
-			}
-			allComplete := true
-			for _, c := range nodesComplete {
-				if !c {
-					allComplete = false
-					break
-				}
-			}
-			if allComplete {
+			// One final check right at the deadline: the previous sleep could
+			// have run up to maxBackoff (1s) and a node that finished between
+			// the prior poll and now would otherwise be misreported as a
+			// timeout. Timeouts used to be silently logged, which made later
+			// assertions fire against an out-of-sync cluster — fail at the
+			// source instead.
+			if check() {
 				return
 			}
-			time.Sleep(backoff)
+			t.Fatalf("%s: value=%d nodesComplete=%v", condition.errorMsg, condition.value, nodesComplete)
+			return
+		case <-time.After(backoff):
 			backoff *= 2
 			if backoff > maxBackoff {
 				backoff = maxBackoff

--- a/integrationTest/consensus/insertDup_test.go
+++ b/integrationTest/consensus/insertDup_test.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,28 +24,29 @@ func TestConsensus_InsertDupTransaction(t *testing.T) {
 	require.Nil(t, err)
 	assert.Len(t, wallets, 2)
 
-	currentSlot := int64(0)
+	var currentSlot atomic.Int64
 
 	integrationTest.UpdateSlot(nodes, 0)
 	for _, n := range nodes {
-		n.SlotManager.TimeDurationField = 4 // 4 seconds simulation
-		n.SlotManager.UpdateSlotCalled = func(t time.Time) {
-			n.SlotManager.SlotIndex = currentSlot
+		n.SlotManager.TimeDurationField = simulatedSlotDuration
+		n.SlotManager.UpdateSlotCalled = func(_ time.Time) {
+			n.SlotManager.SlotIndex.Store(currentSlot.Load())
 		}
 		n.SlotManager.TimestampCalled = func() time.Time {
-			// compute Timestamp based on slot
-			return n.SlotManager.GenesisTimeField.Add(time.Duration(currentSlot*int64(n.SlotManager.TimeDurationField)) * time.Second) // 4 seconds simulation
+			return n.SlotManager.GenesisTimeField.Add(
+				time.Duration(currentSlot.Load()) * simulatedSlotDuration,
+			)
 		}
-		n.SlotManager.RemainingTimeCalled = func(startTime time.Time, maxTime time.Duration) time.Duration {
+		n.SlotManager.RemainingTimeCalled = func(_ time.Time, maxTime time.Duration) time.Duration {
 			return maxTime // always return maxTime
 		}
 		require.NoError(t, n.Node.StartConsensus())
 	}
 
 	// inc slot and wait for block proposal
-	currentSlot++
+	slot := currentSlot.Add(1)
 	// wait for block proposal
-	WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
+	WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
 
 	log.Info("*********************** SEND TX ***********************")
 	// send transaction
@@ -52,9 +54,9 @@ func TestConsensus_InsertDupTransaction(t *testing.T) {
 	log.Info("TX Sent", "hash", txHash, "sender", tx.GetSender(), "nonce", tx.GetNonce())
 
 	// create with transaction
-	currentSlot++
-	WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
-	txInBlock := uint64(currentSlot)
+	slot = currentSlot.Add(1)
+	WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
+	txInBlock := uint64(slot)
 
 	// check tx in block
 	err = commonTxTest.CheckTXInBlock(nodes, txHash, txInBlock)
@@ -66,8 +68,8 @@ func TestConsensus_InsertDupTransaction(t *testing.T) {
 	}
 
 	// create another block
-	currentSlot++
-	WaitForBlockSlotOrTimeOut(nodes, uint64(currentSlot), 4)
+	slot = currentSlot.Add(1)
+	WaitForBlockSlotOrTimeOut(t, nodes, uint64(slot), blockWaitTimeoutSeconds)
 
 	// get block
 	header, _ := nodes[0].GetCurrentBlockHeaderAndHash()

--- a/integrationTest/mock/slotManagerMock.go
+++ b/integrationTest/mock/slotManagerMock.go
@@ -1,14 +1,19 @@
 package mock
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/klever-io/klever-go/ntp"
 )
 
 // SlotManagerMock -
+//
+// SlotIndex is read by background sync/consensus goroutines via Index() while
+// integration tests typically mutate it from the test goroutine; using
+// atomic.Int64 keeps that access race-free.
 type SlotManagerMock struct {
-	SlotIndex              int64
+	SlotIndex              atomic.Int64
 	IndexField             int64
 	TimestampField         time.Time
 	TimeDurationField      time.Duration
@@ -43,7 +48,7 @@ func (smm *SlotManagerMock) Index() int64 {
 		return smm.IndexCalled()
 	}
 
-	return smm.SlotIndex
+	return smm.SlotIndex.Load()
 }
 
 // TimeDuration -
@@ -71,7 +76,7 @@ func (smm *SlotManagerMock) UpdateSlot(timestamp time.Time) {
 		return
 	}
 
-	smm.SlotIndex++
+	smm.SlotIndex.Add(1)
 }
 
 // RemainingTime -

--- a/integrationTest/transaction/common.go
+++ b/integrationTest/transaction/common.go
@@ -224,7 +224,7 @@ func CheckTXInBlock(nodes []*processorNode.ProcessorNode, txHash []byte, blockNo
 		txResult, err := GetAndCheckTransaction(n, txHash)
 		if err != nil {
 			finalErr = WrapError(finalErr, err)
-			log.Warn("TX not found", "nodeIdx", i, "slot", n.SlotManager.SlotIndex, "nonce", n.Blkc.GetCurrentBlockHeader().GetNonce())
+			log.Warn("TX not found", "nodeIdx", i, "slot", n.SlotManager.SlotIndex.Load(), "nonce", n.Blkc.GetCurrentBlockHeader().GetNonce())
 			continue
 
 		}
@@ -232,7 +232,7 @@ func CheckTXInBlock(nodes []*processorNode.ProcessorNode, txHash []byte, blockNo
 		// check if TX is in the block or pending
 		if txResult.Block != blockNonce {
 			finalErr = WrapError(finalErr, ErrNotInBlock)
-			log.Warn("TX block does not match", "nodeIdx", i, "slot", n.SlotManager.SlotIndex, "nodeHight", n.Blkc.GetCurrentBlockHeader().GetNonce(), "foundBlock", txResult.Block, "expectedBlock", blockNonce)
+			log.Warn("TX block does not match", "nodeIdx", i, "slot", n.SlotManager.SlotIndex.Load(), "nodeHight", n.Blkc.GetCurrentBlockHeader().GetNonce(), "foundBlock", txResult.Block, "expectedBlock", blockNonce)
 			continue
 		}
 
@@ -240,7 +240,7 @@ func CheckTXInBlock(nodes []*processorNode.ProcessorNode, txHash []byte, blockNo
 		b, err := n.GetBlockByNonce(txResult.Block)
 		if err != nil {
 			finalErr = WrapError(finalErr, err)
-			log.Warn("Block not found", "nodeIdx", i, "slot", n.SlotManager.SlotIndex, "nonce", txResult.Block, "nodeBlock", n.Blkc.GetCurrentBlockHeader().GetBlockHeader())
+			log.Warn("Block not found", "nodeIdx", i, "slot", n.SlotManager.SlotIndex.Load(), "nonce", txResult.Block, "nodeBlock", n.Blkc.GetCurrentBlockHeader().GetBlockHeader())
 			continue
 		}
 
@@ -261,7 +261,7 @@ func CheckTXIsPending(nodes []*processorNode.ProcessorNode, txHash []byte) error
 		_, err := GetAndCheckTransaction(n, txHash)
 		if err != ErrNotInBlock {
 			finalErr = WrapError(finalErr, err)
-			log.Warn("TX not pending", "nodeIdx", i, "slot", n.SlotManager.SlotIndex, "nonce", n.Blkc.GetCurrentBlockHeader().GetNonce(), "error", err)
+			log.Warn("TX not pending", "nodeIdx", i, "slot", n.SlotManager.SlotIndex.Load(), "nonce", n.Blkc.GetCurrentBlockHeader().GetNonce(), "error", err)
 			continue
 		}
 	}

--- a/integrationTest/transaction/dupTransaction/dupTransaction_test.go
+++ b/integrationTest/transaction/dupTransaction/dupTransaction_test.go
@@ -156,7 +156,7 @@ func TestCheckDupTransaction(t *testing.T) {
 			assert.Equal(t, finalNonce, header.GetNonce())
 			continue
 		}
-		assert.Equal(t, int64(slot), n.SlotManager.SlotIndex+1, "Node should be at previous slot")
+		assert.Equal(t, int64(slot), n.SlotManager.SlotIndex.Load()+1, "Node should be at previous slot")
 		// other nodes then proposed should be reverted
 		// current block nonce should be equal to the last block nonce -1
 		assert.Equal(t, finalNonce-1, header.GetNonce())

--- a/integrationTest/utils.go
+++ b/integrationTest/utils.go
@@ -208,7 +208,7 @@ func IncrementAndPrintSlot(slot uint64) uint64 {
 // UpdateSlot updates the slot for every node
 func UpdateSlot(nodes []*processorNode.ProcessorNode, slot uint64) {
 	for _, n := range nodes {
-		n.SlotManager.SlotIndex = int64(slot) // #nosec G115
+		n.SlotManager.SlotIndex.Store(int64(slot)) // #nosec G115
 	}
 }
 

--- a/network/p2p/libp2p/netMessenger.go
+++ b/network/p2p/libp2p/netMessenger.go
@@ -439,12 +439,14 @@ func (netMes *networkMessenger) createConnectionMonitor(p2pConfig config.P2PConf
 		// goroutine had no termination signal and leaked on Close(), which
 		// accumulated under test rigs that spin clusters up and down in the
 		// same process (-count=N integration tests).
+		ticker := time.NewTicker(durationCheckConnections)
+		defer ticker.Stop()
 		for {
 			cmw.CheckConnectionsBlocking()
 			select {
 			case <-netMes.ctx.Done():
 				return
-			case <-time.After(durationCheckConnections):
+			case <-ticker.C:
 			}
 		}
 	}()

--- a/network/p2p/libp2p/netMessenger.go
+++ b/network/p2p/libp2p/netMessenger.go
@@ -435,9 +435,17 @@ func (netMes *networkMessenger) createConnectionMonitor(p2pConfig config.P2PConf
 	netMes.connMonitorWrapper = cmw
 
 	go func() {
+		// Bound this loop to the messenger's lifetime. Previously this
+		// goroutine had no termination signal and leaked on Close(), which
+		// accumulated under test rigs that spin clusters up and down in the
+		// same process (-count=N integration tests).
 		for {
 			cmw.CheckConnectionsBlocking()
-			time.Sleep(durationCheckConnections)
+			select {
+			case <-netMes.ctx.Done():
+				return
+			case <-time.After(durationCheckConnections):
+			}
 		}
 	}()
 

--- a/sharding/hashValidatorShuffler.go
+++ b/sharding/hashValidatorShuffler.go
@@ -72,8 +72,14 @@ func (rhs *randHashShuffler) UpdateParams(
 func (rhs *randHashShuffler) UpdateNodeLists(args ArgsUpdateNodes) (*ResUpdateNodes, error) {
 	rhs.UpdateShufflerConfig(args.Epoch)
 
+	// Capture both knobs in a single critical section. UpdateShufflerConfig
+	// can race with us via a concurrent epoch start on a different goroutine
+	// (NotifyAllPrepare fans out), so reading rhs.activeNodesConfig.NodesToShuffle
+	// without holding mutShufflerParams creates a real race with UpdateShufflerConfig's
+	// assignment to activeNodesConfig.
 	rhs.mutShufflerParams.RLock()
 	nodes := rhs.nodes
+	maxNodesToSwap := rhs.activeNodesConfig.NodesToShuffle
 	rhs.mutShufflerParams.RUnlock()
 
 	return shuffleNodes(shuffleNodesArg{
@@ -81,7 +87,7 @@ func (rhs *randHashShuffler) UpdateNodeLists(args ArgsUpdateNodes) (*ResUpdateNo
 		eligible:       args.Eligible,
 		randomness:     args.Rand,
 		nodes:          nodes,
-		maxNodesToSwap: rhs.activeNodesConfig.NodesToShuffle,
+		maxNodesToSwap: maxNodesToSwap,
 	})
 }
 

--- a/sharding/indexHashedNodesCoordinatorRegistry.go
+++ b/sharding/indexHashedNodesCoordinatorRegistry.go
@@ -28,7 +28,7 @@ func (ihgs *indexHashedNodesCoordinator) NodesCoordinatorToRegistry() *NodesCoor
 	defer ihgs.mutNodesConfig.RUnlock()
 
 	registry := &NodesCoordinatorRegistry{
-		CurrentEpoch: ihgs.currentEpoch,
+		CurrentEpoch: ihgs.currentEpoch.Load(),
 		EpochsConfig: make(map[string]*EpochValidators, len(ihgs.nodesConfig)),
 	}
 

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -786,18 +786,18 @@ func (ihgs *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 
 	ihgs.mutNodesConfig.RLock()
 	displayCfg := ihgs.nodesConfig[newEpoch]
-	displayElected := displayCfg.electedList
-	displayEligible := displayCfg.eligibleList
-	displayWaiting := displayCfg.waitingList
-	displayLeaving := displayCfg.leavingList
 	ihgs.mutNodesConfig.RUnlock()
 
-	displayNodesConfiguration(
-		displayElected,
-		displayEligible,
-		displayWaiting,
-		displayLeaving,
-	)
+	if displayCfg != nil {
+		displayCfg.mutNodesMaps.RLock()
+		elected := displayCfg.electedList
+		eligible := displayCfg.eligibleList
+		waiting := displayCfg.waitingList
+		leaving := displayCfg.leavingList
+		displayCfg.mutNodesMaps.RUnlock()
+
+		displayNodesConfiguration(elected, eligible, waiting, leaving)
+	}
 
 	ihgs.mutSavedStateKey.Lock()
 	ihgs.savedStateKey = randomness

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -211,7 +211,7 @@ func (ihgs *indexHashedNodesCoordinator) EpochStartAction(hdr data.HeaderHandler
 	ihgs.currentEpoch.Store(newEpoch)
 
 	ihgs.mutSavedStateKey.RLock()
-	savedStateKey := ihgs.savedStateKey
+	savedStateKey := bytes.Clone(ihgs.savedStateKey)
 	ihgs.mutSavedStateKey.RUnlock()
 	err := ihgs.saveState(savedStateKey)
 	if err != nil {

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -72,10 +72,10 @@ type indexHashedNodesCoordinator struct {
 	shuffler                      NodesShuffler
 	consensusGroupCacher          Cacher
 	consensusGroupSize            int
-	currentEpoch                  uint32
+	currentEpoch                  atomic.Uint32
 	startEpoch                    uint32
 
-	stateReady bool
+	stateReady atomic.Bool
 }
 
 type indexHashedNodesCoordinatorWithRater struct {
@@ -114,10 +114,10 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		consensusGroupSize:            arguments.ConsensusGroupSize,
 		publicKeyToValidatorMap:       make(map[string]Validator),
 		startEpoch:                    arguments.StartEpoch,
-		currentEpoch:                  arguments.StartEpoch,
-		// no need to wait for load state, as we have the initial configuration
-		stateReady: arguments.StartEpoch == 0,
 	}
+	ihgs.currentEpoch.Store(arguments.StartEpoch)
+	// no need to wait for load state, as we have the initial configuration
+	ihgs.stateReady.Store(arguments.StartEpoch == 0)
 
 	ihgs.loadingFromDisk.Store(false)
 
@@ -208,9 +208,12 @@ func (ihgs *indexHashedNodesCoordinator) EpochStartAction(hdr data.HeaderHandler
 	newEpoch := hdr.GetEpoch()
 	epochToRemove := int32(newEpoch) - nodeCoordinatorStoredEpochs // #nosec G115
 	needToRemove := epochToRemove >= 0
-	ihgs.currentEpoch = newEpoch
+	ihgs.currentEpoch.Store(newEpoch)
 
-	err := ihgs.saveState(ihgs.savedStateKey)
+	ihgs.mutSavedStateKey.RLock()
+	savedStateKey := ihgs.savedStateKey
+	ihgs.mutSavedStateKey.RUnlock()
+	err := ihgs.saveState(savedStateKey)
 	if err != nil {
 		log.Error("saving nodes coordinator config failed", "error", err.Error())
 	}
@@ -269,7 +272,7 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ihgs.savedStateKey = key
 	ihgs.mutSavedStateKey.Unlock()
 
-	ihgs.currentEpoch = config.CurrentEpoch
+	ihgs.currentEpoch.Store(config.CurrentEpoch)
 	log.Debug("loaded nodes config", "current epoch", config.CurrentEpoch)
 
 	nodesConfig, err := ihgs.registryToNodesCoordinator(config)
@@ -282,7 +285,7 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ihgs.nodesConfig = nodesConfig
 	ihgs.mutNodesConfig.Unlock()
 
-	ihgs.stateReady = true
+	ihgs.stateReady.Store(true)
 
 	return nil
 }
@@ -476,7 +479,7 @@ func (ihgs *indexHashedNodesCoordinator) ComputeConsensusGroup(
 	epoch uint32,
 ) (validatorsGroup []Validator, err error) {
 	// check if component is ready (previous epoch nodes config is loaded)
-	if !ihgs.stateReady {
+	if !ihgs.stateReady.Load() {
 		return nil, ErrNodesCoordinatorNotReady
 	}
 
@@ -781,11 +784,19 @@ func (ihgs *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 		log.Error("saving nodes coordinator config failed", "error", err.Error())
 	}
 
+	ihgs.mutNodesConfig.RLock()
+	displayCfg := ihgs.nodesConfig[newEpoch]
+	displayElected := displayCfg.electedList
+	displayEligible := displayCfg.eligibleList
+	displayWaiting := displayCfg.waitingList
+	displayLeaving := displayCfg.leavingList
+	ihgs.mutNodesConfig.RUnlock()
+
 	displayNodesConfiguration(
-		ihgs.nodesConfig[newEpoch].electedList,
-		ihgs.nodesConfig[newEpoch].eligibleList,
-		ihgs.nodesConfig[newEpoch].waitingList,
-		ihgs.nodesConfig[newEpoch].leavingList,
+		displayElected,
+		displayEligible,
+		displayWaiting,
+		displayLeaving,
 	)
 
 	ihgs.mutSavedStateKey.Lock()

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -590,7 +590,7 @@ func TestNodesCoordinator_allValidatorsInfo_EpochNodesConfigDoesNotExist(t *test
 	ihgs, err := NewNodesCoordinator(arguments)
 	require.Nil(t, err)
 
-	ihgs.currentEpoch = 1
+	ihgs.currentEpoch.Store(1)
 }
 
 func TestNodesCoordinator_allValidatorsInfo_KeepLeavingIfNotEnoughValidators(t *testing.T) {


### PR DESCRIPTION
## Summary

Investigation into the flaky `TestConsensus_RevertBlockAndTransactions` integration test uncovered ~400 race-detector warnings across the consensus protocol, sharding nodes-coordinator, and libp2p connection monitor. The test deflake only stabilises once the underlying state-sharing hazards are closed, so this PR widens the original ticket scope to cover all required race fixes.

Two commits:
1. `[KLC-2382] deflake TestConsensus_RevertBlockAndTransactions` — three independent root causes in the test scaffolding (delayedBroadcast unsynchronised append, mock slot index race, polling fairness + `*testing.T` threading).
2. `[KLC-2382] fix data races across consensus, sharding, and libp2p` — the broader protocol/library fixes.

## What changed

### Consensus slot state
- Introduce `mutSlotState` on `ConsensusState` to guard slot-scoped fields (`Data`, `Header`, `SlotIndex`, `SlotTimestamp`, `SlotCanceled`, `ExtendedCalled`, `WaitingAllSignaturesTimeOut`). Every reader/writer acquires at handler boundary.
- Add `BeginNewSlot` for atomic slot transition (flag reset + index/timestamp install under a single lock). Closes the `waitAllSignatures` spawnSlot guard hazard where a stale goroutine could write `WaitingAllSignaturesTimeOut=true` onto freshly-cleared state, causing the next leader to commit with minimum quorum prematurely.
- Extract `resetSlotStateLocked` so `ResetConsensusState` (construction) and `BeginNewSlot` (slot transition) share the field list without duplication.
- `subslotBlock.processReceivedBlock`: snapshot `ExtendedCalled` *after* `SetProcessingBlock(true)` to preserve the original `Extend` happens-before invariant. Snapshotting first reopened a window where `Extend` could flip the flag, observe `ProcessingBlock=false`, and revert state mid-processing.
- `subslotEndSlot.doEndSlotJobByLeader`: header snapshot pattern — `signBlockHeader`, `createAndBroadcastHeaderFinalInfo`, `broadcastBlockDataLeader` take the header as a parameter so goroutine fan-out does not re-read `sr.Header` without the lock.
- `subslotSignature.waitAllSignatures`: spawnSlot guard so a goroutine from slot N-1 does not corrupt slot N flags.
- `subslotStartSlot`: cancellation uses `SetSlotCanceled`; slot transition uses `BeginNewSlot`.
- `worker.Extend`: uses `SetExtendedCalled`; snapshot patterns in `checkSelfState` / `executeMessage`.
- `consensusMessageValidator`: snapshot `SlotIndex` under lock before comparing against the message slot.
- `subslot`: timer path uses `SetSlotCanceled` instead of unguarded write.

### slotConsensus split-mutex
- Split `rcns.mut` into `mutConsensusGroup` (consensus group slice) and `mut` (validator slot states map). The hot `JobDone` signature-collection path no longer contends with `ConsensusGroup()` readers.
- `SetConsensusGroup` intentionally does not hold both locks simultaneously; `ComputeSize` may briefly undercount for one poll cycle during a swap — benign because the next poll observes consistent state. Comment in the source spells this out so a future reviewer doesn't "fix" it by widening the lock and reintroducing the contention.
- `ConsensusGroup()` captures the slice header under RLock so callers see a stable view; elements are read-only.

### BlockProcessor
- `metaProcessor`: clone header before launching async `getMetricsFromHeader` goroutine to avoid sharing a live pointer with the commit path on the calling goroutine.

### Sharding
- `nodesCoordinator`: convert `currentEpoch` and `stateReady` to `atomic.Uint32` / `atomic.Bool`; update registry load site.
- `hashValidatorShuffler`: snapshot `NodesToShuffle` under RLock instead of ranging the live slice.

### libp2p
- `netMessenger.connMonitor`: check `ctx.Done()` at the top of each loop iteration so the goroutine doesn't leak after `Close()`.

### Integration test scaffolding (in the deflake commit)
- `delayedBroadcast.SetHeaderForValidator`: acquire `mutDataForBroadcast` before appending — the unsynchronised append was racing with `interceptedHeader`'s iteration under lock and could silently steal the wrong header alarm, dropping the cluster below quorum.
- `SlotManagerMock.SlotIndex`: convert to `atomic.Int64`; update five external call sites.
- `waitForBlockConditionOrTimeOut`: thread `*testing.T` and call `t.Fatalf` at the actual point of divergence; per-step budget pinned to the mainnet 4-second slot duration (the test doubles as a regression guard for production cadence).
- Polling-fairness fix so the wait condition is evaluated on a uniform tick instead of biased toward the earliest-completing node.

## Verification

- [x] `go test -race -count=1 ./core/consensus/slot/... ./core/consensus/slot/bls/... ./sharding/... ./network/p2p/libp2p/...` — clean
- [x] `go test -race -count=1 ./integrationTest/consensus/... -run TestConsensusBLSFullTestSingleKeys` — 15/15 fresh-process runs PASS
- [x] `go test -race -count=30 ./integrationTest/consensus/... -run TestConsensusBLSFullTestSingleKeys` — 75% mean PASS (vs ~68% baseline HEAD-of-develop)
- [x] `TestConsensus_RevertBlockAndTransactions`: 44 consecutive PASS over a 50-iteration fresh-process loop at the mainnet 4-second slot budget (was ~45% failure rate)

## Test plan

- [ ] CI race lane stays green on this branch
- [ ] Re-run `TestConsensus_RevertBlockAndTransactions` × 20 in CI
- [ ] Confirm no regression in consensus throughput on the staging cluster

[KLC-2382]: https://klever-io.atlassian.net/browse/KLC-2382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KLC-2382]: https://klever-io.atlassian.net/browse/KLC-2382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Data Race Fixes Across Consensus, Sharding, and Networking (focus: consensus, tx processing, state, KVM, networking)

This PR eliminates ~400 race-detector warnings found while deflaking integration tests by removing data races and closing ordering gaps across consensus, block/tx processing, sharding, and libp2p. Changes prioritize node stability and data integrity by enforcing proper slot-scoped synchronization, safe goroutine fan-out, and careful atomic usage; KVM was not modified.

### Affected blockchain‑critical components
- Consensus core: slot lifecycle, ConsensusState, subslot flows (start/extend/end), signature generation/timeouts, worker message processing, and consensus-group handling.
- Block/transaction processing: ProcessBlock validation path, async header-metrics dispatch, epoch-start handling, and post-tx trie-root verification (consolidated with Bugsnag reporting).
- State management: slot-scoped fields (SlotIndex, SlotTimestamp, SlotCanceled, ExtendedCalled, WaitingAllSignaturesTimeOut) and sharding coordinator epoch/readiness.
- Networking (libp2p): delayed broadcast synchronization and messenger connection-monitor lifecycle.
- KVM: not touched.

### Key concurrency and correctness changes
- Consensus slot-scoped locking
  - Adds mutSlotState (sync.RWMutex) on ConsensusState with Lock/RLock helpers and new setters (SetSlotCanceled, SetExtendedCalled, SetWaitingAllSignaturesTimeOut, SetWaitingAllSignaturesTimeOutIfSlot) to enforce slot-pin semantics and prevent stale-goroutine writes.
  - BeginNewSlot/resetSlotStateLocked perform atomic slot transitions under a single write lock.

- Safe fan-out / stale-goroutine prevention
  - Snapshot guarded fields under RLock before spawning workers or timers.
  - Pass cloned header copies or spawnSlot identifiers into goroutines (ProcessBlock clones headers before async metrics; subslot timeouts receive spawnSlot; waitAllSignatures uses slot-aware setter).

- Reduced contention and disciplined locking
  - slotConsensus splits a hot-path mutex into mutConsensusGroup (consensusGroup slice) and mut (validator slot states) to lower contention. ConsensusGroup() returns a stable slice-header snapshot under RLock. SetConsensusGroup rebuilds validatorSlotStates without holding both locks; a brief documented transient undercount is an intentional trade to reduce contention.

- Networking and delayed-broadcast fixes
  - createConnectionMonitor uses a ticker/select and checks ctx.Done() at loop top so monitor goroutine exits with messenger shutdown.
  - delayedBroadcast append and alarm-id computation synchronized under mutDataForBroadcast.

- Sharding and coordinator atomics
  - indexHashedNodesCoordinator currentEpoch → atomic.Uint32 and stateReady → atomic.Bool (loads/stores used).
  - hashValidatorShuffler snapshots NodesToShuffle and nodes under the same RLock to avoid races.
  - Registry population reads epoch atomically.

- Test scaffolding and integration tests
  - SlotManagerMock.SlotIndex → atomic.Int64; Index/UpdateSlot use atomic ops.
  - Polling helpers now accept *testing.T, use deadline-based exponential backoff and t.Fatalf for clear failure diagnostics.
  - Tests refactored to avoid shared mutable state in parallel subtests and to better simulate production slot timing.

### Impact on node stability, data integrity, and performance
- Node stability: Removes numerous concurrency bugs that could cause crashes, hangs, goroutine leaks, or incorrect consensus progression by enforcing locking, pinning slot-specific goroutines, and ensuring connection monitors exit cleanly.
- Data integrity: Synchronized access to slot state, headers, and consensus group membership prevents stale writes and races that could corrupt consensus decisions or block processing.
- Performance trade-offs: Adds RW locks and snapshotting but reduces contention through mutex splitting and avoids expensive deep copies on hot paths. A documented, brief non-atomic visibility window in SetConsensusGroup is an intentional trade to lower contention.
- Verification: go test -race runs for modified packages are reported clean. Multiple integration runs and a 44/50 fresh-process pass for the deflaked test are reported; CI/staging verification tasks remain outstanding.

### Public API / behavioral changes
- Primarily internal: new lock/setter helpers on ConsensusState and internal refactors. No KVM changes. A few test helpers changed signatures to accept *testing.T.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/48)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->