### PR TITLE
[KLC-2418] seednode: reduce log noise + expose /peers, /node/status, /node/metrics

### DIFF
--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -98,7 +98,7 @@ type peerSnapshot struct {
 }
 
 func (s *server) snapshot() peerSnapshot {
-	connected := s.messenger.ConnectedAddresses()
+	connected := append([]string(nil), s.messenger.ConnectedAddresses()...)
 	sort.Strings(connected)
 	return peerSnapshot{
 		connectedAddrs: connected,

--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -1,33 +1,68 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	logger "github.com/klever-io/klever-go-logger"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/network/api/logs"
 	"github.com/klever-io/klever-go/tools/marshal"
 )
 
 var log = logger.GetOrCreate("seednode/api")
 
-// Start will boot up the api and appropriate routes, handlers and validators
-func Start(restAPIInterface string, marshalizer marshal.Marshalizer) error {
+// peerInfoProvider is the narrow surface the seednode API needs from the p2p
+// messenger. Kept inside this package so handlers can be tested without
+// pulling in the full libp2p stack.
+type peerInfoProvider interface {
+	Peers() []core.PeerID
+	Addresses() []string
+	ConnectedAddresses() []string
+}
+
+// server bundles the state needed to serve the seednode HTTP surface.
+type server struct {
+	marshalizer marshal.Marshalizer
+	messenger   peerInfoProvider
+	version     string
+	startTime   time.Time
+}
+
+// Start boots the gin server with the seednode routes. messenger and version
+// are exposed by the /peers, /node/status and /node/metrics endpoints.
+// startTime should reflect process start so uptime reflects the binary, not
+// the API listener.
+func Start(restAPIInterface string, marshalizer marshal.Marshalizer, messenger peerInfoProvider, version string, startTime time.Time) error {
+	srv := &server{
+		marshalizer: marshalizer,
+		messenger:   messenger,
+		version:     version,
+		startTime:   startTime,
+	}
+
 	ws := gin.Default()
 	ws.Use(cors.Default())
 
-	registerRoutes(ws, marshalizer)
+	srv.registerRoutes(ws)
 
 	return ws.Run(restAPIInterface)
 }
 
-func registerRoutes(ws *gin.Engine, marshalizer marshal.Marshalizer) {
-	registerLoggerWsRoute(ws, marshalizer)
+func (s *server) registerRoutes(ws *gin.Engine) {
+	s.registerLoggerWsRoute(ws)
+	ws.GET("/peers", s.peers)
+	ws.GET("/node/status", s.nodeStatus)
+	ws.GET("/node/metrics", s.nodeMetrics)
 }
 
-func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
+func (s *server) registerLoggerWsRoute(ws *gin.Engine) {
 	upgrader := websocket.Upgrader{}
 
 	ws.GET("/log", func(c *gin.Context) {
@@ -41,7 +76,7 @@ func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
 			return
 		}
 
-		ls, err := logs.NewLogSender(marshalizer, conn, log)
+		ls, err := logs.NewLogSender(s.marshalizer, conn, log)
 		if err != nil {
 			log.Error(err.Error())
 			return
@@ -49,4 +84,77 @@ func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
 
 		ls.StartSendingBlocking()
 	})
+}
+
+// snapshot reads the peer view in one shot so the response cannot tear
+// across separate getter calls under churn.
+type peerSnapshot struct {
+	connectedAddrs []string
+	knownPeers     int
+	listenAddrs    []string
+}
+
+func (s *server) snapshot() peerSnapshot {
+	connected := s.messenger.ConnectedAddresses()
+	sort.Strings(connected)
+	return peerSnapshot{
+		connectedAddrs: connected,
+		knownPeers:     len(s.messenger.Peers()),
+		listenAddrs:    s.messenger.Addresses(),
+	}
+}
+
+type peersResponse struct {
+	ConnectedPeers     int      `json:"connectedPeers"`
+	KnownPeers         int      `json:"knownPeers"`
+	ListenAddresses    []string `json:"listenAddresses"`
+	ConnectedAddresses []string `json:"connectedAddresses"`
+}
+
+func (s *server) peers(c *gin.Context) {
+	snap := s.snapshot()
+	c.JSON(http.StatusOK, peersResponse{
+		ConnectedPeers:     len(snap.connectedAddrs),
+		KnownPeers:         snap.knownPeers,
+		ListenAddresses:    snap.listenAddrs,
+		ConnectedAddresses: snap.connectedAddrs,
+	})
+}
+
+type nodeStatusResponse struct {
+	Version         string   `json:"version"`
+	UptimeSeconds   uint64   `json:"uptimeSeconds"`
+	ConnectedPeers  int      `json:"connectedPeers"`
+	KnownPeers      int      `json:"knownPeers"`
+	ListenAddresses []string `json:"listenAddresses"`
+}
+
+func (s *server) nodeStatus(c *gin.Context) {
+	snap := s.snapshot()
+	c.JSON(http.StatusOK, nodeStatusResponse{
+		Version:         s.version,
+		UptimeSeconds:   uint64(time.Since(s.startTime).Seconds()),
+		ConnectedPeers:  len(snap.connectedAddrs),
+		KnownPeers:      snap.knownPeers,
+		ListenAddresses: snap.listenAddrs,
+	})
+}
+
+var prometheusLabelEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	"\n", `\n`,
+	`"`, `\"`,
+)
+
+func (s *server) nodeMetrics(c *gin.Context) {
+	snap := s.snapshot()
+	var b strings.Builder
+	fmt.Fprintf(&b, "seednode_connected_peers %d\n", len(snap.connectedAddrs))
+	fmt.Fprintf(&b, "seednode_known_peers %d\n", snap.knownPeers)
+	fmt.Fprintf(&b, "seednode_uptime_seconds %d\n", uint64(time.Since(s.startTime).Seconds()))
+	if s.version != "" {
+		fmt.Fprintf(&b, "klv_build_info{version=\"%s\",node_type=\"seednode\"} 1\n",
+			prometheusLabelEscaper.Replace(s.version))
+	}
+	c.String(http.StatusOK, b.String())
 }

--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -47,7 +47,11 @@ func Start(restAPIInterface string, marshalizer marshal.Marshalizer, messenger p
 		startTime:   startTime,
 	}
 
-	ws := gin.Default()
+	gin.SetMode(gin.ReleaseMode)
+
+	// gin.New skips the access logger so /node/metrics scrapes don't spam stdout.
+	ws := gin.New()
+	ws.Use(gin.Recovery())
 	ws.Use(cors.Default())
 
 	srv.registerRoutes(ws)
@@ -86,8 +90,7 @@ func (s *server) registerLoggerWsRoute(ws *gin.Engine) {
 	})
 }
 
