### PR TITLE
[KLC-2402] appStatusPolling: make Poll stoppable; wire shutdown

### DIFF
--- a/cmd/node/metrics/machineStatistics.go
+++ b/cmd/node/metrics/machineStatistics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"time"
@@ -15,17 +16,19 @@ import (
 )
 
 // StartMachineStatisticsPolling will start read information about current running machine.
-// The returned io.Closer stops the AppStatusPolling goroutine; the per-statistic
-// goroutines in registerCPUStatistics, registerNetStatistics, and registerDiskStatistics
-// still leak — tracked as a separate follow-up.
+// The returned io.Closer stops the AppStatusPolling goroutine; the inner goroutines in
+// registerCPUStatistics / registerNetStatistics / registerDiskStatistics still leak
 func StartMachineStatisticsPolling(ash core.AppStatusHandler, notifier eventNotifier.EpochStartEventNotifier, pollingInterval time.Duration, workingDir string) (io.Closer, error) {
 	if check.IfNil(ash) {
 		return nil, errors.New("nil AppStatusHandler")
 	}
+	if check.IfNil(notifier) {
+		return nil, errors.New("nil EpochStartEventNotifier")
+	}
 
 	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
 	if err != nil {
-		return nil, errors.New("cannot init AppStatusPolling")
+		return nil, fmt.Errorf("cannot init AppStatusPolling: %w", err)
 	}
 
 	err = registerCPUStatistics(appStatusPollingHandler)

--- a/cmd/node/metrics/machineStatistics.go
+++ b/cmd/node/metrics/machineStatistics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"errors"
+	"io"
 	"path/filepath"
 	"time"
 
@@ -13,40 +14,43 @@ import (
 	"github.com/klever-io/klever-go/tools/check"
 )
 
-// StartMachineStatisticsPolling will start read information about current running machine
-func StartMachineStatisticsPolling(ash core.AppStatusHandler, notifier eventNotifier.EpochStartEventNotifier, pollingInterval time.Duration, workingDir string) error {
+// StartMachineStatisticsPolling will start read information about current running machine.
+// The returned io.Closer stops the AppStatusPolling goroutine; the per-statistic
+// goroutines in registerCPUStatistics, registerNetStatistics, and registerDiskStatistics
+// still leak — tracked as a separate follow-up.
+func StartMachineStatisticsPolling(ash core.AppStatusHandler, notifier eventNotifier.EpochStartEventNotifier, pollingInterval time.Duration, workingDir string) (io.Closer, error) {
 	if check.IfNil(ash) {
-		return errors.New("nil AppStatusHandler")
+		return nil, errors.New("nil AppStatusHandler")
 	}
 
 	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
 	if err != nil {
-		return errors.New("cannot init AppStatusPolling")
+		return nil, errors.New("cannot init AppStatusPolling")
 	}
 
 	err = registerCPUStatistics(appStatusPollingHandler)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = registerMemStatistics(appStatusPollingHandler)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = registerNetStatistics(appStatusPollingHandler, notifier)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = registerDiskStatistics(appStatusPollingHandler, workingDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	appStatusPollingHandler.Poll()
 
-	return nil
+	return appStatusPollingHandler, nil
 }
 
 func registerMemStatistics(appStatusPollingHandler *appStatusPolling.AppStatusPolling) error {

--- a/cmd/node/metrics/matics_test.go
+++ b/cmd/node/metrics/matics_test.go
@@ -262,7 +262,7 @@ func TestStartStatusPolling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Call the function to test
-			err := StartStatusPolling(
+			closer, err := StartStatusPolling(
 				tt.appStatusHandler,
 				time.Second,
 				tt.networkComponents,
@@ -272,8 +272,11 @@ func TestStartStatusPolling(t *testing.T) {
 			// Assert the result
 			if tt.expectedError {
 				assert.Error(t, err)
+				assert.Nil(t, closer)
 			} else {
 				assert.Nil(t, err)
+				require.NotNil(t, closer)
+				t.Cleanup(func() { _ = closer.Close() })
 			}
 		})
 	}
@@ -451,6 +454,7 @@ func TestRegisterPollConnectedPeers(t *testing.T) {
 	assert.NotPanics(t, func() {
 		pollingHandler.Poll()
 	})
+	t.Cleanup(func() { _ = pollingHandler.Close() })
 }
 
 // TestRegisterPollProbableHighestNonce tests the function that registers a polling function for the probable highest nonce
@@ -485,6 +489,7 @@ func TestRegisterPollProbableHighestNonce(t *testing.T) {
 	assert.NotPanics(t, func() {
 		pollingHandler.Poll()
 	})
+	t.Cleanup(func() { _ = pollingHandler.Close() })
 
 	// Optionally, verify that the metric gets set when Poll() is called
 	// This requires a metricsMap to track what values are set
@@ -498,6 +503,7 @@ func TestRegisterPollProbableHighestNonce(t *testing.T) {
 	pollingWithMetricsHandler, _ := appStatusPolling.NewAppStatusPolling(metricsHandler, time.Second)
 	_ = registerPollProbableHighestNonce(pollingWithMetricsHandler, processComponents)
 	pollingWithMetricsHandler.Poll()
+	t.Cleanup(func() { _ = pollingWithMetricsHandler.Close() })
 
 	// Verify that the metric was set correctly
 	// Note: This might not be reliable depending on the implementation of AppStatusPolling
@@ -553,16 +559,18 @@ func TestStartNodeMetricsPolling_NilHandler(t *testing.T) {
 	t.Parallel()
 
 	redundancyHandler := &consensusMock.NodeRedundancyHandlerStub{}
-	err := StartNodeMetricsPolling(nil, time.Second, redundancyHandler)
+	closer, err := StartNodeMetricsPolling(nil, time.Second, redundancyHandler)
 	assert.Error(t, err)
+	assert.Nil(t, closer)
 }
 
 func TestStartNodeMetricsPolling_NilRedundancyHandler(t *testing.T) {
 	t.Parallel()
 
 	handler := &mock.AppStatusHandlerStub{}
-	err := StartNodeMetricsPolling(handler, time.Second, nil)
+	closer, err := StartNodeMetricsPolling(handler, time.Second, nil)
 	assert.Error(t, err)
+	assert.Nil(t, closer)
 }
 
 func TestStartNodeMetricsPolling_Valid(t *testing.T) {
@@ -583,8 +591,10 @@ func TestStartNodeMetricsPolling_Valid(t *testing.T) {
 		GetSlotsOfInactivityCalled: func() uint64 { return 3 },
 	}
 
-	err := StartNodeMetricsPolling(handler, time.Second, redundancyHandler)
+	closer, err := StartNodeMetricsPolling(handler, time.Second, redundancyHandler)
 	assert.NoError(t, err)
+	require.NotNil(t, closer)
+	t.Cleanup(func() { _ = closer.Close() })
 
 	// Start timestamp should be set immediately (non-zero)
 	mu.Lock()

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -122,41 +123,42 @@ func SaveStringMetric(ash core.AppStatusHandler, key, value string) {
 	ash.SetStringValue(key, value)
 }
 
-// StartStatusPolling will start save information in status handler about network
+// StartStatusPolling will start save information in status handler about network.
+// The returned io.Closer stops the polling goroutine.
 func StartStatusPolling(
 	ash core.AppStatusHandler,
 	pollingInterval time.Duration,
 	networkComponents *factory.NetworkComponents,
 	processComponents *factory.Process,
-) error {
+) (io.Closer, error) {
 	if ash == nil {
-		return errors.New("nil AppStatusHandler")
+		return nil, errors.New("nil AppStatusHandler")
 	}
 	if networkComponents == nil {
-		return errors.New("nil networkComponents")
+		return nil, errors.New("nil networkComponents")
 	}
 	if processComponents == nil {
-		return errors.New("nil processComponents")
+		return nil, errors.New("nil processComponents")
 	}
 
 	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
 	if err != nil {
-		return errors.New("cannot init AppStatusPolling")
+		return nil, errors.New("cannot init AppStatusPolling")
 	}
 
 	err = registerPollConnectedPeers(appStatusPollingHandler, networkComponents)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = registerPollProbableHighestNonce(appStatusPollingHandler, processComponents)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	appStatusPollingHandler.Poll()
 
-	return nil
+	return appStatusPollingHandler, nil
 }
 
 func registerPollConnectedPeers(
@@ -234,16 +236,17 @@ func setCurrentP2pNodeAddresses(
 
 // StartNodeMetricsPolling starts polling for uptime and redundancy metrics on a single shared
 // polling goroutine, avoiding the overhead of separate AppStatusPolling instances for each.
+// The returned io.Closer stops the polling goroutine.
 func StartNodeMetricsPolling(
 	ash core.AppStatusHandler,
 	pollingInterval time.Duration,
 	redundancyHandler consensus.NodeRedundancyHandler,
-) error {
+) (io.Closer, error) {
 	if check.IfNil(ash) {
-		return errors.New("nil AppStatusHandler")
+		return nil, errors.New("nil AppStatusHandler")
 	}
 	if check.IfNil(redundancyHandler) {
-		return errors.New("nil NodeRedundancyHandler")
+		return nil, errors.New("nil NodeRedundancyHandler")
 	}
 
 	startTime := time.Now()
@@ -251,13 +254,13 @@ func StartNodeMetricsPolling(
 
 	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
 	if err != nil {
-		return fmt.Errorf("cannot init AppStatusPolling for node metrics: %w", err)
+		return nil, fmt.Errorf("cannot init AppStatusPolling for node metrics: %w", err)
 	}
 
 	pollingFunc := buildNodeMetricsPollingFunc(startTime, redundancyHandler)
 	err = appStatusPollingHandler.RegisterPollingFunc(pollingFunc)
 	if err != nil {
-		return fmt.Errorf("cannot register node metrics polling function: %w", err)
+		return nil, fmt.Errorf("cannot register node metrics polling function: %w", err)
 	}
 
 	// Prime before the recurring poll so /node/status returns the real level on
@@ -265,7 +268,7 @@ func StartNodeMetricsPolling(
 	pollingFunc(ash)
 
 	appStatusPollingHandler.Poll()
-	return nil
+	return appStatusPollingHandler, nil
 }
 
 func buildNodeMetricsPollingFunc(

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -131,7 +131,7 @@ func StartStatusPolling(
 	networkComponents *factory.NetworkComponents,
 	processComponents *factory.Process,
 ) (io.Closer, error) {
-	if ash == nil {
+	if check.IfNil(ash) {
 		return nil, errors.New("nil AppStatusHandler")
 	}
 	if networkComponents == nil {
@@ -143,7 +143,7 @@ func StartStatusPolling(
 
 	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
 	if err != nil {
-		return nil, errors.New("cannot init AppStatusPolling")
+		return nil, fmt.Errorf("cannot init AppStatusPolling: %w", err)
 	}
 
 	err = registerPollConnectedPeers(appStatusPollingHandler, networkComponents)

--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -967,7 +967,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 
 	log.Trace("starting status pooling components")
 	statusPollingInterval := time.Duration(cfg.Preferences.StatusPollingIntervalSec) * time.Second
-	err = metrics.StartStatusPolling(
+	statusPollingCloser, err := metrics.StartStatusPolling(
 		currentNode.GetAppStatusHandler(),
 		statusPollingInterval,
 		networkComponents,
@@ -978,15 +978,17 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 	}
 
 	updateMachineStatisticsDuration := time.Second
-	err = metrics.StartMachineStatisticsPolling(coreComponents.StatusHandler, epochStartNotifier, updateMachineStatisticsDuration, workingDir)
+	machineStatsCloser, err := metrics.StartMachineStatisticsPolling(coreComponents.StatusHandler, epochStartNotifier, updateMachineStatisticsDuration, workingDir)
 	if err != nil {
 		return err
 	}
 
-	err = metrics.StartNodeMetricsPolling(coreComponents.StatusHandler, statusPollingInterval, nodeRedundancy)
+	nodeMetricsCloser, err := metrics.StartNodeMetricsPolling(coreComponents.StatusHandler, statusPollingInterval, nodeRedundancy)
 	if err != nil {
 		return err
 	}
+
+	pollingClosers := []io.Closer{statusPollingCloser, machineStatsCloser, nodeMetricsCloser}
 
 	log.Trace("creating klever node facade")
 	restAPIServerDebugMode := ctx.GlobalBool(restAPIDebug.Name)
@@ -1041,7 +1043,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 
 	chanCloseComponents := make(chan struct{})
 	go func() {
-		closeAllComponents(log, healthService, dataComponents, triesComponents, networkComponents, chanCloseComponents)
+		closeAllComponents(log, healthService, dataComponents, triesComponents, networkComponents, pollingClosers, chanCloseComponents)
 	}()
 
 	_ = tracing.Shutdown() // errors logged internally
@@ -1134,8 +1136,19 @@ func closeAllComponents(
 	dataComponents *factory.DataComponents,
 	triesComponents *factory.TriesComponents,
 	networkComponents *factory.NetworkComponents,
+	pollingClosers []io.Closer,
 	chanCloseComponents chan struct{},
 ) {
+	// Stop background polling first so handlers cannot fire against components
+	// being torn down below.
+	log.Debug("closing status polling goroutines...")
+	for _, c := range pollingClosers {
+		if c == nil {
+			continue
+		}
+		log.LogIfError(c.Close())
+	}
+
 	log.Debug("closing health service...")
 	err := healthService.Close()
 	log.LogIfError(err)

--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -988,6 +988,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		return err
 	}
 
+	// Pollers are independent; order doesn't matter.
 	pollingClosers := []io.Closer{statusPollingCloser, machineStatsCloser, nodeMetricsCloser}
 
 	log.Trace("creating klever node facade")
@@ -1139,8 +1140,7 @@ func closeAllComponents(
 	pollingClosers []io.Closer,
 	chanCloseComponents chan struct{},
 ) {
-	// Stop background polling first so handlers cannot fire against components
-	// being torn down below.
+	// Stop polling first so handlers cannot fire against components being torn down below.
 	log.Debug("closing status polling goroutines...")
 	for _, c := range pollingClosers {
 		if c == nil {

--- a/core/appStatusPolling/appStatusPolling.go
+++ b/core/appStatusPolling/appStatusPolling.go
@@ -16,6 +16,8 @@ type AppStatusPolling struct {
 	mutRegisteredFunc   sync.RWMutex
 	registeredFunctions []func(appStatusHandler core.AppStatusHandler)
 	appStatusHandler    core.AppStatusHandler
+	done                chan struct{}
+	closeOnce           sync.Once
 }
 
 // NewAppStatusPolling will return an instance of AppStatusPolling
@@ -29,6 +31,7 @@ func NewAppStatusPolling(appStatusHandler core.AppStatusHandler, pollingDuration
 	return &AppStatusPolling{
 		pollingDuration:  pollingDuration,
 		appStatusHandler: appStatusHandler,
+		done:             make(chan struct{}),
 	}, nil
 }
 
@@ -43,17 +46,32 @@ func (asp *AppStatusPolling) RegisterPollingFunc(handler func(appStatusHandler c
 	return nil
 }
 
-// Poll will notify the AppStatusHandler at a given time
+// Poll will notify the AppStatusHandler at a given time. The goroutine runs
+// until Close is called.
 func (asp *AppStatusPolling) Poll() {
 	go func() {
-		for {
-			time.Sleep(asp.pollingDuration)
+		ticker := time.NewTicker(asp.pollingDuration)
+		defer ticker.Stop()
 
-			asp.mutRegisteredFunc.RLock()
-			for _, handler := range asp.registeredFunctions {
-				handler(asp.appStatusHandler)
+		for {
+			select {
+			case <-asp.done:
+				return
+			case <-ticker.C:
+				asp.mutRegisteredFunc.RLock()
+				for _, handler := range asp.registeredFunctions {
+					handler(asp.appStatusHandler)
+				}
+				asp.mutRegisteredFunc.RUnlock()
 			}
-			asp.mutRegisteredFunc.RUnlock()
 		}
 	}()
+}
+
+// Close stops the polling goroutine. Idempotent; always returns nil.
+func (asp *AppStatusPolling) Close() error {
+	asp.closeOnce.Do(func() {
+		close(asp.done)
+	})
+	return nil
 }

--- a/core/appStatusPolling/appStatusPolling_test.go
+++ b/core/appStatusPolling/appStatusPolling_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/klever-io/klever-go/core/appStatusPolling"
 	"github.com/klever-io/klever-go/statusHandler"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAppStatusPooling_NilAppStatusHandlerShouldErr(t *testing.T) {
@@ -76,7 +77,7 @@ func TestAppStatusPolling_Poll_TestNumOfConnectedAddressesCalled(t *testing.T) {
 
 	select {
 	case <-chDone:
-	case <-time.After(pollingDuration * 2 * time.Second):
+	case <-time.After(2 * pollingDuration):
 		assert.Fail(t, "timeout calling SetInt64Value")
 	}
 }
@@ -110,15 +111,19 @@ func TestAppStatusPolling_Close_StopsGoroutine(t *testing.T) {
 	assert.Nil(t, err)
 
 	asp.Poll()
-	// Wait for at least one tick to confirm the goroutine is running.
-	time.Sleep(pollingDuration + 200*time.Millisecond)
-	beforeClose := atomic.LoadInt32(&callCount)
-	assert.Greater(t, beforeClose, int32(0), "expected goroutine to fire at least once before Close")
+	// Poll until the goroutine has fired at least once — tolerant of -race jitter.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&callCount) > 0
+	}, 3*pollingDuration, 50*time.Millisecond, "expected goroutine to fire at least once before Close")
 
 	assert.NoError(t, asp.Close())
 
-	// Wait long enough that the next tick would have fired had the goroutine not exited.
+	// Close does not synchronously join the goroutine, so a tick already
+	// selected may complete after Close returns. Wait long enough that the
+	// goroutine has observed `done`, then assert the count is stable across a
+	// second polling interval.
 	time.Sleep(2 * pollingDuration)
-	afterClose := atomic.LoadInt32(&callCount)
-	assert.Equal(t, beforeClose, afterClose, "expected no further handler invocations after Close")
+	stable := atomic.LoadInt32(&callCount)
+	time.Sleep(2 * pollingDuration)
+	assert.Equal(t, stable, atomic.LoadInt32(&callCount), "expected no further handler invocations after Close settles")
 }

--- a/core/appStatusPolling/appStatusPolling_test.go
+++ b/core/appStatusPolling/appStatusPolling_test.go
@@ -1,6 +1,7 @@
 package appStatusPolling_test
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -53,10 +54,13 @@ func TestAppStatusPolling_Poll_TestNumOfConnectedAddressesCalled(t *testing.T) {
 	t.Parallel()
 
 	pollingDuration := time.Second
-	chDone := make(chan struct{})
+	chDone := make(chan struct{}, 1)
 	ash := mock.AppStatusHandlerStub{
 		SetInt64ValueHandler: func(key string, value int64) {
-			chDone <- struct{}{}
+			select {
+			case chDone <- struct{}{}:
+			default:
+			}
 		},
 	}
 	asp, err := appStatusPolling.NewAppStatusPolling(&ash, pollingDuration)
@@ -68,10 +72,53 @@ func TestAppStatusPolling_Poll_TestNumOfConnectedAddressesCalled(t *testing.T) {
 	assert.Nil(t, err)
 
 	asp.Poll()
+	t.Cleanup(func() { _ = asp.Close() })
 
 	select {
 	case <-chDone:
 	case <-time.After(pollingDuration * 2 * time.Second):
 		assert.Fail(t, "timeout calling SetInt64Value")
 	}
+}
+
+func TestAppStatusPolling_Close_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	asp, err := appStatusPolling.NewAppStatusPolling(&statusHandler.NilStatusHandler{}, time.Second)
+	assert.Nil(t, err)
+
+	assert.NoError(t, asp.Close())
+	assert.NoError(t, asp.Close())
+}
+
+func TestAppStatusPolling_Close_StopsGoroutine(t *testing.T) {
+	t.Parallel()
+
+	pollingDuration := time.Second
+	var callCount int32
+	ash := mock.AppStatusHandlerStub{
+		SetInt64ValueHandler: func(key string, value int64) {
+			atomic.AddInt32(&callCount, 1)
+		},
+	}
+	asp, err := appStatusPolling.NewAppStatusPolling(&ash, pollingDuration)
+	assert.Nil(t, err)
+
+	err = asp.RegisterPollingFunc(func(appStatusHandler core.AppStatusHandler) {
+		appStatusHandler.SetInt64Value(core.MetricNumConnectedPeers, int64(10))
+	})
+	assert.Nil(t, err)
+
+	asp.Poll()
+	// Wait for at least one tick to confirm the goroutine is running.
+	time.Sleep(pollingDuration + 200*time.Millisecond)
+	beforeClose := atomic.LoadInt32(&callCount)
+	assert.Greater(t, beforeClose, int32(0), "expected goroutine to fire at least once before Close")
+
+	assert.NoError(t, asp.Close())
+
+	// Wait long enough that the next tick would have fired had the goroutine not exited.
+	time.Sleep(2 * pollingDuration)
+	afterClose := atomic.LoadInt32(&callCount)
+	assert.Equal(t, beforeClose, afterClose, "expected no further handler invocations after Close")
 }


### PR DESCRIPTION
## Summary

Replaces the unbounded `for { Sleep; ... }` goroutine in `AppStatusPolling.Poll()` with a `select` over a `done` channel and a `time.Ticker`, exposing an idempotent `Close() error` (satisfying `io.Closer`).

Fixes a pre-existing intermittent nil-pointer panic in `TestStartStatusPolling/Valid_configuration` (cmd/node/metrics) where the leaked polling goroutine outlived the test and fired against a `MessengerStub{}` whose `ConnectedAddressesCalled` field was nil. Was previously masked by the `TpsBenchmark` races; surfaced cleanly after [KLC-2398].

## Changes

**`core/appStatusPolling/appStatusPolling.go`**
- Added `done chan struct{}` + `sync.Once` fields.
- `Poll()` now runs `select { case <-done: return; case <-ticker.C: ... }`.
- New `Close() error` — idempotent; always returns nil; does not block on the goroutine (per the ticket's requirement).

**Public API change in `cmd/node/metrics`** (three wrappers now return the closer):
- `StartStatusPolling(...) (io.Closer, error)`
- `StartNodeMetricsPolling(...) (io.Closer, error)`
- `StartMachineStatisticsPolling(...) (io.Closer, error)`

**`cmd/node/startup.go`**
- Captures the three closers into a `[]io.Closer` slice.
- `closeAllComponents` now Closes pollers **first**, before tearing down the components (NetMessenger, Store, Tries) that handlers read from — so no late tick can race a half-closed component.

**Tests**
- `matics_test.go` & `appStatusPolling_test.go` use `t.Cleanup(func() { _ = closer.Close() })` after starting polling.
- Added `TestAppStatusPolling_Close_IsIdempotent`.
- Added `TestAppStatusPolling_Close_StopsGoroutine` — counts handler invocations before/after `Close()` to assert the goroutine actually exits.

## Acceptance criteria

- [x] `go test -race -count=5 ./cmd/node/metrics/` passes consistently — no panics, no race findings.
- [x] No goroutine leak past test exit (asserted by `TestAppStatusPolling_Close_StopsGoroutine`).
- [x] Production behaviour unchanged on the happy path; closers wired into the graceful shutdown sequence.
- [x] API change documented in each wrapper's docstring.

## Out of scope (follow-up)

- The other leaky goroutines in `core/statistics/machine` — `registerCPUStatistics`, `registerNetStatistics`, `registerDiskStatistics` — each spawn their own unbounded `for {}` loops with no shutdown. Same class of bug, different files; will be a separate ticket.

## Test plan

- [x] Unit tests pass with `-race -count=5`
- [x] Manual smoke: built node, ran ~60s, sent SIGINT — clean shutdown in 26ms, no panic, network messenger closed successfully
- [ ] Reviewer to optionally repeat the smoke in `--use-log-view` mode

[KLC-2398]: https://klever-io.atlassian.net/browse/KLC-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes AppStatusPolling stoppable and wires shutdown handles through node startup so polling goroutines are closed before core components are torn down.

- What changed
  - core/appStatusPolling: replaced unbounded sleep loop with ticker+select on a done channel; added done chan struct{} and sync.Once; added idempotent Close() implementing io.Closer. Poll() exits when done is closed.
  - cmd/node/metrics: StartStatusPolling, StartNodeMetricsPolling, StartMachineStatisticsPolling now return (io.Closer, error). Added nil/typed-nil guards, wrapped init errors with context, and prime a polling sample before starting to avoid stale first-read behavior.
  - cmd/node/startup.go: captures returned closers and closeAllComponents now closes pollers first, then health, Store, Tries, and NetMessenger.
  - Tests: updated tests to call Close via t.Cleanup; added tests asserting Close is idempotent and that Close stops the polling goroutine; fixed flaky waits under -race.

- Security / blockchain-critical components affected
  - Consensus, transaction processing, state management, KVM, and core networking logic are NOT changed. AppStatusPolling and the metric collectors only observe/read component state (peer counts, redundancy, CPU/mem/disk, uptime). No write-path or consensus logic is modified.

- Node stability, data integrity, and concurrency impact
  - Positive stability fixes: eliminates leaking/unbounded polling goroutines, fixes intermittent nil-pointer panic in tests caused by late ticks during shutdown, and prevents background pollers from accessing components after they begin teardown by closing pollers first.
  - Concurrency: introduces a controlled shutdown path (done + sync.Once) to avoid races during termination. Happy-path polling behavior preserved.
  - Residual: machine statistics worker goroutines for CPU/net/disk still leak (acknowledged and tracked as out-of-scope for this PR).

- Tests & acceptance
  - Tests updated to use t.Cleanup and new Close semantics. New tests for Close idempotency and stopping behavior were added. Reported acceptance: tests pass with -race -count=5 for ./cmd/node/metrics/; no goroutine leaks observed for the polling components covered.

- Risk assessment
  - Low risk to blockchain correctness or data integrity. Changes are defensive and operational—aimed at deterministic shutdown and eliminating goroutine leaks—without altering production observation semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->