### PR TITLE
[KLC-2408] operator: show tx hash in pre-sign review prompt

### DIFF
--- a/cmd/operator/query.go
+++ b/cmd/operator/query.go
@@ -225,9 +225,11 @@ func formatAndDumpRawTX(tx *transaction.Transaction) error {
 	// safe (and stable) to display at this point.
 	var hashHex string
 	if tx != nil && tx.RawData != nil {
-		if hash, err := computeTxHash(tx); err == nil {
-			hashHex = hex.EncodeToString(hash)
+		hash, err := computeTxHash(tx)
+		if err != nil {
+			return fmt.Errorf("failed to compute tx hash from raw data: %w", err)
 		}
+		hashHex = hex.EncodeToString(hash)
 	}
 
 	return formatAndDumpTX(&api.Transaction{

--- a/cmd/operator/query.go
+++ b/cmd/operator/query.go
@@ -219,9 +219,20 @@ func fetchBlockByNonce(nonce uint64) (*api.Block, error) {
 }
 
 func formatAndDumpRawTX(tx *transaction.Transaction) error {
+	// Compute the hash from the unsigned RawData so reviewers can see the
+	// final tx hash before authorizing the signature. The hash is fully
+	// determined by RawData and does not depend on the signature, so it is
+	// safe (and stable) to display at this point.
+	var hashHex string
+	if tx != nil && tx.RawData != nil {
+		if hash, err := computeTxHash(tx); err == nil {
+			hashHex = hex.EncodeToString(hash)
+		}
+	}
+
 	return formatAndDumpTX(&api.Transaction{
 		Transaction: tx,
-	}, "", &api.Block{
+	}, hashHex, &api.Block{
 		Block:        &block.Block{},
 		Hash:         "",
 		Status:       "",


### PR DESCRIPTION
## Summary

The `koperator` pre-sign review prompt (\"Requested Transaction Details\") printed an empty `\"hash\": \"\"` field, so users could not verify the final tx hash before authorizing the signature.

The Klever tx hash is computed solely from `tx.RawData` (blake2b over the marshaled `RawData`) and does **not** depend on the signature — `SignTX` already uses the same `computeTxHash` helper to obtain the bytes it signs. The hash is therefore fully determined and stable from the moment `RawData` is built.

`cmd/operator/query.go::formatAndDumpRawTX` now computes the hash via `computeTxHash` and forwards it to `formatAndDumpTX`. The `koperator ms decode` subcommand (which also uses `formatAndDumpRawTX`) gets the hash for free.

## Changes

- `cmd/operator/query.go`: compute hash from `RawData` in `formatAndDumpRawTX` and pass it to the formatter.

## Acceptance criteria

- [x] `koperator <any-tx-command>` without `--sign` displays the final tx hash in the \"Requested Transaction Details\" JSON.
- [x] The hash shown before signing matches the hash returned by the same command run with `--sign --await --result-only` (same `computeTxHash` helper as `SignTX`).
- [x] `koperator ms decode <tx>` shows the hash (calls `formatAndDumpRawTX`).
- [x] No regression on `--sign` / `--create-only` paths:
  - `--sign` (`autoSign=true`) bypasses `shouldSign` entirely.
  - `--create-only` dumps the signed tx via `DumpAsJson(tx)`, not `formatAndDumpRawTX`. Its pre-sign review prompt now also shows the hash (improvement, not regression).

## Test plan

- [x] \`go build ./cmd/operator/...\`
- [x] \`go vet ./cmd/operator/...\`
- [x] \`go test ./cmd/operator/...\`
- [ ] Manual: \`koperator account send <addr> 1 --nonce N\` (without \`--sign\`) → confirm displayed hash matches the hash from the same command with \`--sign --await --result-only\`.
- [ ] Manual: \`koperator ms decode <tx>\` → confirm hash is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Scope
This change is limited to the operator CLI tool (cmd/operator/query.go) and does **not** affect blockchain consensus, transaction processing, state management, KVM, or networking.

## Summary
- formatAndDumpRawTX now computes the Klever transaction hash (Blake2b over the marshaled RawData via computeTxHash), hex-encodes it, and passes it into the formatter so the pre-sign review prompt ("Requested Transaction Details") and `koperator ms decode` display the final transaction hash instead of an empty string.
- A follow-up commit changes error handling: computeTxHash errors are wrapped and returned (fmt.Errorf) so callers can propagate failures instead of silently showing an empty hash. A nil-guard remains so multisig decode can still surface other tx fields for malformed transactions without aborting early.
- Behavior for actual signing flows is preserved: --sign (autoSign=true) bypasses shouldSign, and --create-only still dumps the signed tx via DumpAsJson(tx).

## Blockchain Impact
None in terms of consensus, transaction processing, or on-chain state. The change is informational/display-only:
- Hash computation is deterministic and identical to that used during signing (SignTX), and is computed from unsigned RawData (signature-independent).
- No changes to validation, signing logic, or transaction flow.

## Risk Assessment
Very low risk. The only cross-cutting change is improved error propagation for computeTxHash (helps surface hash computation failures). This does not modify node behavior or data integrity. Two manual checks were noted: parity of hash with/without --sign, and that ms decode shows the hash.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->