-// snapshot reads the peer view in one shot so the response cannot tear
-// across separate getter calls under churn.
+// peerSnapshot: connected count matches its slice; knownPeers is a separate read and may drift under churn.
 type peerSnapshot struct {
 	connectedAddrs []string
 	knownPeers     int

--- a/cmd/seednode/api/api_test.go
+++ b/cmd/seednode/api/api_test.go
@@ -140,6 +140,9 @@ func TestNodeMetrics_emptyVersionOmitsBuildInfo(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
 	if strings.Contains(w.Body.String(), "klv_build_info") {
 		t.Errorf("expected klv_build_info to be omitted when version empty, got:\n%s", w.Body.String())
 	}
@@ -156,6 +159,9 @@ func TestNodeMetrics_versionLabelEscaped(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
 	body := w.Body.String()
 	// If escaping worked, every newline in the body is a line terminator —
 	// no raw newline leaked from the version label into the middle of a line.
@@ -169,7 +175,7 @@ func TestNodeMetrics_versionLabelEscaped(t *testing.T) {
 
 func countNonEmptyLines(body string) int {
 	n := 0
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if line != "" {
 			n++
 		}

--- a/cmd/seednode/api/api_test.go
+++ b/cmd/seednode/api/api_test.go
@@ -173,6 +173,27 @@ func TestNodeMetrics_versionLabelEscaped(t *testing.T) {
 	}
 }
 
+func TestSnapshot_doesNotMutateMessengerSlices(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stub := &stubMessenger{
+		connected: []string{"/ip4/9/tcp/1/p2p/Z", "/ip4/1/tcp/1/p2p/A", "/ip4/5/tcp/1/p2p/M"},
+	}
+	srv := newTestServer(stub, "", time.Now())
+
+	wantConnected := append([]string(nil), stub.connected...)
+
+	for range 3 {
+		_ = srv.snapshot()
+	}
+
+	for i, addr := range stub.connected {
+		if addr != wantConnected[i] {
+			t.Fatalf("snapshot mutated stub.connected[%d]: got %q, want %q (full got: %v)",
+				i, addr, wantConnected[i], stub.connected)
+		}
+	}
+}
+
 func countNonEmptyLines(body string) int {
 	n := 0
 	for line := range strings.SplitSeq(body, "\n") {

--- a/cmd/seednode/api/api_test.go
+++ b/cmd/seednode/api/api_test.go
@@ -1,0 +1,178 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/klever-io/klever-go/core"
+)
+
+type stubMessenger struct {
+	peers       []core.PeerID
+	listenAddrs []string
+	connected   []string
+}
+
+func (s *stubMessenger) Peers() []core.PeerID         { return s.peers }
+func (s *stubMessenger) Addresses() []string          { return s.listenAddrs }
+func (s *stubMessenger) ConnectedAddresses() []string { return s.connected }
+
+func newTestServer(stub *stubMessenger, version string, started time.Time) *server {
+	return &server{
+		messenger: stub,
+		version:   version,
+		startTime: started,
+	}
+}
+
+func setup(t *testing.T) (*gin.Engine, *stubMessenger) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	stub := &stubMessenger{
+		peers:       []core.PeerID{"peer-a", "peer-b", "peer-c"},
+		listenAddrs: []string{"/ip4/127.0.0.1/tcp/1/p2p/A", "/ip4/10.0.0.1/tcp/1/p2p/A"},
+		connected:   []string{"/ip4/2.2.2.2/tcp/1/p2p/Y", "/ip4/1.1.1.1/tcp/1/p2p/X"},
+	}
+	srv := newTestServer(stub, "v1.2.3", time.Now().Add(-90*time.Second))
+
+	r := gin.New()
+	srv.registerRoutes(r)
+	return r, stub
+}
+
+func TestPeers_returnsCountsAndSortedAddresses(t *testing.T) {
+	r, _ := setup(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/peers", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var got peersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.ConnectedPeers != 2 {
+		t.Errorf("connectedPeers = %d, want 2", got.ConnectedPeers)
+	}
+	if got.KnownPeers != 3 {
+		t.Errorf("knownPeers = %d, want 3", got.KnownPeers)
+	}
+	if len(got.ConnectedAddresses) != 2 || got.ConnectedAddresses[0] >= got.ConnectedAddresses[1] {
+		t.Errorf("connectedAddresses not sorted: %v", got.ConnectedAddresses)
+	}
+	if len(got.ListenAddresses) != 2 {
+		t.Errorf("listenAddresses = %v, want 2 entries", got.ListenAddresses)
+	}
+}
+
+func TestNodeStatus_reportsUptimeAndVersion(t *testing.T) {
+	r, _ := setup(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/node/status", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var got nodeStatusResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Version != "v1.2.3" {
+		t.Errorf("version = %q, want v1.2.3", got.Version)
+	}
+	if got.UptimeSeconds < 89 || got.UptimeSeconds > 120 {
+		t.Errorf("uptimeSeconds = %d, want ~90", got.UptimeSeconds)
+	}
+	if got.ConnectedPeers != 2 || got.KnownPeers != 3 {
+		t.Errorf("counts = (%d,%d), want (2,3)", got.ConnectedPeers, got.KnownPeers)
+	}
+}
+
+func TestNodeMetrics_prometheusFormat(t *testing.T) {
+	r, _ := setup(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/node/metrics", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	body := w.Body.String()
+	wantLines := []string{
+		"seednode_connected_peers 2",
+		"seednode_known_peers 3",
+		`klv_build_info{version="v1.2.3",node_type="seednode"} 1`,
+	}
+	for _, want := range wantLines {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics body missing %q\nfull body:\n%s", want, body)
+		}
+	}
+	if !strings.Contains(body, "seednode_uptime_seconds ") {
+		t.Errorf("metrics body missing seednode_uptime_seconds line\nfull body:\n%s", body)
+	}
+}
+
+func TestNodeMetrics_emptyVersionOmitsBuildInfo(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stub := &stubMessenger{}
+	srv := newTestServer(stub, "", time.Now())
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/node/metrics", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if strings.Contains(w.Body.String(), "klv_build_info") {
+		t.Errorf("expected klv_build_info to be omitted when version empty, got:\n%s", w.Body.String())
+	}
+}
+
+func TestNodeMetrics_versionLabelEscaped(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stub := &stubMessenger{}
+	srv := newTestServer(stub, `v"weird\ne`+"\n"+`xt`, time.Now())
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/node/metrics", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	body := w.Body.String()
+	// If escaping worked, every newline in the body is a line terminator —
+	// no raw newline leaked from the version label into the middle of a line.
+	if got, want := strings.Count(body, "\n"), countNonEmptyLines(body); got != want {
+		t.Errorf("escaping leaked a raw newline into the label: \\n count = %d, lines = %d, body:\n%s", got, want, body)
+	}
+	if !strings.Contains(body, `\"`) || !strings.Contains(body, `\\`) {
+		t.Errorf("expected escaped quote and backslash in label, body:\n%s", body)
+	}
+}
+
+func countNonEmptyLines(body string) int {
+	n := 0
+	for _, line := range strings.Split(body, "\n") {
+		if line != "" {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -251,9 +251,7 @@ func displayStartupAddresses(messenger p2p.Messenger) {
 
 func emitPeerStatus(messenger p2p.Messenger, prevConnected map[string]struct{}) {
 	connected := messenger.ConnectedAddresses()
-	sort.Slice(connected, func(i, j int) bool {
-		return strings.Compare(connected[i], connected[j]) < 0
-	})
+	sort.Strings(connected)
 
 	known := len(messenger.Peers())
 

--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -250,7 +250,7 @@ func displayStartupAddresses(messenger p2p.Messenger) {
 }
 
 func emitPeerStatus(messenger p2p.Messenger, prevConnected map[string]struct{}) {
-	connected := messenger.ConnectedAddresses()
+	connected := append([]string(nil), messenger.ConnectedAddresses()...)
 	sort.Strings(connected)
 
 	known := len(messenger.Peers())

--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -127,10 +127,10 @@ func main() {
 }
 
 func startNode(ctx *cli.Context) error {
-	var err error
+	startTime := time.Now()
 
 	logLevelFlagValue := ctx.GlobalString(logLevel.Name)
-	err = logger.SetLogLevel(logLevelFlagValue)
+	err := logger.SetLogLevel(logLevelFlagValue)
 	if err != nil {
 		return err
 	}
@@ -164,8 +164,6 @@ func startNode(ctx *cli.Context) error {
 		}
 	}
 
-	startRestServices(ctx, internalMarshalizer)
-
 	log.Info("starting seednode...")
 
 	sigs := make(chan os.Signal, 1)
@@ -193,6 +191,8 @@ func startNode(ctx *cli.Context) error {
 		return err
 	}
 
+	startRestServices(ctx, internalMarshalizer, messenger, startTime)
+
 	log.Info("application is now running...")
 	mainLoop(messenger, sigs)
 
@@ -205,15 +205,24 @@ func startNode(ctx *cli.Context) error {
 	return nil
 }
 
+const peerStatusTickInterval = 30 * time.Second
+
 func mainLoop(messenger p2p.Messenger, stop chan os.Signal) {
-	displayMessengerInfo(messenger)
+	displayStartupAddresses(messenger)
+
+	prevConnected := make(map[string]struct{})
+	emitPeerStatus(messenger, prevConnected)
+
+	ticker := time.NewTicker(peerStatusTickInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-stop:
 			log.Info("terminating at user's signal...")
 			return
-		case <-time.After(time.Second * 5):
-			displayMessengerInfo(messenger)
+		case <-ticker.C:
+			emitPeerStatus(messenger, prevConnected)
 		}
 	}
 }
@@ -230,32 +239,88 @@ func createNode(p2pConfig config.P2PConfig, marshalizer marshal.Marshalizer) (p2
 	return libp2p.NewNetworkMessenger(arg)
 }
 
-func displayMessengerInfo(messenger p2p.Messenger) {
-	headerSeedAddresses := []string{"Seednode addresses:"}
+func displayStartupAddresses(messenger p2p.Messenger) {
 	addresses := make([]*display.LineData, 0)
-
 	for _, address := range messenger.Addresses() {
 		addresses = append(addresses, display.NewLineData(false, []string{address}))
 	}
 
-	tbl, _ := display.CreateTableString(headerSeedAddresses, addresses)
+	tbl, _ := display.CreateTableString([]string{"Seednode addresses:"}, addresses)
 	log.Info("\n" + tbl)
+}
 
-	mesConnectedAddrs := messenger.ConnectedAddresses()
-	sort.Slice(mesConnectedAddrs, func(i, j int) bool {
-		return strings.Compare(mesConnectedAddrs[i], mesConnectedAddrs[j]) < 0
+func emitPeerStatus(messenger p2p.Messenger, prevConnected map[string]struct{}) {
+	connected := messenger.ConnectedAddresses()
+	sort.Slice(connected, func(i, j int) bool {
+		return strings.Compare(connected[i], connected[j]) < 0
 	})
 
-	log.Info("known peers", "num peers", len(messenger.Peers()))
-	headerConnectedAddresses := []string{fmt.Sprintf("Seednode is connected to %d peers:", len(mesConnectedAddrs))}
-	connAddresses := make([]*display.LineData, len(mesConnectedAddrs))
+	known := len(messenger.Peers())
 
-	for idx, address := range mesConnectedAddrs {
-		connAddresses[idx] = display.NewLineData(false, []string{address})
+	curConnected := make(map[string]struct{}, len(connected))
+	for _, addr := range connected {
+		curConnected[addr] = struct{}{}
 	}
 
-	tbl2, _ := display.CreateTableString(headerConnectedAddresses, connAddresses)
-	log.Info("\n" + tbl2)
+	var gained, lost int
+	for addr := range curConnected {
+		if _, ok := prevConnected[addr]; !ok {
+			gained++
+		}
+	}
+	for addr := range prevConnected {
+		if _, ok := curConnected[addr]; !ok {
+			lost++
+		}
+	}
+
+	listen := pickReportableListenAddress(messenger.Addresses())
+
+	log.Info("seednode status",
+		"connected", len(connected),
+		"known", known,
+		"gained", gained,
+		"lost", lost,
+		"listen", listen,
+	)
+
+	if log.GetLevel() <= logger.LogDebug {
+		headerConnectedAddresses := []string{fmt.Sprintf("Seednode is connected to %d peers:", len(connected))}
+		rows := make([]*display.LineData, len(connected))
+		for idx, address := range connected {
+			rows[idx] = display.NewLineData(false, []string{address})
+		}
+		tbl, _ := display.CreateTableString(headerConnectedAddresses, rows)
+		log.Debug("\n" + tbl)
+	}
+
+	for addr := range prevConnected {
+		delete(prevConnected, addr)
+	}
+	for addr := range curConnected {
+		prevConnected[addr] = struct{}{}
+	}
+}
+
+// pickReportableListenAddress returns the first multiaddr useful to a human
+// reading the single-line status log: skip loopback and the Docker default
+// bridge (172.17.x), which appears on every container-hosted seed but never
+// helps operators find the node. Falls back to the first address so the log
+// line is never empty.
+func pickReportableListenAddress(addresses []string) string {
+	for _, addr := range addresses {
+		if strings.HasPrefix(addr, "/ip4/127.") || strings.HasPrefix(addr, "/ip6/::1/") {
+			continue
+		}
+		if strings.HasPrefix(addr, "/ip4/172.17.") {
+			continue
+		}
+		return addr
+	}
+	if len(addresses) > 0 {
+		return addresses[0]
+	}
+	return ""
 }
 
 func getWorkingDir(log logger.Logger) string {
@@ -292,17 +357,17 @@ func checkExpectedPeerCount(p2pConfig config.P2PConfig) error {
 	return nil
 }
 
-func startRestServices(ctx *cli.Context, marshalizer marshal.Marshalizer) {
+func startRestServices(ctx *cli.Context, marshalizer marshal.Marshalizer, messenger p2p.Messenger, startTime time.Time) {
 	restAPIInterface := ctx.GlobalString(restAPIInterfaceFlag.Name)
 	if restAPIInterface != facade.DefaultRestPortOff {
-		go startGinServer(restAPIInterface, marshalizer)
+		go startGinServer(restAPIInterface, marshalizer, messenger, startTime)
 	} else {
 		log.Info("rest api is disabled")
 	}
 }
 
-func startGinServer(restAPIInterface string, marshalizer marshal.Marshalizer) {
-	err := api.Start(restAPIInterface, marshalizer)
+func startGinServer(restAPIInterface string, marshalizer marshal.Marshalizer, messenger p2p.Messenger, startTime time.Time) {
+	err := api.Start(restAPIInterface, marshalizer, messenger, appVersion, startTime)
 	if err != nil {
 		log.LogIfError(err)
 	}


### PR DESCRIPTION
## Summary

- Replaces the 5 s INFO peer-table dump (~190 lines/tick at production peer counts) with a single-line summary every 30 s; full table preserved at DEBUG; the "Seednode addresses:" table prints once at startup.
- Adds `GET /peers`, `GET /node/status`, `GET /node/metrics` (Prometheus). The latter clears the `404` that operator tooling has been hitting in the logs.
- Refactors `cmd/seednode/api` into a `server` struct behind exported `Start`; `/log` websocket unchanged. Adds httptest coverage for the new handlers.

## INFO output, before / after

Before — every 5 s, ~190 lines at production peer count:
```
INFO  \n+-- Seednode addresses table (3-5 lines) ----+
INFO  known peers  num peers = 218
INFO  \n+-- Seednode is connected to 187 peers ------+  (187 lines)
```

After — once at startup + 1 line per 30 s:
```
INFO  \n+-- Seednode addresses table -------+         (startup only)
INFO  seednode status  connected=187  known=218  gained=3  lost=1  listen=/ip4/.../tcp/.../p2p/...
```

`--log-level '*:DEBUG'` still produces the full connected-peers table — no information loss.

## New HTTP surface

`GET /node/status`
```json
{
  "version": "v…",
  "uptimeSeconds": 64,
  "connectedPeers": 187,
  "knownPeers": 218,
  "listenAddresses": ["/ip4/…", "/ip4/127.0.0.1/…", …]
}
```

`GET /peers`
```json
{
  "connectedPeers": 187,
  "knownPeers": 218,
  "listenAddresses": [...],
  "connectedAddresses": [...sorted multiaddrs...]
}
```

`GET /node/metrics`
```
seednode_connected_peers 187
seednode_known_peers 218
seednode_uptime_seconds 64
klv_build_info{version="v…",node_type="seednode"} 1
```

## Behavior notes

- The API now starts **after** `messenger.Bootstrap()` (was before) because the new endpoints query the messenger. External scrapers will see a brief `connection refused` during the bootstrap window instead of a `/log`-only gin server.
- `uptimeSeconds` is "since process start" (captured at the top of `startNode`), not "since API listener bound".
- `pickReportableListenAddress` skips `/ip4/127.`, `/ip6/::1/` and the Docker default bridge `/ip4/172.17.` for the log line only; JSON/Prometheus surfaces report `messenger.Addresses()` raw (ground truth for monitoring).

## Test plan

- [x] `go build ./cmd/seednode/...`
- [x] `go vet ./cmd/seednode/...`
- [x] `go test ./cmd/seednode/...` — 5 new tests passing
- [x] Local smoke test: seednode emits one `seednode status` INFO line per 30 s tick, `uptimeSeconds` advances across ticks, `--log-level '*:DEBUG'` reinstates the verbose table, `/peers` `/node/status` `/node/metrics` all return expected payloads.
- [ ] Verify against the live network once deployed on a real seed (isolated test seed has no peers to bootstrap with so `connected`/`known` stay at 0/1).

## References

- KLC-2358 — the Prometheus pattern already established for regular nodes
- KLC-2416 — surfacing change that exposed this log-noise issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Blockchain-Critical Impact Assessment

**This PR has minimal blockchain-critical impact — it only touches the seednode (peer discovery/observability) and does not modify consensus, transaction processing, state management, or the KVM.**

### Affected Components
- Seednode networking / observability only:
  - Replaces noisy 5s full peer-table INFO dumps with a 30s single-line status log; full peer table remains available at DEBUG and is printed once at startup.
  - Adds HTTP endpoints: GET /peers, GET /node/status, GET /node/metrics (Prometheus).
  - Prometheus metrics: seednode_connected_peers, seednode_known_peers, seednode_uptime_seconds, and optional klv_build_info{version,node_type}.
  - API refactor: Gin-based server moved into a server struct with an exported Start; routes are wired to a messenger-providing interface; the /log websocket is preserved.
  - Human-readable listen-address selection (pickReportableListenAddress) omits loopback and Docker-bridge addresses for the single-line log only; JSON and Prometheus return messenger.Addresses() raw.

### Stability and Safety Considerations
- Minimal risk to node stability or data integrity:
  - No changes to P2P protocol, peer discovery algorithms, message handling, consensus, transaction processing, or persistent state.
  - Peer-visibility changes are observational only; the peer diffing (prevConnected) and emitted status affect only logging/metrics.
  - A defensive copy is now made before sorting ConnectedAddresses in snapshot()/emitPeerStatus to avoid mutating messenger-owned backing slices — this fixes a reported regression and prevents accidental mutation of messenger state visible to other code paths.

### Concurrency and Startup Behaviour
- API startup moved to after messenger.Bootstrap():
  - The REST server now starts after bootstrap, so scrapers may observe a brief connection refusal during startup (short-lived) instead of the previous /log-only gin server behavior.
  - startRestServices launches the API in a goroutine when enabled; Start runs the Gin server.
- No new synchronization primitives introduced; handlers read messenger state on-demand. snapshot() sorts a defensive copy and may observe transient state under churn (documented).

### Error Handling and Metrics
- Metrics:
  - Version label values are escaped for Prometheus safety (quotes, backslashes, newlines).
  - If version is empty, klv_build_info is omitted.
- No broad changes to error-handling semantics; handlers return HTTP 200 for successful snapshots/metrics.

### Tests and Build
- Five new httptest cases added validating endpoints, sorting, uptime ranges, metrics formatting, and label escaping.
- go build and go vet pass for cmd/seednode locally; a regression test (TestSnapshot_doesNotMutateMessengerSlices) verifies the defensive-copy fix.

### Data Integrity
- No impact to blockchain data integrity or consensus. Changes are limited to observability and logging; no code path modifies persisted state or peer-management semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->