### PR TITLE
[KLC-2358] expose redundancy metrics via /node/status and Prometheus

### DIFF
--- a/cmd/connector/provider/metricsProvider.go
+++ b/cmd/connector/provider/metricsProvider.go
@@ -129,18 +129,20 @@ func (smp *StatusMetricsProvider) setPresenterValue(key string, value interface{
 		// JSON numbers decode as float64; route signed metrics through SetInt64Value
 		// to preserve the sign (see signedMetricKeys). Bound-check both casts —
 		// `int64(NaN/±Inf/out-of-range float64)` is implementation-defined per the
-		// Go spec, same trap this allowlist exists to avoid for uint64.
+		// Go spec, same trap this allowlist exists to avoid for uint64. Use `>=`
+		// because float64 cannot represent MaxInt64 / MaxUint64 exactly — both
+		// round up to 2^63 / 2^64, and `int64(2^63)` / `uint64(2^64)` are UB.
 		if math.IsNaN(v) || math.IsInf(v, 0) {
 			return ErrTypeAssertionFailed
 		}
 		if _, signed := signedMetricKeys[key]; signed {
-			if v < math.MinInt64 || v > math.MaxInt64 {
+			if v < math.MinInt64 || v >= math.MaxInt64 {
 				return ErrTypeAssertionFailed
 			}
 			smp.presenter.SetInt64Value(key, int64(v))
 			return nil
 		}
-		if v < 0 || v > math.MaxUint64 {
+		if v < 0 || v >= math.MaxUint64 {
 			return ErrTypeAssertionFailed
 		}
 		smp.presenter.SetUInt64Value(key, uint64(v))

--- a/cmd/connector/provider/metricsProvider.go
+++ b/cmd/connector/provider/metricsProvider.go
@@ -3,12 +3,27 @@ package provider
 import (
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"time"
 
 	logger "github.com/klever-io/klever-go-logger"
+	"github.com/klever-io/klever-go/core"
 )
+
+// signedMetricKeys lists metrics whose JSON value may be negative. Routing them
+// through SetInt64Value preserves the sign — `uint64(float64(-1.0))` is
+// implementation-defined per the Go spec and yields 0 on gc.
+//
+// NOTE: keys here must be co-listed in core/metrics.go as conceptually-signed.
+// Today the only signed metric is MetricRedundancyLevel (domain: -1/0/N). Adding
+// a future signed metric without listing it here will silently truncate negatives
+// to 0 on the connector path. Consider co-locating with core/metrics.go via a
+// `signed: true` flag or a registry walked at init.
+var signedMetricKeys = map[string]struct{}{
+	core.MetricRedundancyLevel: {},
+}
 
 var log = logger.GetOrCreate("connector/provider")
 
@@ -111,8 +126,23 @@ func (smp *StatusMetricsProvider) applyMetricsToPresenter(metricsMap map[string]
 func (smp *StatusMetricsProvider) setPresenterValue(key string, value interface{}) error {
 	switch v := value.(type) {
 	case float64:
-		// json unmarshal treats all the numbers (in a field interface{}) as floats so we need to cast it to uint64
-		// because it is the numeric type used by the presenter
+		// JSON numbers decode as float64; route signed metrics through SetInt64Value
+		// to preserve the sign (see signedMetricKeys). Bound-check both casts —
+		// `int64(NaN/±Inf/out-of-range float64)` is implementation-defined per the
+		// Go spec, same trap this allowlist exists to avoid for uint64.
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return ErrTypeAssertionFailed
+		}
+		if _, signed := signedMetricKeys[key]; signed {
+			if v < math.MinInt64 || v > math.MaxInt64 {
+				return ErrTypeAssertionFailed
+			}
+			smp.presenter.SetInt64Value(key, int64(v))
+			return nil
+		}
+		if v < 0 || v > math.MaxUint64 {
+			return ErrTypeAssertionFailed
+		}
 		smp.presenter.SetUInt64Value(key, uint64(v))
 	case string:
 		smp.presenter.SetStringValue(key, v)

--- a/cmd/connector/provider/metricsProvider_test.go
+++ b/cmd/connector/provider/metricsProvider_test.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/statusHandler/presenter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Non-fixed path: JSON -1 → float64(-1) → uint64(0) on gc → int64(0), which
+// would display an inactive node as a main producer.
+func TestSetPresenterValue_ConnectorPath_PreservesNegativeRedundancyLevel(t *testing.T) {
+	t.Parallel()
+
+	rawJSON := []byte(`{"klv_redundancy_level": -1, "klv_num_tx_block": 42}`)
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(rawJSON, &decoded))
+	require.IsType(t, float64(0), decoded[core.MetricRedundancyLevel])
+
+	psh := presenter.NewPresenterStatusHandler()
+	smp := &StatusMetricsProvider{presenter: psh}
+
+	for key, value := range decoded {
+		require.NoError(t, smp.setPresenterValue(key, value))
+	}
+
+	assert.Equal(t, int64(-1), psh.GetRedundancyLevel())
+	assert.Equal(t, uint64(42), psh.GetNumTxInBlock())
+}
+
+func TestSetPresenterValue_NonSignedMetricStaysUInt64(t *testing.T) {
+	t.Parallel()
+
+	psh := presenter.NewPresenterStatusHandler()
+	smp := &StatusMetricsProvider{presenter: psh}
+
+	require.NoError(t, smp.setPresenterValue(core.MetricNumTxInBlock, float64(1234)))
+	assert.Equal(t, uint64(1234), psh.GetNumTxInBlock())
+}
+
+func TestSetPresenterValue_StringMetric(t *testing.T) {
+	t.Parallel()
+
+	psh := presenter.NewPresenterStatusHandler()
+	smp := &StatusMetricsProvider{presenter: psh}
+
+	require.NoError(t, smp.setPresenterValue(core.MetricChainID, "klv-test"))
+	assert.Equal(t, "klv-test", psh.GetChainID())
+}
+
+func TestSetPresenterValue_UnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	psh := presenter.NewPresenterStatusHandler()
+	smp := &StatusMetricsProvider{presenter: psh}
+
+	err := smp.setPresenterValue(core.MetricChainID, []byte{1, 2, 3})
+	assert.ErrorIs(t, err, ErrTypeAssertionFailed)
+}
+
+func TestSetPresenterValue_RejectsOutOfRangeFloats(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		key   string
+		value float64
+	}{
+		{"NaN signed", core.MetricRedundancyLevel, math.NaN()},
+		{"+Inf signed", core.MetricRedundancyLevel, math.Inf(1)},
+		{"-Inf signed", core.MetricRedundancyLevel, math.Inf(-1)},
+		{"above MaxInt64 signed", core.MetricRedundancyLevel, math.MaxInt64 * 2.0},
+		{"below MinInt64 signed", core.MetricRedundancyLevel, -math.MaxInt64 * 2.0},
+		{"NaN unsigned", core.MetricNumTxInBlock, math.NaN()},
+		{"+Inf unsigned", core.MetricNumTxInBlock, math.Inf(1)},
+		{"negative unsigned", core.MetricNumTxInBlock, -1.0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			psh := presenter.NewPresenterStatusHandler()
+			smp := &StatusMetricsProvider{presenter: psh}
+			err := smp.setPresenterValue(tc.key, tc.value)
+			assert.ErrorIs(t, err, ErrTypeAssertionFailed,
+				"out-of-range float64 must be rejected to avoid implementation-defined cast")
+		})
+	}
+}

--- a/cmd/node/metrics/matics_test.go
+++ b/cmd/node/metrics/matics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/klever-io/klever-go/factory"
 	"github.com/klever-io/klever-go/network/p2p"
 	"github.com/klever-io/klever-go/sharding"
+	"github.com/klever-io/klever-go/statusHandler"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,6 +96,9 @@ func TestInitMetrics(t *testing.T) {
 			if !check.IfNil(tt.appStatusHandler) {
 				ash := tt.appStatusHandler.(*mock.AppStatusHandlerStub)
 				ash.SetUInt64ValueHandler = func(key string, value uint64) {
+					metricsMap.metrics[key] = value
+				}
+				ash.SetInt64ValueHandler = func(key string, value int64) {
 					metricsMap.metrics[key] = value
 				}
 				ash.SetStringValueHandler = func(key string, value string) {
@@ -503,6 +508,47 @@ func TestRegisterPollProbableHighestNonce(t *testing.T) {
 	}
 }
 
+// Pins the contract: MetricRedundancyIsActive must not be pre-initialised
+// so the presenter returns "N/A" and the TUI hides the row until the first poll.
+func TestInitMetrics_DoesNotPreInitRedundancyIsActive(t *testing.T) {
+	t.Parallel()
+
+	uint64Keys := make(map[string]struct{})
+	int64Keys := make(map[string]struct{})
+	stringKeys := make(map[string]struct{})
+	handler := &mock.AppStatusHandlerStub{
+		SetUInt64ValueHandler: func(key string, _ uint64) { uint64Keys[key] = struct{}{} },
+		SetInt64ValueHandler:  func(key string, _ int64) { int64Keys[key] = struct{}{} },
+		SetStringValueHandler: func(key string, _ string) { stringKeys[key] = struct{}{} },
+	}
+
+	ns, err := sharding.NewNodesSetup(
+		"../../../sharding/mock/nodesSetupMock.json",
+		mock.NewPubkeyConverterMock(32),
+		mock.NewPubkeyConverterMock(96),
+	)
+	require.NoError(t, err)
+
+	err = InitMetrics(handler, "pk", "validator", ns, "v1.0.0", "1000000", 100)
+	require.NoError(t, err)
+
+	_, inUint64 := uint64Keys[core.MetricRedundancyIsActive]
+	_, inInt64 := int64Keys[core.MetricRedundancyIsActive]
+	_, inString := stringKeys[core.MetricRedundancyIsActive]
+	assert.False(t, inUint64 || inInt64 || inString,
+		"MetricRedundancyIsActive must not be pre-initialised")
+
+	// Second half of the contract: the polling closure must write the key on its
+	// first run, otherwise the row stays hidden forever.
+	redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{}
+	pollingFunc := buildNodeMetricsPollingFunc(time.Now(), redundancyHandler)
+	pollingFunc(handler)
+
+	_, presentAfterPoll := uint64Keys[core.MetricRedundancyIsActive]
+	assert.True(t, presentAfterPoll,
+		"the polling closure must publish MetricRedundancyIsActive on its first run")
+}
+
 func TestStartNodeMetricsPolling_NilHandler(t *testing.T) {
 	t.Parallel()
 
@@ -530,6 +576,8 @@ func TestStartNodeMetricsPolling_Valid(t *testing.T) {
 			setValues[key] = value
 			mu.Unlock()
 		},
+		SetInt64ValueHandler:  func(key string, value int64) {},
+		SetStringValueHandler: func(key string, value string) {},
 	}
 	redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{
 		GetSlotsOfInactivityCalled: func() uint64 { return 3 },
@@ -543,6 +591,132 @@ func TestStartNodeMetricsPolling_Valid(t *testing.T) {
 	ts := setValues[core.MetricNodeStartTimestamp]
 	mu.Unlock()
 	assert.Greater(t, ts, uint64(0))
+}
+
+func TestBuildNodeMetricsPollingFunc_AppearsInStatusMetricsAndPrometheus(t *testing.T) {
+	t.Parallel()
+
+	// Full chain: polling → statusMetrics → JSON map and Prometheus output.
+	// String-typed metrics are silently skipped by the Prometheus serializer.
+	sm := statusHandler.NewStatusMetrics()
+	redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{
+		GetSlotsOfInactivityCalled:       func() uint64 { return 4 },
+		GetInternalRedundancyLevelCalled: func() int64 { return 2 },
+		IsMainMachineActiveCalled:        func() bool { return false },
+	}
+
+	pollingFunc := buildNodeMetricsPollingFunc(time.Now(), redundancyHandler)
+	pollingFunc(sm)
+
+	jsonMap := sm.StatusMetricsMapWithoutP2P()
+	assert.Equal(t, int64(2), jsonMap[core.MetricRedundancyLevel])
+	assert.Equal(t, uint64(1), jsonMap[core.MetricRedundancyIsActive],
+		"backup with upstream silent must emit is_active=1 (taking over)")
+	assert.Equal(t, uint64(4), jsonMap[core.MetricRedundancySlotsInactive])
+
+	promOut := sm.StatusMetricsWithoutP2PPrometheusString()
+	assert.Contains(t, promOut, core.MetricRedundancyLevel+"{")
+	assert.Contains(t, promOut, core.MetricRedundancyIsActive+"{")
+	// Sanity: the value must be emitted, not just the label. Match "} <value>" rather
+	// than the trailing suffix so the assert survives any future label additions.
+	for _, line := range strings.Split(promOut, "\n") {
+		if strings.HasPrefix(line, core.MetricRedundancyIsActive+"{") {
+			assert.Contains(t, line, "} 1", "expected uint64 1, got: %q", line)
+		}
+		if strings.HasPrefix(line, core.MetricRedundancyLevel+"{") {
+			assert.Contains(t, line, "} 2", "expected int64 2, got: %q", line)
+		}
+	}
+}
+
+func TestBuildNodeMetricsPollingFunc_PublishesRedundancyMetrics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		slotsOfInactivity uint64
+		redundancyLevel   int64
+		// isMainActive is the value IsMainMachineActive() returns. The writer
+		// must only consult it for level>0; for level==0 and level<0 the
+		// writer hard-codes the answer without consulting the formula.
+		isMainActive     bool
+		expectedIsActive uint64
+	}{
+		{
+			name:              "main producer is always active",
+			slotsOfInactivity: 0,
+			redundancyLevel:   0,
+			isMainActive:      false, // writer must IGNORE this for level==0
+			expectedIsActive:  1,
+		},
+		{
+			name:              "backup level 1, upstream alive, standby",
+			slotsOfInactivity: 3,
+			redundancyLevel:   1,
+			isMainActive:      true,
+			expectedIsActive:  0,
+		},
+		{
+			name:              "backup level 2, upstream silent, taking over",
+			slotsOfInactivity: 7,
+			redundancyLevel:   2,
+			isMainActive:      false,
+			expectedIsActive:  1,
+		},
+		{
+			name:              "inactive node never produces",
+			slotsOfInactivity: 0,
+			redundancyLevel:   -1,
+			isMainActive:      true, // writer must IGNORE this for level<0
+			expectedIsActive:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// pollingFunc runs synchronously here, so the maps need no lock. If
+			// refactored to call StartNodeMetricsPolling, add a mutex.
+			uint64Values := make(map[string]uint64)
+			int64Values := make(map[string]int64)
+			handler := &mock.AppStatusHandlerStub{
+				SetUInt64ValueHandler: func(key string, value uint64) {
+					uint64Values[key] = value
+				},
+				SetInt64ValueHandler: func(key string, value int64) {
+					int64Values[key] = value
+				},
+				SetStringValueHandler: func(key string, value string) {},
+			}
+			redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{
+				GetSlotsOfInactivityCalled:       func() uint64 { return tc.slotsOfInactivity },
+				GetInternalRedundancyLevelCalled: func() int64 { return tc.redundancyLevel },
+				IsMainMachineActiveCalled:        func() bool { return tc.isMainActive },
+			}
+
+			pollingFunc := buildNodeMetricsPollingFunc(time.Now().Add(-5*time.Second), redundancyHandler)
+			pollingFunc(handler)
+
+			assert.GreaterOrEqual(t, uint64Values[core.MetricNodeUptimeSeconds], uint64(5))
+			assert.Equal(t, tc.slotsOfInactivity, uint64Values[core.MetricRedundancySlotsInactive])
+			assert.Equal(t, tc.redundancyLevel, int64Values[core.MetricRedundancyLevel])
+			gotIsActive, ok := uint64Values[core.MetricRedundancyIsActive]
+			assert.True(t, ok, "MetricRedundancyIsActive should be published as uint64")
+			assert.Equal(t, tc.expectedIsActive, gotIsActive)
+
+			// is_main_active is backup-only (level>0). For other roles it must be absent.
+			gotMainActive, mainOk := uint64Values[core.MetricRedundancyIsMainActive]
+			if tc.redundancyLevel > 0 {
+				assert.True(t, mainOk, "MetricRedundancyIsMainActive must be emitted for backups")
+				expected := uint64(0)
+				if tc.isMainActive {
+					expected = 1
+				}
+				assert.Equal(t, expected, gotMainActive)
+			} else {
+				assert.False(t, mainOk, "MetricRedundancyIsMainActive must NOT be emitted for level<=0 (got %d)", gotMainActive)
+			}
+		})
+	}
 }
 
 func TestSliceToString(t *testing.T) {

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -95,6 +95,11 @@ func InitMetrics(
 	appStatusHandler.SetUInt64Value(core.MetricNodeUptimeSeconds, initUint)
 	appStatusHandler.SetUInt64Value(core.MetricNodeStartTimestamp, initUint)
 	appStatusHandler.SetUInt64Value(core.MetricRedundancySlotsInactive, initUint)
+	appStatusHandler.SetInt64Value(core.MetricRedundancyLevel, 0)
+	// MetricRedundancyIsActive is intentionally NOT pre-initialised so the
+	// presenter sees "key absent" and hides the TUI redundancy row until the
+	// first polling run publishes the real value. MetricRedundancyIsMainActive
+	// is only emitted at runtime when level>0, so it is also not pre-initialised.
 
 	validatorsNodes, _, err := nodesConfig.InitialNodesInfo()
 	if err != nil {
@@ -249,16 +254,63 @@ func StartNodeMetricsPolling(
 		return fmt.Errorf("cannot init AppStatusPolling for node metrics: %w", err)
 	}
 
-	err = appStatusPollingHandler.RegisterPollingFunc(func(appStatusHandler core.AppStatusHandler) {
-		appStatusHandler.SetUInt64Value(core.MetricNodeUptimeSeconds, uint64(time.Since(startTime).Seconds())) // #nosec G115
-		appStatusHandler.SetUInt64Value(core.MetricRedundancySlotsInactive, redundancyHandler.GetSlotsOfInactivity())
-	})
+	pollingFunc := buildNodeMetricsPollingFunc(startTime, redundancyHandler)
+	err = appStatusPollingHandler.RegisterPollingFunc(pollingFunc)
 	if err != nil {
 		return fmt.Errorf("cannot register node metrics polling function: %w", err)
 	}
 
+	// Prime before the recurring poll so /node/status returns the real level on
+	// request 1 (AppStatusPolling.Poll sleeps before its first tick).
+	pollingFunc(ash)
+
 	appStatusPollingHandler.Poll()
 	return nil
+}
+
+func buildNodeMetricsPollingFunc(
+	startTime time.Time,
+	redundancyHandler consensus.NodeRedundancyHandler,
+) func(core.AppStatusHandler) {
+	return func(appStatusHandler core.AppStatusHandler) {
+		appStatusHandler.SetUInt64Value(core.MetricNodeUptimeSeconds, uint64(time.Since(startTime).Seconds())) // #nosec G115
+
+		// Snapshot the redundancy state under a single lock so the metrics
+		// triple cannot disagree across separate getter calls (e.g. slots
+		// reported pre-increment while is_main_active reflects post-increment).
+		// redundancyLevel itself is effectively immutable post-construction —
+		// SetInternalRedundancyLevel mutates slotsOfInactivity, not the level —
+		// but reading slots and isMainMachineActive together still requires the
+		// shared lock to stay consistent across slot-handler activity.
+		level, slotsOfInactivity, upstreamAlive := redundancyHandler.Snapshot()
+
+		appStatusHandler.SetUInt64Value(core.MetricRedundancySlotsInactive, slotsOfInactivity)
+		appStatusHandler.SetInt64Value(core.MetricRedundancyLevel, level)
+
+		var isActive uint64
+		switch {
+		case level == 0:
+			// Main producer: active for its slots whenever it is emitting metrics.
+			isActive = 1
+		case level > 0:
+			// Backup: active only when the upstream chain has gone silent.
+			// Also emit is_main_active so operators can monitor upstream health
+			// independently of failover status; this metric is backup-only.
+			if !upstreamAlive {
+				isActive = 1
+			}
+			var isMainActive uint64
+			if upstreamAlive {
+				isMainActive = 1
+			}
+			appStatusHandler.SetUInt64Value(core.MetricRedundancyIsMainActive, isMainActive)
+		case level < 0:
+			// Inactive node: never produces. The upstreamAlive bit from the
+			// snapshot reflects the backup-perspective formula and is not
+			// meaningful here, so it is deliberately ignored.
+		}
+		appStatusHandler.SetUInt64Value(core.MetricRedundancyIsActive, isActive)
+	}
 }
 
 func registerPollProbableHighestNonce(

--- a/core/consensus/interface.go
+++ b/core/consensus/interface.go
@@ -142,5 +142,9 @@ type NodeRedundancyHandler interface {
 	SetInternalRedundancyLevel(level int64) error
 	GetInternalRedundancyLevel() int64
 	GetSlotsOfInactivity() uint64
+	// Snapshot returns (level, slotsOfInactivity, isMainMachineActive) read atomically
+	// under a single lock so observers see a consistent triple. Prefer this over
+	// chained getter calls when publishing all three together.
+	Snapshot() (int64, uint64, bool)
 	IsInterfaceNil() bool
 }

--- a/core/consensus/mock/nodeRedundancyHandlerStub.go
+++ b/core/consensus/mock/nodeRedundancyHandlerStub.go
@@ -8,12 +8,14 @@ import (
 
 // NodeRedundancyHandlerStub -
 type NodeRedundancyHandlerStub struct {
-	IsRedundancyNodeCalled         func() bool
-	IsMainMachineActiveCalled      func() bool
-	AdjustInactivityIfNeededCalled func(selfPubKey string, consensusPubKeys []string, roundIndex int64)
-	ResetInactivityIfNeededCalled  func(selfPubKey string, consensusMsgPubKey string, consensusMsgPeerID core.PeerID)
-	ObserverPrivateKeyCalled       func() crypto.PrivateKey
-	GetSlotsOfInactivityCalled     func() uint64
+	IsRedundancyNodeCalled           func() bool
+	IsMainMachineActiveCalled        func() bool
+	AdjustInactivityIfNeededCalled   func(selfPubKey string, consensusPubKeys []string, roundIndex int64)
+	ResetInactivityIfNeededCalled    func(selfPubKey string, consensusMsgPubKey string, consensusMsgPeerID core.PeerID)
+	ObserverPrivateKeyCalled         func() crypto.PrivateKey
+	GetSlotsOfInactivityCalled       func() uint64
+	GetInternalRedundancyLevelCalled func() int64
+	SnapshotCalled                   func() (int64, uint64, bool)
 }
 
 // IsRedundancyNode -
@@ -51,7 +53,11 @@ func (nrhs *NodeRedundancyHandlerStub) SetInternalRedundancyLevel(level int64) e
 	return nil
 }
 
+// GetInternalRedundancyLevel -
 func (nrhs *NodeRedundancyHandlerStub) GetInternalRedundancyLevel() int64 {
+	if nrhs.GetInternalRedundancyLevelCalled != nil {
+		return nrhs.GetInternalRedundancyLevelCalled()
+	}
 	return 0
 }
 
@@ -70,6 +76,17 @@ func (nrhs *NodeRedundancyHandlerStub) GetSlotsOfInactivity() uint64 {
 		return nrhs.GetSlotsOfInactivityCalled()
 	}
 	return 0
+}
+
+// Snapshot -
+// If SnapshotCalled is nil, falls back to composing the result from the other
+// stub fields so existing tests that only configure the per-field handlers keep
+// working without setting Snapshot explicitly.
+func (nrhs *NodeRedundancyHandlerStub) Snapshot() (int64, uint64, bool) {
+	if nrhs.SnapshotCalled != nil {
+		return nrhs.SnapshotCalled()
+	}
+	return nrhs.GetInternalRedundancyLevel(), nrhs.GetSlotsOfInactivity(), nrhs.IsMainMachineActive()
 }
 
 // IsInterfaceNil -

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -246,10 +246,26 @@ const MetricCreatedProposedBlock = "klv_consensus_created_proposed_block"
 // subslot spare duration)
 const MetricProcessedProposedBlock = "klv_consensus_processed_proposed_block"
 
-// MetricRedundancyLevel is the metric that specifies the redundancy level of the current node
+// MetricRedundancyLevel is the redundancy level: -1 inactive, 0 main producer,
+// N>0 backup rank (lower N takes over sooner when upstream is silent).
 const MetricRedundancyLevel = "klv_redundancy_level" // #nosec G101: false positive
 
-// MetricRedundancyIsMainActive is the metric that specifies data about the redundancy main machine
+// MetricRedundancyIsActive reports whether this node is currently the active
+// block producer (uint64, 1/0). The value's meaning is uniform across roles:
+//
+//	1 = this node is producing for its slots right now,
+//	0 = standby (backup whose upstream is still alive) or inactive.
+//
+// The role-aware computation lives in cmd/node/metrics.buildNodeMetricsPollingFunc.
+const MetricRedundancyIsActive = "klv_redundancy_is_active"
+
+// MetricRedundancyIsMainActive reports whether the upstream producer chain is
+// alive, from this backup's perspective (uint64, 1/0). Only emitted when
+// redundancy level > 0 — the question does not apply to main producers or
+// inactive nodes, so the metric is absent for them (canonical Prometheus
+// idiom for "not applicable to this role"). Pair with klv_redundancy_is_active
+// to distinguish "I'm a backup on standby" (is_main_active=1, is_active=0)
+// from "I'm a backup that has taken over" (is_main_active=0, is_active=1).
 const MetricRedundancyIsMainActive = "klv_redundancy_is_main_active"
 
 // MetricBlockProcessDuration is the metric for the duration in milliseconds of ProcessBlock()

--- a/core/redundancy/redundancy.go
+++ b/core/redundancy/redundancy.go
@@ -116,7 +116,13 @@ func (nr *nodeRedundancy) SetInternalRedundancyLevel(level int64) error {
 	return nil
 }
 
+// GetInternalRedundancyLevel returns the configured redundancy level. RLock
+// matches sibling accessors so the call stays safe if redundancyLevel ever
+// becomes mutable.
 func (nr *nodeRedundancy) GetInternalRedundancyLevel() int64 {
+	nr.mutNodeRedundancy.RLock()
+	defer nr.mutNodeRedundancy.RUnlock()
+
 	return nr.redundancyLevel
 }
 
@@ -126,6 +132,16 @@ func (nr *nodeRedundancy) GetSlotsOfInactivity() uint64 {
 	defer nr.mutNodeRedundancy.RUnlock()
 
 	return nr.slotsOfInactivity
+}
+
+// Snapshot returns (level, slotsOfInactivity, isMainMachineActive) read under a
+// single RLock so observers (metric writers, dashboards) cannot see a torn state
+// where the three fields disagree across separate getter calls.
+func (nr *nodeRedundancy) Snapshot() (int64, uint64, bool) {
+	nr.mutNodeRedundancy.RLock()
+	defer nr.mutNodeRedundancy.RUnlock()
+
+	return nr.redundancyLevel, nr.slotsOfInactivity, nr.isMainMachineActive()
 }
 
 func (nr *nodeRedundancy) isMainMachineActive() bool {

--- a/network/api/node/routes.go
+++ b/network/api/node/routes.go
@@ -37,9 +37,6 @@ const AccStateCheckpointsKey = "klv_num_accounts_state_checkpoints"
 // PeerStateCheckpointsKey is used as a key for the number of peer state checkpoints in the api response
 const PeerStateCheckpointsKey = "klv_num_peer_state_checkpoints"
 
-// RedundancyLevelKey is used as a key for the redundancy level in the api response
-const RedundancyLevelKey = "klv_redundancy_level"
-
 // FacadeHandler interface defines methods that can be used by the gin webserver
 type FacadeHandler interface {
 	GetHeartbeats() ([]data.PubKeyHeartbeat, error)
@@ -48,7 +45,6 @@ type FacadeHandler interface {
 	GetQueryHandler(name string) (debug.QueryHandler, error)
 	GetPeerInfo(pid string) ([]core.QueryP2PPeerInfo, error)
 	SetRedundancy(level int64) error
-	GetRedundancy() int64
 	GetEnableEpochs() (config.EnableEpochsConfig, error)
 	GetNodeOverview() (models.NodeOverview, error)
 	IsInterfaceNil() bool
@@ -193,7 +189,6 @@ func StatusMetrics(c *gin.Context) {
 	}
 
 	details := facade.StatusMetrics().StatusMetricsMapWithoutP2P()
-	details[RedundancyLevelKey] = facade.GetRedundancy()
 
 	// TODO:
 	//details[AccStateCheckpointsKey] = facade.GetNumCheckpointsFromAccountState()

--- a/node/heartbeat/mock/redundancyHandlerStub.go
+++ b/node/heartbeat/mock/redundancyHandlerStub.go
@@ -62,6 +62,11 @@ func (rhs *RedundancyHandlerStub) GetSlotsOfInactivity() uint64 {
 	return 0
 }
 
+// Snapshot -
+func (rhs *RedundancyHandlerStub) Snapshot() (int64, uint64, bool) {
+	return rhs.GetInternalRedundancyLevel(), rhs.GetSlotsOfInactivity(), rhs.IsMainMachineActive()
+}
+
 // IsInterfaceNil -
 func (rhs *RedundancyHandlerStub) IsInterfaceNil() bool {
 	return rhs == nil

--- a/statusHandler/presenter/common.go
+++ b/statusHandler/presenter/common.go
@@ -23,6 +23,28 @@ func (psh *PresenterStatusHandler) getFromCacheAsUint64(metric string) uint64 {
 	return valUint64
 }
 
+// getFromCacheAsInt64 reads an int64 metric. The uint64 fallback (for legacy
+// writers) is bound-checked so values above MaxInt64 return 0 instead of
+// wrapping negative. Returns 0 when missing or of an unsupported type.
+func (psh *PresenterStatusHandler) getFromCacheAsInt64(metric string) int64 {
+	val, ok := psh.presenterMetrics.Load(metric)
+	if !ok {
+		return 0
+	}
+
+	switch v := val.(type) {
+	case int64:
+		return v
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0
+		}
+		return int64(v) // #nosec G115: bound-checked above
+	default:
+		return 0
+	}
+}
+
 func (psh *PresenterStatusHandler) getFromCacheAsString(metric string) string {
 	val, ok := psh.presenterMetrics.Load(metric)
 	if !ok {

--- a/statusHandler/presenter/instanceInfoGetters.go
+++ b/statusHandler/presenter/instanceInfoGetters.go
@@ -2,7 +2,6 @@ package presenter
 
 import (
 	"math/big"
-	"strconv"
 	"strings"
 
 	"github.com/klever-io/klever-go/core"
@@ -30,21 +29,38 @@ func (psh *PresenterStatusHandler) GetPublicKeyBlockSign() string {
 	return psh.getFromCacheAsString(core.MetricPublicKeyBlockSign)
 }
 
-// GetRedundancyLevel will return the redundancy level of the node
+// GetRedundancyLevel returns the redundancy level (see core.MetricRedundancyLevel).
+// Returns 0 for missing/wrong-type AND for the real level=0 main producer; to
+// distinguish those, check GetRedundancyIsActive() for "N/A".
 func (psh *PresenterStatusHandler) GetRedundancyLevel() int64 {
-	// redundancy level is sent as string as JSON unmarshal doesn't treat well the casting from interface{} to int64
-	redundancyLevelStr := psh.getFromCacheAsString(core.MetricRedundancyLevel)
-	i64Val, err := strconv.ParseInt(redundancyLevelStr, 10, 64)
-	if err != nil {
-		return 0
-	}
-
-	return i64Val
+	return psh.getFromCacheAsInt64(core.MetricRedundancyLevel)
 }
 
-// GetRedundancyIsMainActive will return the info about redundancy main machine
-func (psh *PresenterStatusHandler) GetRedundancyIsMainActive() string {
-	return psh.getFromCacheAsString(core.MetricRedundancyIsMainActive)
+// GetRedundancyIsActive returns "true"/"false" from the uint64 metric (1/0),
+// or metricNotAvailable when unset or out of range — the TUI uses the absent
+// signal to hide the redundancy row at startup. The value's meaning is uniform
+// across roles: "true" means this node is currently the active block producer.
+func (psh *PresenterStatusHandler) GetRedundancyIsActive() string {
+	val, ok := psh.presenterMetrics.Load(core.MetricRedundancyIsActive)
+	if !ok {
+		return metricNotAvailable
+	}
+
+	valUint64, ok := val.(uint64)
+	if !ok {
+		return metricNotAvailable
+	}
+
+	switch valUint64 {
+	case 1:
+		return "true"
+	case 0:
+		return "false"
+	default:
+		// Surface N/A rather than coercing unknown values, which would
+		// misreport an undefined state.
+		return metricNotAvailable
+	}
 }
 
 // GetChainID will return node chainID

--- a/statusHandler/presenter/instanceInfoGetters_test.go
+++ b/statusHandler/presenter/instanceInfoGetters_test.go
@@ -1,6 +1,7 @@
 package presenter
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -39,6 +40,96 @@ func TestPresenterStatusHandler_GetPublicKeyBlockSign(t *testing.T) {
 	result := presenterStatusHandler.GetPublicKeyBlockSign()
 
 	assert.Equal(t, publicKeyBlock, result)
+}
+
+func TestPresenterStatusHandler_GetRedundancyIsActive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("metric not present returns N/A so TUI hides redundancy row", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		assert.Equal(t, metricNotAvailable, psh.GetRedundancyIsActive())
+	})
+
+	t.Run("uint64 1 returns true", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetUInt64Value(core.MetricRedundancyIsActive, 1)
+		assert.Equal(t, "true", psh.GetRedundancyIsActive())
+	})
+
+	t.Run("uint64 0 returns false", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetUInt64Value(core.MetricRedundancyIsActive, 0)
+		assert.Equal(t, "false", psh.GetRedundancyIsActive())
+	})
+
+	t.Run("wrong cached type returns N/A", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetStringValue(core.MetricRedundancyIsActive, "true")
+		assert.Equal(t, metricNotAvailable, psh.GetRedundancyIsActive())
+	})
+
+	t.Run("uint64 outside {0,1} returns N/A instead of false", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetUInt64Value(core.MetricRedundancyIsActive, 2)
+		assert.Equal(t, metricNotAvailable, psh.GetRedundancyIsActive())
+	})
+}
+
+func TestPresenterStatusHandler_GetRedundancyLevel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not set returns 0", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		assert.Equal(t, int64(0), psh.GetRedundancyLevel())
+	})
+
+	t.Run("main producer", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetInt64Value(core.MetricRedundancyLevel, 0)
+		assert.Equal(t, int64(0), psh.GetRedundancyLevel())
+	})
+
+	t.Run("backup level 2", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetInt64Value(core.MetricRedundancyLevel, 2)
+		assert.Equal(t, int64(2), psh.GetRedundancyLevel())
+	})
+
+	t.Run("permanently inactive (negative)", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetInt64Value(core.MetricRedundancyLevel, -1)
+		assert.Equal(t, int64(-1), psh.GetRedundancyLevel())
+	})
+
+	t.Run("legacy uint64 storage tolerated for non-negative values", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetUInt64Value(core.MetricRedundancyLevel, 3)
+		assert.Equal(t, int64(3), psh.GetRedundancyLevel())
+	})
+
+	t.Run("uint64 above MaxInt64 returns 0 instead of wrapping negative", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetUInt64Value(core.MetricRedundancyLevel, math.MaxInt64+1)
+		assert.Equal(t, int64(0), psh.GetRedundancyLevel())
+	})
+
+	t.Run("wrong cached type returns 0", func(t *testing.T) {
+		t.Parallel()
+		psh := NewPresenterStatusHandler()
+		psh.SetStringValue(core.MetricRedundancyLevel, "2")
+		assert.Equal(t, int64(0), psh.GetRedundancyLevel())
+	})
 }
 
 func TestPresenterStatusHandler_GetCountConsensus(t *testing.T) {

--- a/statusHandler/view/interface.go
+++ b/statusHandler/view/interface.go
@@ -6,7 +6,7 @@ type Presenter interface {
 	GetNodeName() string
 	GetPublicKeyBlockSign() string
 	GetRedundancyLevel() int64
-	GetRedundancyIsMainActive() string
+	GetRedundancyIsActive() string
 	GetChainID() string
 	GetNodeType() string
 	GetPeerType() string

--- a/statusHandler/view/termuic/termuiRenders/widgetsRender.go
+++ b/statusHandler/view/termuic/termuiRenders/widgetsRender.go
@@ -167,7 +167,7 @@ func (wr *WidgetsRender) prepareInstanceInfo() {
 	countAcceptedBlocks := wr.presenter.GetCountAcceptedBlocks()
 	rows[4] = []string{fmt.Sprintf("Blocks proposed: %d | Blocks accepted:  %d", countLeader, countAcceptedBlocks)}
 
-	rows[5] = []string{computeRedundancyStr(wr.presenter.GetRedundancyLevel(), wr.presenter.GetRedundancyIsMainActive())}
+	rows[5] = []string{computeRedundancyStr(wr.presenter.GetRedundancyLevel(), wr.presenter.GetRedundancyIsActive())}
 	rows[6] = []string{fmt.Sprintf("Chain ID: %s", chainID)}
 
 	wr.instanceInfo.Title = "Klever instance info"
@@ -243,20 +243,27 @@ func (wr *WidgetsRender) prepareChainInfo(numMillisecondsRefreshTime int) {
 	wr.chainInfo.Rows = rows
 }
 
-func computeRedundancyStr(redundancyLevel int64, redundancyIsMainActive string) string {
-	if redundancyIsMainActive == statusNotApplicable {
+// computeRedundancyStr formats the TUI redundancy row. It returns the empty
+// string while the metric is unavailable (pre-first-poll) so the row stays
+// hidden at startup. Main and inactive nodes show only their role; backups
+// also show whether they are currently producing.
+func computeRedundancyStr(redundancyLevel int64, redundancyIsActive string) string {
+	if redundancyIsActive == statusNotApplicable {
 		return ""
 	}
 
 	redundancyStr := "Redundancy: "
-	if redundancyLevel < 0 {
+	switch {
+	case redundancyLevel < 0:
 		redundancyStr += "inactive"
-	} else {
-		if redundancyLevel == 0 {
-			redundancyStr += "main machine"
+	case redundancyLevel == 0:
+		redundancyStr += "main machine"
+	default:
+		redundancyStr += fmt.Sprintf("back-up #%d", redundancyLevel)
+		if redundancyIsActive == "true" {
+			redundancyStr += " (taking over)"
 		} else {
-			redundancyStr += fmt.Sprintf("back-up #%d", redundancyLevel)
-			redundancyStr += fmt.Sprintf(" (is main active: %s)", redundancyIsMainActive)
+			redundancyStr += " (standby)"
 		}
 	}
 

--- a/statusHandler/view/termuic/termuiRenders/widgetsRender_test.go
+++ b/statusHandler/view/termuic/termuiRenders/widgetsRender_test.go
@@ -1,0 +1,80 @@
+package termuiRenders
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeRedundancyStr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		level          int64
+		isActive       string
+		expected       string
+		expectedHidden bool
+	}{
+		{
+			name:           "metric not yet polled hides the row",
+			level:          0,
+			isActive:       statusNotApplicable,
+			expectedHidden: true,
+		},
+		{
+			name:     "main producer has no suffix",
+			level:    0,
+			isActive: "true",
+			expected: "Redundancy: main machine",
+		},
+		{
+			name:     "inactive node has no suffix",
+			level:    -1,
+			isActive: "false",
+			expected: "Redundancy: inactive",
+		},
+		{
+			name:     "backup on standby",
+			level:    2,
+			isActive: "false",
+			expected: "Redundancy: back-up #2 (standby)",
+		},
+		{
+			name:     "backup taking over",
+			level:    1,
+			isActive: "true",
+			expected: "Redundancy: back-up #1 (taking over)",
+		},
+		{
+			name:     "main with is_active=false still shows just main (no suffix)",
+			level:    0,
+			isActive: "false",
+			expected: "Redundancy: main machine",
+		},
+		{
+			name:     "deeply negative level still shows inactive",
+			level:    -100,
+			isActive: "false",
+			expected: "Redundancy: inactive",
+		},
+		{
+			name:     "high backup rank formats correctly",
+			level:    100,
+			isActive: "false",
+			expected: "Redundancy: back-up #100 (standby)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := computeRedundancyStr(tc.level, tc.isActive)
+			if tc.expectedHidden {
+				assert.Equal(t, "", got)
+				return
+			}
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Expose `klv_redundancy_level`, `klv_redundancy_is_active`, and (for backups) `klv_redundancy_is_main_active` via both `/node/status` JSON and the `/node/metrics` Prometheus surface. Replaces a prior design where a single role-dependent metric was misread as "main producer down" for healthy main nodes.

## Problem
Three related gaps existed:

1. **Prometheus blind to redundancy state.** Previous wiring injected `klv_redundancy_level` directly into the `/node/status` JSON map in `network/api/node/routes.go`, bypassing `statusMetrics`. The Prometheus serializer reads from that same store, so the metric never appeared in `/node/metrics`.
2. **Inactive node silently misreported.** In the klever-connector path, `node → JSON → connector → presenter` decodes JSON numbers as `float64`. The connector cast them via `uint64(v)`, and `uint64(float64(-1.0))` is implementation-defined per the Go spec — on `gc/amd64` it yields `0`. A node started with `--redundancy-level=-1` was displayed as a main producer.
3. **Role-confused metric.** An initial fix added `klv_redundancy_is_main_active` mirroring the `slotsOfInactivity < 5*level` formula. The formula is backup-perspective ("is my upstream alive?") but the metric was emitted for every role. For a level=0 main the formula always returned 0, so healthy main producers reported `is_main_active=0` and triggered false alerts.

## Solution
**Role-aware metrics, role-agnostic interpretation.** Two booleans, each answering one question with the same meaning for every role:

| Metric | Role applicability | What it answers |
|---|---|---|
| `klv_redundancy_level` | Every node | What's my configured role? (-1 inactive / 0 main / N>0 backup-rank-N) |
| `klv_redundancy_is_active` | Every node | Am I currently producing for my slots? (1 yes / 0 standby or inactive) |
| `klv_redundancy_is_main_active` | **Backups only** (`level > 0`) | Is my upstream chain alive? (1 alive / 0 silent — this backup is taking over) |
| `klv_redundancy_slots_inactive` | Every node | Slots elapsed since last upstream activity (unchanged from develop) |

Computation is role-aware inside `buildNodeMetricsPollingFunc` and reads `(level, slotsOfInactivity, isMainMachineActive)` atomically via a new `NodeRedundancyHandler.Snapshot()` under a single RLock, so the published triple cannot disagree across separate getter calls.

Operator queries become single-liners with no role filter:

```promql
# Who's producing right now?
klv_redundancy_is_active == 1

# Is exactly one node producing per shard?
count by (shard) (klv_redundancy_is_active == 1)

# Failover happening (a backup is producing instead of the main)
klv_redundancy_is_active == 1 and klv_redundancy_level > 0

# Backup upstream-health monitoring (only meaningful for level > 0)
klv_redundancy_is_main_active == 0
```

For the connector, signed metrics dispatch through `SetInt64Value` via a `signedMetricKeys` allowlist; the float→int casts are now guarded against `NaN`, `±Inf`, and out-of-range values (using `>=` against `MaxInt64` / `MaxUint64` because float64 cannot represent those bounds exactly).

## Key Changes
- **New:**
  - `klv_redundancy_is_active` metric — every node.
  - `klv_redundancy_is_main_active` metric — backups only (emitted iff `level > 0`).
  - `NodeRedundancyHandler.Snapshot() (int64, uint64, bool)` — atomic read of level/slots/upstreamAlive under one RLock.
  - `core.redundancy.GetInternalRedundancyLevel()` — RLocked accessor for parity with sibling getters.
  - `signedMetricKeys` allowlist in `cmd/connector/provider/metricsProvider.go`.
  - `getFromCacheAsInt64` helper in `statusHandler/presenter/common.go` with `MaxInt64`-bounded uint64 fallback.
- **Updated:**
  - `cmd/node/metrics/metrics.go` — polling closure now writes all redundancy metrics through the shared status-handler store, primed synchronously before the recurring loop so request #1 sees real values.
  - `statusHandler/presenter/instanceInfoGetters.go` — typed int64/uint64 lookups (`GetRedundancyLevel`, `GetRedundancyIsActive`). The presenter returns `"N/A"` when the metric is absent so the TUI hides the redundancy row before the first poll.
  - `statusHandler/view/termuic/termuiRenders/widgetsRender.go` — main and inactive nodes show only their role; backups append `(standby)` or `(taking over)` derived from `is_active`.
  - `core/metrics.go` — godoc on both new constants documents the role-agnostic value semantics and (for `is_main_active`) the backup-only emission contract.
- **Removed:**
  - `network/api/node.RedundancyLevelKey` — orphan constant; the same string value is available as `core.MetricRedundancyLevel`.
  - The inline `details[RedundancyLevelKey] = facade.GetRedundancy()` injection (superseded by the polling path).
  - `GetRedundancy()` method on `network/api/node.FacadeHandler` interface — no remaining consumers in the package.

## Testing
- [x] All existing tests pass for touched packages.
- [x] `go vet ./...` clean on changed files (pre-existing `kvm/wasmer2/*` `unsafe.Pointer` warnings are unrelated).
- [x] Race detector clean on the new tests.
- [x] New tests:
  - `TestSetPresenterValue_ConnectorPath_PreservesNegativeRedundancyLevel` — full JSON → presenter pipeline; no shortcuts that bypass `float64`.
  - `TestSetPresenterValue_RejectsOutOfRangeFloats` — NaN, ±Inf, above MaxInt64 / below MinInt64 / above MaxUint64 / negative-on-unsigned all rejected with `ErrTypeAssertionFailed`.
  - `TestBuildNodeMetricsPollingFunc_AppearsInStatusMetricsAndPrometheus` — pins both metrics appearing in JSON and Prometheus.
  - `TestBuildNodeMetricsPollingFunc_PublishesRedundancyMetrics` — table-driven (main / backup-standby / backup-taking-over / inactive) covering all 4 role × upstream-state combinations, including the assertion that `is_main_active` is **absent** for non-backups.
  - `TestInitMetrics_DoesNotPreInitRedundancyIsActive` — pins the deliberate "hide-until-polled" contract.
  - `TestPresenterStatusHandler_GetRedundancyLevel` / `GetRedundancyIsActive` — typed-getter coverage including legacy uint64 fallback, MaxInt64-overflow rejection, and out-of-range `{0,1}` → N/A.
  - `TestComputeRedundancyStr` — five role × is_active states for the TUI renderer, including hidden-row pre-first-poll and edge cases (level=-100, level=100).

### Manual smoke test
```bash
go build -o klever-node ./cmd/node

# main producer
./klever-node ... --redundancy-level=0
# backup rank 2
./klever-node ... --redundancy-level=2
# permanently inactive
./klever-node ... --redundancy-level=-1
```

Expected values per role:

| Role | level | is_active | is_main_active |
|---|---|---|---|
| `--redundancy-level=0` main, healthy | `0` | `1` | _absent_ |
| `--redundancy-level=2` backup, upstream alive | `2` | `0` | `1` |
| `--redundancy-level=2` backup, upstream silent (taken over) | `2` | `1` | `0` |
| `--redundancy-level=-1` inactive | `-1` | `0` | _absent_ |

```bash
curl -s http://127.0.0.1:8080/node/status | jq '.data.metrics | {
  klv_redundancy_level,
  klv_redundancy_is_active,
  klv_redundancy_is_main_active,
  klv_redundancy_slots_inactive
}'

curl -s http://127.0.0.1:8080/node/metrics | grep klv_redundancy_
```

## Configuration Changes
None. `--redundancy-level` flag is unchanged.

## Breaking Changes
- **Removed exported Go symbols:**
  - `network/api/node.RedundancyLevelKey` — use `core.MetricRedundancyLevel` (same string value).
  - `GetRedundancy() int64` method on the local `network/api/node.FacadeHandler` interface — the method is still defined on `common/facade.NodeHandler` for other callers.
- **New `Snapshot() (int64, uint64, bool)` method on `consensus.NodeRedundancyHandler`** — third-party implementers (none known) must add it. Both in-tree implementer and mock stub are updated.
- **New JSON / Prometheus surface:** `klv_redundancy_is_active` (every node) and `klv_redundancy_is_main_active` (backups only). The metric `klv_redundancy_is_main_active` was a defined constant on `develop` but never written, so no released binary emitted it; consumers depending on the old never-written semantic do not exist.
- **The on-the-wire format of `klv_redundancy_level`** is unchanged (still JSON int64 / Prometheus numeric).

## Operator notes
- `/node/status` and `/node/metrics` expose redundancy topology (level + role flags). Operators with public-facing nodes should either restrict the endpoints to a private network / management VLAN, or set `Secured=true` on the routes — otherwise an attacker can map the backup chain and mount a targeted DoS.
- Alerts on `klv_redundancy_is_active == 0` will fire on permanently-inactive observers too. Filter on `klv_redundancy_level >= 0` if you only care about validators, or use the simpler `klv_redundancy_is_active == 1 and klv_redundancy_level > 0` to surface failover events specifically.

## Related Issues
Fixes KLC-2358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Affected blockchain-critical components
- Consensus: consensus.NodeRedundancyHandler gained Snapshot(); core/redundancy enforces RLock for GetInternalRedundancyLevel and adds Snapshot() to atomically return (redundancyLevel, slotsOfInactivity, isMainMachineActive). Consensus mocks updated to implement Snapshot().
- Networking / API surface: redundancy metrics are moved onto the StatusMetrics store and exposed via /node/status (JSON) and /node/metrics (Prometheus). network/api/node no longer injects redundancy directly into the route; exported RedundancyLevelKey constant and FacadeHandler.GetRedundancy() were removed.
- Connector (metrics ingestion): cmd/connector/provider now uses a signedMetricKeys allowlist and guarded float→int conversions, routing signed metrics via SetInt64Value and rejecting NaN/±Inf/out-of-range floats.
- Node metrics subsystem & presenter/view: cmd/node/metrics now primes and uses a single polling closure that reads redundancy via Snapshot(), computes role-aware metrics (MetricRedundancyLevel, MetricRedundancyIsActive for all nodes, MetricRedundancyIsMainActive only for backups), and publishes them atomically. Presenter helpers and view interfaces changed to consume the new metrics (getFromCacheAsInt64, GetRedundancyIsActive, Presenter interface updated).
- State/heartbeat mocks: node/heartbeat mock RedundancyHandlerStub implements Snapshot().

## Impact on node stability and data integrity
- Fixes a data-integrity bug in the connector where JSON-decoded float64 → unsigned casts could silently convert negative redundancy levels to zero (mislabeling inactive nodes as mains). Signed metrics now use int64 with explicit bounds checks; all float inputs reject NaN/Inf/out-of-range values to avoid implementation-defined casts.
- Atomic Snapshot() prevents torn reads of related redundancy state (level, inactivity slots, upstream alive) that could otherwise produce inconsistent metric combinations and lead to incorrect takeover/alerting behavior.
- Metrics publication is role-aware and atomic within the polling closure, reducing race-induced metric churn and false alerts (e.g., previously emitting backup-perspective main-active formulas for all roles).

## Concurrency and error-handling changes
- Added RLock/RUnlock protection and a Snapshot() reader to ensure consistent multi-field reads under a single lock.
- Connector path now explicitly validates numeric inputs and returns errors for unsupported types or out-of-range float values; presenter getters now return "N/A" for missing/invalid metrics to hide rows until first poll.
- Presenter cache access gains getFromCacheAsInt64 with legacy uint64 fallback guarded against overflow to avoid wraparound.

## Cross-cutting concerns and testing
- Presenter/view changes adjust TUI formatting: redundancy row hidden until MetricRedundancyIsActive is first published; computeRedundancyStr updated to format role-aware strings.
- Tests and stubs updated/added across connector, metrics polling, presenter getters, and render formatting; mock stubs adapted to provide Snapshot() fallback for backwards-compatible test behavior.
- Race-detector/vet-conscious fixes: tighter float bound checks and mock changes to satisfy updated interfaces.

## Breaking changes / migration notes
- Removed exported constant: network/api/node.RedundancyLevelKey (klv_redundancy_level).
- Removed FacadeHandler.GetRedundancy() method.
- Added Snapshot() to consensus.NodeRedundancyHandler interface — implementations must provide atomic snapshot support.
- New JSON/Prometheus metrics: klv_redundancy_is_active and klv_redundancy_is_main_active (semantics documented in core/metrics.go).

## Operational effect
- Behavior change: redundancy metrics are now accurate, role-aware, and appear in both /node/status and Prometheus; TUI hides redundancy until metrics are polled. These changes improve correctness of takeover coordination and alerting and remove a source of false-positive main/backup state reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->