### PR TITLE
[KLC-2398] Fix data races in TpsBenchmark + add Snapshot() for consistent reads

### DIFF
--- a/core/statistics/tpsBenchmark.go
+++ b/core/statistics/tpsBenchmark.go
@@ -107,42 +107,58 @@ func (s *TpsBenchmark) SlotTime() uint64 {
 
 // BlockNumber returns the last processed block number
 func (s *TpsBenchmark) BlockNumber() uint64 {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	return s.blockNumber
 }
 
 // SlotNumber returns the slot index for this benchmark object
 func (s *TpsBenchmark) SlotNumber() uint64 {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	return s.slotNumber
 }
 
 // AverageBlockTxCount returns an average of the tx/block
 func (s *TpsBenchmark) AverageBlockTxCount() *big.Int {
-	return s.averageBlockTxCount
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+	return new(big.Int).Set(s.averageBlockTxCount)
 }
 
 // CurrentBlockTxCount returns the number of transactions processed in the current block
 func (s *TpsBenchmark) CurrentBlockTxCount() uint32 {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	return s.currentBlockTxCount
 }
 
 // TotalProcessedTxCount returns the total number of processed transactions
 func (s *TpsBenchmark) TotalProcessedTxCount() *big.Int {
-	return s.totalProcessedTxCount
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+	return new(big.Int).Set(s.totalProcessedTxCount)
 }
 
 // LiveTPS returns tps for the current block
 func (s *TpsBenchmark) LiveTPS() float64 {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	return float64(uint64(s.currentBlockTxCount) / s.slotTime)
 }
 
 // PeakTPS returns tps for the last block
 func (s *TpsBenchmark) PeakTPS() float64 {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	return s.peakTPS
 }
 
 // AverageTPS returns the average tps for the last block
 func (s *TpsBenchmark) AverageTPS() *big.Int {
-	return s.averageTPS
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+	return new(big.Int).Set(s.averageTPS)
 }
 
 // Update receives a metablock and updates all fields accordingly for each shard available in the meta block

--- a/core/statistics/tpsBenchmark.go
+++ b/core/statistics/tpsBenchmark.go
@@ -30,6 +30,28 @@ type TpsPersistentData struct {
 	CurrentBlockTxCount   uint32
 }
 
+// TpsBenchmarkSnapshot is a consistent point-in-time copy of a TpsBenchmark.
+// All *big.Int fields are defensive copies — safe to read or mutate without affecting the source.
+type TpsBenchmarkSnapshot struct {
+	BlockNumber           uint64
+	SlotNumber            uint64
+	SlotTime              uint64
+	PeakTPS               float64
+	LiveTPS               float64
+	CurrentBlockTxCount   uint32
+	AverageTPS            *big.Int
+	AverageBlockTxCount   *big.Int
+	TotalProcessedTxCount *big.Int
+}
+
+// copyBigInt returns a defensive deep copy of b, or a fresh zero when b is nil.
+func copyBigInt(b *big.Int) *big.Int {
+	if b == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Set(b)
+}
+
 // TpsBenchmark will calculate statistics for the network activity
 type TpsBenchmark struct {
 	mut         sync.RWMutex
@@ -65,12 +87,12 @@ func NewTPSBenchmarkWithInitialData(
 	return &TpsBenchmark{
 		slotTime:              slotInterval,
 		peakTPS:               initialTpsBenchmark.PeakTPS,
-		averageTPS:            initialTpsBenchmark.AverageTPS,
+		averageTPS:            copyBigInt(initialTpsBenchmark.AverageTPS),
 		currentBlockTxCount:   initialTpsBenchmark.CurrentBlockTxCount,
 		blockNumber:           initialTpsBenchmark.BlockNumber,
 		slotNumber:            initialTpsBenchmark.SlotNumber,
-		totalProcessedTxCount: initialTpsBenchmark.TotalProcessedTxCount,
-		averageBlockTxCount:   initialTpsBenchmark.AverageBlockTxCount,
+		totalProcessedTxCount: copyBigInt(initialTpsBenchmark.TotalProcessedTxCount),
+		averageBlockTxCount:   copyBigInt(initialTpsBenchmark.AverageBlockTxCount),
 		statusHandler:         appStatusHandler,
 		initialBlockNumber:    int64(initialTpsBenchmark.BlockNumber), // #nosec G115
 	}, nil
@@ -123,7 +145,7 @@ func (s *TpsBenchmark) SlotNumber() uint64 {
 func (s *TpsBenchmark) AverageBlockTxCount() *big.Int {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
-	return new(big.Int).Set(s.averageBlockTxCount)
+	return copyBigInt(s.averageBlockTxCount)
 }
 
 // CurrentBlockTxCount returns the number of transactions processed in the current block
@@ -137,7 +159,7 @@ func (s *TpsBenchmark) CurrentBlockTxCount() uint32 {
 func (s *TpsBenchmark) TotalProcessedTxCount() *big.Int {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
-	return new(big.Int).Set(s.totalProcessedTxCount)
+	return copyBigInt(s.totalProcessedTxCount)
 }
 
 // LiveTPS returns tps for the current block
@@ -158,7 +180,27 @@ func (s *TpsBenchmark) PeakTPS() float64 {
 func (s *TpsBenchmark) AverageTPS() *big.Int {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
-	return new(big.Int).Set(s.averageTPS)
+	return copyBigInt(s.averageTPS)
+}
+
+// Snapshot returns a consistent, defensively-copied view of all benchmark fields under a single read lock.
+// Prefer this over per-getter calls when consuming multiple fields together (e.g. for API responses) —
+// it guarantees the returned values all come from the same block.
+func (s *TpsBenchmark) Snapshot() TpsBenchmarkSnapshot {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	return TpsBenchmarkSnapshot{
+		BlockNumber:           s.blockNumber,
+		SlotNumber:            s.slotNumber,
+		SlotTime:              s.slotTime,
+		PeakTPS:               s.peakTPS,
+		LiveTPS:               float64(uint64(s.currentBlockTxCount) / s.slotTime),
+		CurrentBlockTxCount:   s.currentBlockTxCount,
+		AverageTPS:            copyBigInt(s.averageTPS),
+		AverageBlockTxCount:   copyBigInt(s.averageBlockTxCount),
+		TotalProcessedTxCount: copyBigInt(s.totalProcessedTxCount),
+	}
 }
 
 // Update receives a metablock and updates all fields accordingly for each shard available in the meta block

--- a/core/statistics/tpsBenchmark_test.go
+++ b/core/statistics/tpsBenchmark_test.go
@@ -3,6 +3,7 @@ package statistics_test
 import (
 	"math/big"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -295,4 +296,59 @@ func TestTpsBenchmark_ZeroTxMetaBlockAndEmptyShardHeader(t *testing.T) {
 
 	bigTxCount := big.NewInt(0)
 	assert.Equal(t, bigTxCount, tpsBenchmark.TotalProcessedTxCount())
+}
+
+// TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates verifies that Snapshot()
+// returns a cross-field-consistent view: every snapshot must satisfy the invariant
+// enforced by updateStatistics — averageBlockTxCount = totalProcessedTxCount / blockNumber
+// (integer quotient). Per-getter calls would tear this invariant when Update() interleaves
+// between calls; Snapshot() takes a single RLock so all three fields advance together.
+func TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+	t.Parallel()
+
+	tpsBenchmark, _ := statistics.NewTPSBenchmark(uint64(6))
+	txCount := uint32(10)
+	nrUpdates := 2000
+
+	done := make(chan struct{})
+	var inconsistent atomic.Uint64
+	var observed atomic.Uint64
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			snap := tpsBenchmark.Snapshot()
+			if snap.BlockNumber == 0 {
+				continue
+			}
+			observed.Add(1)
+			blockNumber := new(big.Int).SetUint64(snap.BlockNumber)
+			lo := new(big.Int).Mul(snap.AverageBlockTxCount, blockNumber)
+			hi := new(big.Int).Add(lo, blockNumber)
+			if snap.TotalProcessedTxCount.Cmp(lo) < 0 || snap.TotalProcessedTxCount.Cmp(hi) >= 0 {
+				inconsistent.Add(1)
+			}
+		}
+	}()
+
+	for i := 1; i <= nrUpdates; i++ {
+		updateTpsBenchmark(tpsBenchmark, txCount, uint64(i))
+	}
+	close(done)
+	wg.Wait()
+
+	assert.Equal(t, uint64(0), inconsistent.Load(),
+		"Snapshot returned %d inconsistent views out of %d observations",
+		inconsistent.Load(), observed.Load())
+	assert.Greater(t, observed.Load(), uint64(0), "reader should have observed at least one non-zero snapshot")
 }

--- a/core/statistics/tpsBenchmark_test.go
+++ b/core/statistics/tpsBenchmark_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/klever-io/klever-go/core/statistics"
 	"github.com/klever-io/klever-go/data/block"
+	"github.com/klever-io/klever-go/statusHandler"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
 )
@@ -32,6 +33,7 @@ func updateTpsBenchmark(tpsBenchmark *statistics.TpsBenchmark, txCount uint32, n
 	_ = tpsBenchmark.TotalProcessedTxCount()
 	_ = tpsBenchmark.LiveTPS()
 	_ = tpsBenchmark.PeakTPS()
+	_ = tpsBenchmark.AverageTPS()
 }
 
 func TestTpsBenchmark_NewTPSBenchmarkReturnsErrorOnInvalidDuration(t *testing.T) {
@@ -296,6 +298,103 @@ func TestTpsBenchmark_ZeroTxMetaBlockAndEmptyShardHeader(t *testing.T) {
 
 	bigTxCount := big.NewInt(0)
 	assert.Equal(t, bigTxCount, tpsBenchmark.TotalProcessedTxCount())
+}
+
+func TestTpsBenchmark_NewTPSBenchmarkWithInitialData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero slotInterval returns ErrInvalidSlotInterval", func(t *testing.T) {
+		t.Parallel()
+		tps, err := statistics.NewTPSBenchmarkWithInitialData(
+			statusHandler.NewNilStatusHandler(),
+			&statistics.TpsPersistentData{},
+			0,
+		)
+		assert.Nil(t, tps)
+		assert.Equal(t, statistics.ErrInvalidSlotInterval, err)
+	})
+
+	t.Run("nil initial benchmark returns ErrNilInitialTPSBenchmarks", func(t *testing.T) {
+		t.Parallel()
+		tps, err := statistics.NewTPSBenchmarkWithInitialData(
+			statusHandler.NewNilStatusHandler(),
+			nil,
+			6,
+		)
+		assert.Nil(t, tps)
+		assert.Equal(t, statistics.ErrNilInitialTPSBenchmarks, err)
+	})
+
+	t.Run("nil status handler returns ErrNilStatusHandler", func(t *testing.T) {
+		t.Parallel()
+		tps, err := statistics.NewTPSBenchmarkWithInitialData(
+			nil,
+			&statistics.TpsPersistentData{
+				AverageTPS:            big.NewInt(0),
+				AverageBlockTxCount:   big.NewInt(0),
+				TotalProcessedTxCount: big.NewInt(0),
+			},
+			6,
+		)
+		assert.Nil(t, tps)
+		assert.Equal(t, statistics.ErrNilStatusHandler, err)
+	})
+
+	t.Run("happy path with full data and aliasing protection", func(t *testing.T) {
+		t.Parallel()
+		// The constructor must defensively copy *big.Int inputs so callers that mutate
+		// the source after construction cannot race the writer.
+		totalTxs := big.NewInt(1234)
+		avgBlockTxs := big.NewInt(5)
+		avgTPS := big.NewInt(2)
+
+		tps, err := statistics.NewTPSBenchmarkWithInitialData(
+			statusHandler.NewNilStatusHandler(),
+			&statistics.TpsPersistentData{
+				BlockNumber:           42,
+				SlotNumber:            100,
+				PeakTPS:               7.5,
+				CurrentBlockTxCount:   30,
+				AverageTPS:            avgTPS,
+				AverageBlockTxCount:   avgBlockTxs,
+				TotalProcessedTxCount: totalTxs,
+			},
+			6,
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, tps)
+		assert.Equal(t, uint64(42), tps.BlockNumber())
+		assert.Equal(t, uint64(100), tps.SlotNumber())
+		assert.Equal(t, big.NewInt(1234), tps.TotalProcessedTxCount())
+		assert.Equal(t, big.NewInt(5), tps.AverageBlockTxCount())
+		assert.Equal(t, big.NewInt(2), tps.AverageTPS())
+
+		// Mutate the source *big.Int values — the benchmark must be unaffected.
+		totalTxs.SetInt64(9999)
+		avgBlockTxs.SetInt64(9999)
+		avgTPS.SetInt64(9999)
+
+		assert.Equal(t, big.NewInt(1234), tps.TotalProcessedTxCount())
+		assert.Equal(t, big.NewInt(5), tps.AverageBlockTxCount())
+		assert.Equal(t, big.NewInt(2), tps.AverageTPS())
+	})
+
+	t.Run("nil *big.Int fields are tolerated and exposed as zero", func(t *testing.T) {
+		t.Parallel()
+		tps, err := statistics.NewTPSBenchmarkWithInitialData(
+			statusHandler.NewNilStatusHandler(),
+			&statistics.TpsPersistentData{
+				BlockNumber: 1,
+				// AverageTPS, AverageBlockTxCount, TotalProcessedTxCount left nil
+			},
+			6,
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, tps)
+		assert.Equal(t, big.NewInt(0), tps.TotalProcessedTxCount())
+		assert.Equal(t, big.NewInt(0), tps.AverageBlockTxCount())
+		assert.Equal(t, big.NewInt(0), tps.AverageTPS())
+	})
 }
 
 // TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates verifies that Snapshot()

--- a/core/statistics/tpsBenchmark_test.go
+++ b/core/statistics/tpsBenchmark_test.go
@@ -34,6 +34,7 @@ func updateTpsBenchmark(tpsBenchmark *statistics.TpsBenchmark, txCount uint32, n
 	_ = tpsBenchmark.LiveTPS()
 	_ = tpsBenchmark.PeakTPS()
 	_ = tpsBenchmark.AverageTPS()
+	_ = tpsBenchmark.Snapshot()
 }
 
 func TestTpsBenchmark_NewTPSBenchmarkReturnsErrorOnInvalidDuration(t *testing.T) {
@@ -397,6 +398,72 @@ func TestTpsBenchmark_NewTPSBenchmarkWithInitialData(t *testing.T) {
 	})
 }
 
+func TestTpsBenchmark_Snapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("after an update, fields match underlying state", func(t *testing.T) {
+		t.Parallel()
+		slotInterval := uint64(4)
+		tpsBenchmark, err := statistics.NewTPSBenchmark(slotInterval)
+		assert.NoError(t, err)
+
+		metaBlock := &block.Block{
+			Header: &block.BlockHeader{
+				Nonce:   3,
+				Slot:    6,
+				TxCount: 24,
+			},
+		}
+		tpsBenchmark.Update(metaBlock)
+
+		snap := tpsBenchmark.Snapshot()
+		assert.Equal(t, uint64(3), snap.BlockNumber)
+		assert.Equal(t, uint64(6), snap.SlotNumber)
+		assert.Equal(t, slotInterval, snap.SlotTime)
+		assert.Equal(t, uint32(24), snap.CurrentBlockTxCount)
+		assert.Equal(t, float64(24/slotInterval), snap.LiveTPS)
+		assert.Equal(t, float64(24/slotInterval), snap.PeakTPS)
+		assert.Equal(t, big.NewInt(24), snap.TotalProcessedTxCount)
+		assert.Equal(t, big.NewInt(8), snap.AverageBlockTxCount) // 24 / 3 nonce
+		assert.Equal(t, big.NewInt(4), snap.AverageTPS)          // 24 / 6 slot
+	})
+
+	t.Run("returns defensive copies for *big.Int fields", func(t *testing.T) {
+		t.Parallel()
+		tpsBenchmark, _ := statistics.NewTPSBenchmark(uint64(4))
+		tpsBenchmark.Update(&block.Block{
+			Header: &block.BlockHeader{Nonce: 1, Slot: 2, TxCount: 10},
+		})
+
+		// Mutating the snapshot's *big.Int values must not affect subsequent reads.
+		snap := tpsBenchmark.Snapshot()
+		snap.TotalProcessedTxCount.SetInt64(9999)
+		snap.AverageBlockTxCount.SetInt64(9999)
+		snap.AverageTPS.SetInt64(9999)
+
+		snap2 := tpsBenchmark.Snapshot()
+		assert.Equal(t, big.NewInt(10), snap2.TotalProcessedTxCount)
+		assert.Equal(t, big.NewInt(10), snap2.AverageBlockTxCount)
+		assert.Equal(t, big.NewInt(5), snap2.AverageTPS) // 10 / 2 slot
+	})
+
+	t.Run("zero-state snapshot from fresh benchmark", func(t *testing.T) {
+		t.Parallel()
+		tpsBenchmark, _ := statistics.NewTPSBenchmark(uint64(4))
+		snap := tpsBenchmark.Snapshot()
+
+		assert.Equal(t, uint64(0), snap.BlockNumber)
+		assert.Equal(t, uint64(0), snap.SlotNumber)
+		assert.Equal(t, uint64(4), snap.SlotTime)
+		assert.Equal(t, uint32(0), snap.CurrentBlockTxCount)
+		assert.Equal(t, float64(0), snap.LiveTPS)
+		assert.Equal(t, float64(0), snap.PeakTPS)
+		assert.Equal(t, big.NewInt(0), snap.TotalProcessedTxCount)
+		assert.Equal(t, big.NewInt(0), snap.AverageBlockTxCount)
+		assert.Equal(t, big.NewInt(0), snap.AverageTPS)
+	})
+}
+
 // TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates verifies that Snapshot()
 // returns a cross-field-consistent view: every snapshot must satisfy the invariant
 // enforced by updateStatistics — averageBlockTxCount = totalProcessedTxCount / blockNumber
@@ -413,6 +480,7 @@ func TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates(t *testing.T) {
 	nrUpdates := 2000
 
 	done := make(chan struct{})
+	firstObserved := make(chan struct{})
 	var inconsistent atomic.Uint64
 	var observed atomic.Uint64
 
@@ -420,6 +488,7 @@ func TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		var onceObserved bool
 		for {
 			select {
 			case <-done:
@@ -429,6 +498,10 @@ func TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates(t *testing.T) {
 			snap := tpsBenchmark.Snapshot()
 			if snap.BlockNumber == 0 {
 				continue
+			}
+			if !onceObserved {
+				close(firstObserved)
+				onceObserved = true
 			}
 			observed.Add(1)
 			blockNumber := new(big.Int).SetUint64(snap.BlockNumber)
@@ -440,7 +513,15 @@ func TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates(t *testing.T) {
 		}
 	}()
 
-	for i := 1; i <= nrUpdates; i++ {
+	// Prime the benchmark with one Update so the reader sees a non-zero snapshot
+	// on its first observation. Wait for that observation before continuing the
+	// main writer loop — this removes the test's dependency on scheduler timing
+	// for the `observed > 0` assertion, without weakening the in-flight
+	// consistency check (the reader still runs concurrently with the remaining updates).
+	updateTpsBenchmark(tpsBenchmark, txCount, uint64(1))
+	<-firstObserved
+
+	for i := 2; i <= nrUpdates; i++ {
 		updateTpsBenchmark(tpsBenchmark, txCount, uint64(i))
 	}
 	close(done)

--- a/network/api/node/routes.go
+++ b/network/api/node/routes.go
@@ -235,18 +235,18 @@ func statsFromTpsBenchmark(tpsBenchmark *statistics.TpsBenchmark) statisticsResp
 	if tpsBenchmark == nil {
 		return statisticsResponse{}
 	}
-	sr := statisticsResponse{}
-	sr.LiveTPS = tpsBenchmark.LiveTPS()
-	sr.AverageTPS = tpsBenchmark.AverageTPS()
-	sr.PeakTPS = tpsBenchmark.PeakTPS()
-	sr.SlotTime = tpsBenchmark.SlotTime()
-	sr.BlockNumber = tpsBenchmark.BlockNumber()
-	sr.SlotNumber = tpsBenchmark.SlotNumber()
-	sr.AverageBlockTxCount = tpsBenchmark.AverageBlockTxCount()
-	sr.CurrentBlockTxCount = tpsBenchmark.CurrentBlockTxCount()
-	sr.TotalProcessedTxCount = tpsBenchmark.TotalProcessedTxCount()
-
-	return sr
+	snap := tpsBenchmark.Snapshot()
+	return statisticsResponse{
+		LiveTPS:               snap.LiveTPS,
+		AverageTPS:            snap.AverageTPS,
+		PeakTPS:               snap.PeakTPS,
+		SlotTime:              snap.SlotTime,
+		BlockNumber:           snap.BlockNumber,
+		SlotNumber:            snap.SlotNumber,
+		AverageBlockTxCount:   snap.AverageBlockTxCount,
+		CurrentBlockTxCount:   snap.CurrentBlockTxCount,
+		TotalProcessedTxCount: snap.TotalProcessedTxCount,
+	}
 }
 
 // @Summary returns the debug information after the query has been interpreted


### PR DESCRIPTION
## Summary
Fixes the data races on every getter in `core/statistics/TpsBenchmark` that `go test -race` trips on, and adds `Snapshot()` so the API layer (`/node/statistics`) gets a cross-field-consistent point-in-time view instead of 8 independent locked reads.

## Problem
`core/statistics/tpsBenchmark.go` declares `sync.RWMutex` (`mut`) that the writer takes in `Update() -> updateStatistics()`, but **none of the 8 getters took the lock**. `go test -race ./core/statistics/` failed consistently on `develop`:

- `TestTpsBenchmark_Concurrent` — explicit concurrency stress (25 iterations × 8000 goroutines)
- `TestResourceMonitor_GenerateStatisticsShouldPass` — parallel-test casualty
- `TestResourceMonitor_SaveStatisticsShouldNotPanic` — same

A second-opinion review (Codex MCP) surfaced two extra issues beyond the bare race fix:
1. Even with per-getter `RLock`, `statsFromTpsBenchmark` in `network/api/node/routes.go` issues **8 separate getter calls** — `Update()` can interleave between them, so the JSON response can mix block `N` with block `N+1` field values. The race is gone but cross-field snapshot consistency is not.
2. `NewTPSBenchmarkWithInitialData` stored caller-provided `*big.Int` pointers directly — if the caller retained those pointers and mutated them, the writer would race outside the mutex.

## Solution
**`core/statistics/tpsBenchmark.go`:**
- Add `s.mut.RLock(); defer s.mut.RUnlock()` to the 8 mutable-state getters. `ActiveNodes()` and `SlotTime()` are immutable after construction — stay unlocked.
- Add `copyBigInt(b *big.Int) *big.Int` helper — nil-tolerant defensive copy. Use it in the 3 `*big.Int` getters because the writer mutates `averageBlockTxCount` and `totalProcessedTxCount` in place via `.Quo` / `.Add`; returning the raw pointer would still let callers observe in-progress mutation even with `RLock` taken.
- Add `TpsBenchmarkSnapshot` value struct + `Snapshot()` method — single `RLock` returns a consistent point-in-time copy of all 9 visible fields with defensive `*big.Int` copies, including `LiveTPS` computed under the same lock.
- `NewTPSBenchmarkWithInitialData` now defensively copies the 3 `*big.Int` inputs via `copyBigInt` — closes the caller-aliasing race.

**`network/api/node/routes.go`:**
- `statsFromTpsBenchmark` rewritten from 8 getter calls to one `Snapshot()` call — JSON response guaranteed coherent across all fields.

**`core/statistics/tpsBenchmark_test.go`:**
- New `TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates`: a writer drives sequential updates while a reader takes `Snapshot()` in a tight loop and asserts the writer-enforced invariant
  ```
  averageBlockTxCount * blockNumber ≤ totalProcessedTxCount < (averageBlockTxCount + 1) * blockNumber
  ```
  on every observation. Per-getter calls would tear this invariant.

## Key Changes
- **New:**
  - `TpsBenchmarkSnapshot` value type and `Snapshot()` method in `core/statistics/tpsBenchmark.go`
  - `copyBigInt` helper in `core/statistics/tpsBenchmark.go`
  - `TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates` in `core/statistics/tpsBenchmark_test.go`
- **Updated:**
  - 8 getters in `core/statistics/tpsBenchmark.go` now take `mut.RLock` / `RUnlock` (3 `*big.Int` getters return defensive copies)
  - `NewTPSBenchmarkWithInitialData` defensively copies caller-supplied `*big.Int` fields
  - `statsFromTpsBenchmark` in `network/api/node/routes.go` uses `Snapshot()` (single locked read instead of 8)
- **Removed:** None

## Testing
- [x] All existing tests pass (`make tests`)
- [x] New tests added for new functionality (`TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates`)
- [x] Manual testing performed:
  - `go test -race -count=1 ./core/statistics/ ./network/api/node/...` — clean
  - `go test -race -count=5 -run "TestTpsBenchmark_Snapshot|TestTpsBenchmark_Concurrent" ./core/statistics/` — clean (5/5)
  - `go test -count=1 ./factory/...` — clean (exercises `TpsPersistentData` construction)
  - `go build ./factory/... ./cmd/node/...` — clean
  - `go vet ./core/statistics/ ./network/api/node/...` — clean

## Configuration Changes
None.

## Breaking Changes
None. All 8 public getters retain their signatures and remain safe to call individually (just locked now). `Snapshot()` is additive. The defensive copy in `NewTPSBenchmarkWithInitialData` is observable only to callers that previously relied on aliasing the input `*big.Int` pointers (which would have been racy by definition).

## Related Issues
Related to KLC-2398 — https://klever-io.atlassian.net/browse/KLC-2398
Discovered while running `-race` verification for KLC-2384 (gopsutil v3 → v4); reproduces identically on `develop` with gopsutil v3 → unrelated to that upgrade.

## Checklist
- [x] Code follows project style guidelines (`make goimports`)
- [x] Tests added/updated and passing
- [x] Documentation updated (README, CLAUDE.md, code comments) — godoc on `Snapshot` and `TpsBenchmarkSnapshot` explains the consistency guarantee
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unnecessary files included
- [x] Breaking changes documented above
- [x] Configuration changes documented above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Data Race Fixes and Consistent Snapshot Reads for Transaction Processing Statistics

**Blockchain-Critical Impact:** Hardens the TPS statistics subsystem used by transaction processing, node monitoring, and the API/telemetry surfaces. These metrics feed operator decisions and can indirectly affect consensus participation; the changes reduce risk of incorrect or torn metrics under concurrent load.

**Problem Fixed:**
- Writer Update() used a write lock but public getters did not, causing race-detector failures and permitting torn/mixed multi-field reads.
- NewTPSBenchmarkWithInitialData aliased caller-provided *big.Int pointers, allowing caller-side mutations to race with internal updates.
- API code built JSON responses by calling multiple getters sequentially, which could observe inconsistent state.

**Key Changes:**
1. Getters now use s.mut.RLock/RUnlock to eliminate read-write races for mutable fields (ActiveNodes and SlotTime intentionally remain unlocked).
2. Defensive copying: added copyBigInt and updated getters/constructor to return/hold deep copies of *big.Int to prevent aliasing and in-place mutation races.
3. Snapshot API: added TpsBenchmarkSnapshot and Snapshot() which take a single RLock and return a point-in-time, defensively-copied view (LiveTPS computed under the same lock) for cross-field-consistent reads.
4. API update: network/api/node/routes.go now uses tpsBenchmark.Snapshot() to produce coherent JSON responses instead of calling multiple getters.
5. Constructor hardening: NewTPSBenchmarkWithInitialData defensively copies incoming *big.Int inputs.
6. Tests: added TestTpsBenchmark_SnapshotConsistencyUnderConcurrentUpdates and other Snapshot/constructor tests; coverage increased and targeted packages are race-detector clean.

**Concurrency & Data Integrity:** Eliminates the observed race conditions and prevents torn/mixed observations by ensuring reads are either locked or taken from a single, consistent snapshot. Defensive copying removes aliasing bugs that could silently corrupt reported metrics.

**Node Stability & Error Handling:** No breaking API changes (getter signatures unchanged); Snapshot() is additive. Constructor now avoids unsafe aliasing and validates inputs. Overall improves runtime stability under concurrent update/read scenarios.

**Testing & Verification:** Existing and new tests pass; race detector clean for targeted packages; manual build and vet checks clean.

**Notes:** Callers that previously relied on aliasing of provided *big.Int pointers will no longer observe shared underlying memory — this is intentional to remove racy behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/51)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->