### PR TITLE
[KLC-2400] fix flaky configITO ShouldError test: slot-relative ITO windows

### DIFF
--- a/integrationTest/transaction/configITO/configITO_test.go
+++ b/integrationTest/transaction/configITO/configITO_test.go
@@ -195,6 +195,21 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, asset)
 
+	// Block timestamps in tests are deterministic: blockTs(s) = genesis + s*slotDuration.
+	// Pin the ITO window to slot-relative anchors so it doesn't race wall-clock — KAPP
+	// validates ITO windows against ctx.Block().GetTimestamp(), not time.Now().
+	//   configITOTxHash is processed at block(slot)   → ts = genesisTs + slot*slotDuration
+	//   buy txs are processed at block(slot+1)        → ts = genesisTs + (slot+1)*slotDuration
+	//   "out of window" buy at block(slot+2)          → ts = genesisTs + (slot+2)*slotDuration
+	// Required: blockTs(slot) < itoStart ≤ blockTs(slot+1) ≤ itoEnd < blockTs(slot+2).
+	slotDuration := int64(nodes[xidProposerBlock].SlotManager.TimeDuration().Seconds())
+	genesisTs := nodes[xidProposerBlock].SlotManager.Timestamp().Unix()
+	itoStart := genesisTs + int64(slot+1)*slotDuration
+	itoEnd := itoStart + 1
+	// Deliberately end-before-start values for the two malformed-time test cases.
+	itoTimeInvertedStart := genesisTs + int64(slot+2)*slotDuration
+	itoTimeInvertedEnd := itoStart
+
 	// ################### CONFIG ITO TESTS ###################
 
 	// error: invalid asset
@@ -211,10 +226,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Nil(t, err)
@@ -233,10 +248,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -255,10 +270,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -277,10 +292,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -299,10 +314,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -321,10 +336,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -343,10 +358,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Nil(t, err)
@@ -365,10 +380,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -387,10 +402,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: -10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -409,10 +424,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -431,10 +446,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, "INVALID": {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -453,10 +468,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: -1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -475,10 +490,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 10).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 5).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoTimeInvertedStart,
+			WhitelistEndTime:       itoTimeInvertedEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Error(t, err)
@@ -497,10 +512,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 10).Unix(),
-			EndTime:                time.Now().Add(time.Second * 5).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoTimeInvertedStart,
+			EndTime:                itoTimeInvertedEnd,
 		},
 	)
 	require.Error(t, err)
@@ -519,10 +534,10 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 			DefaultLimitPerAddress: 10,
 			WhitelistStatus:        int32(*transaction.ConfigITOContract_ActiveITO.Enum()),
 			WhitelistInfo:          map[string]models.WhitelistInfoRequest{whitelistAddress1: {Limit: 1}, whitelistAddress2: {Limit: 1}},
-			WhitelistStartTime:     time.Now().Add(time.Second * 4).Unix(),
-			WhitelistEndTime:       time.Now().Add(time.Second * 9).Unix(),
-			StartTime:              time.Now().Add(time.Second * 4).Unix(),
-			EndTime:                time.Now().Add(time.Second * 9).Unix(),
+			WhitelistStartTime:     itoStart,
+			WhitelistEndTime:       itoEnd,
+			StartTime:              itoStart,
+			EndTime:                itoEnd,
 		},
 	)
 	require.Nil(t, err)

--- a/integrationTest/transaction/configITO/configITO_test.go
+++ b/integrationTest/transaction/configITO/configITO_test.go
@@ -195,19 +195,25 @@ func TestTransaction_CreateConfigITO_ShouldError(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, asset)
 
-	// Block timestamps in tests are deterministic: blockTs(s) = genesis + s*slotDuration.
+	// Block timestamps in tests are deterministic: blockTs(s) = slot0Ts + s*slotDuration,
+	// where slot0Ts is the proposer's slot-0 reference time (SlotManagerMock captures
+	// time.Now() at node construction — not actual chain genesis, just the anchor the
+	// proposer uses to compute block timestamps in block.go).
 	// Pin the ITO window to slot-relative anchors so it doesn't race wall-clock — KAPP
 	// validates ITO windows against ctx.Block().GetTimestamp(), not time.Now().
-	//   configITOTxHash is processed at block(slot)   → ts = genesisTs + slot*slotDuration
-	//   buy txs are processed at block(slot+1)        → ts = genesisTs + (slot+1)*slotDuration
-	//   "out of window" buy at block(slot+2)          → ts = genesisTs + (slot+2)*slotDuration
+	//   configITOTxHash is processed at block(slot)   → ts = slot0Ts + slot*slotDuration
+	//   buy txs are processed at block(slot+1)        → ts = slot0Ts + (slot+1)*slotDuration
+	//   "out of window" buy at block(slot+2)          → ts = slot0Ts + (slot+2)*slotDuration
 	// Required: blockTs(slot) < itoStart ≤ blockTs(slot+1) ≤ itoEnd < blockTs(slot+2).
 	slotDuration := int64(nodes[xidProposerBlock].SlotManager.TimeDuration().Seconds())
-	genesisTs := nodes[xidProposerBlock].SlotManager.Timestamp().Unix()
-	itoStart := genesisTs + int64(slot+1)*slotDuration
-	itoEnd := itoStart + 1
+	slot0Ts := nodes[xidProposerBlock].SlotManager.Timestamp().Unix()
+	itoStart := slot0Ts + int64(slot+1)*slotDuration
+	// Strictly less than blockTs(slot+2) regardless of slotDuration — the buy rejection
+	// at ito.go:336-337 is `EndTime < block.Timestamp`, so equality at block(slot+2)
+	// would leave the final "out of window" buy in-window if slotDuration ever became 1s.
+	itoEnd := slot0Ts + int64(slot+2)*slotDuration - 1
 	// Deliberately end-before-start values for the two malformed-time test cases.
-	itoTimeInvertedStart := genesisTs + int64(slot+2)*slotDuration
+	itoTimeInvertedStart := slot0Ts + int64(slot+2)*slotDuration
 	itoTimeInvertedEnd := itoStart
 
 	// ################### CONFIG ITO TESTS ###################


### PR DESCRIPTION
## Summary

`TestTransaction_CreateConfigITO_ShouldError` was flaky (~40% failure rate on `develop`) because it pinned ITO `StartTime` to `time.Now().Add(4s)`. The KAPP, however, validates ITO windows against `ctx.Block().GetTimestamp()` (`core/kapp/ito/ito.go:660-666`), and the test harness computes that as `genesis + slot * slotDuration` (`integrationTest/processorNode/block.go:72`) — fully deterministic. When the runner was slow enough that wall-clock drifted past the 4-second cushion, the block-time check `StartTime <= block.Timestamp` fired and rejected the only `configITOTxHash` the test expected to succeed.

## Fix

Replace wall-clock offsets with slot-relative anchors derived from the proposer's `SlotManager`:

```go
slotDuration := int64(nodes[xidProposerBlock].SlotManager.TimeDuration().Seconds())
genesisTs   := nodes[xidProposerBlock].SlotManager.Timestamp().Unix()
itoStart    := genesisTs + int64(slot+1)*slotDuration
itoEnd      := itoStart + 1
```

This guarantees `blockTs(slot) < itoStart <= blockTs(slot+1) <= itoEnd < blockTs(slot+2)`, which is exactly the window the rest of the test (config submission at `slot`, in-window buys at `slot+1`, out-of-window buy at `slot+2`) needs — independent of wall-clock load. Two malformed-time test cases still use deliberately inverted values for `start > end` validation.

Sibling `triggerITO_test.go` was audited: it uses day-scale `AddDate` offsets and isn't affected.

## Test plan

- [x] `go test ./integrationTest/transaction/configITO/ -run TestTransaction_CreateConfigITO_ShouldError -count=1` — 20/20 pass in a loop (~270s total); previously ~40% failure rate.
- [x] Full `go test ./integrationTest/transaction/configITO/ -count=1` package — pass.
- [ ] CI green on `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Test-Only Reliability Fix (configITO_test.go)

Scope
- Changes confined to integrationTest/transaction/configITO/configITO_test.go (test code only). No production code modified.

Problem
- TestTransaction_CreateConfigITO_ShouldError was flaky (~40% failures) because the test used wall-clock offsets (time.Now().Add...) for ITO Start/End timestamps while KAPP validates ITO windows against block timestamps computed from the proposer's SlotManager (slot0 reference + slot*slotDuration). On slow runners a wall-clock StartTime could be ≤ block timestamp and the config ITO got rejected unexpectedly.

Fix
- All ITO/whitelist times in the problematic test are now derived from the proposer node’s SlotManager:
  - slotDuration := nodes[xidProposerBlock].SlotManager.TimeDuration().Seconds()
  - slot0Ts := nodes[xidProposerBlock].SlotManager.Timestamp().Unix() (renamed from genesisTs)
  - itoStart := slot0Ts + int64(slot+1)*slotDuration
  - itoEnd := slot0Ts + int64(slot+2)*slotDuration - 1 (hardened to ensure itoEnd < blockTs(slot+2))
- Two negative test cases still use intentionally inverted start/end timestamps to validate error paths.
- All uses of time.Now().Add(...) for WhitelistStartTime, WhitelistEndTime, StartTime, EndTime in this test were replaced with the deterministic slot-relative values.

Rationale / Invariants
- Guarantees blockTs(slot) < itoStart ≤ blockTs(slot+1) ≤ itoEnd < blockTs(slot+2), aligning test submission/buy windows with how block timestamps are produced during tests and removing flakiness.

Other edits
- Renamed variable genesisTs → slot0Ts for clarity.
- Tightened itoEnd calculation (-1) to avoid equality at block boundary when slotDuration == 1s.

Blockchain-critical impact
- None to production behavior: consensus, transaction processing, state management, KVM, and networking code remain unchanged.
- The ITO validation logic in KAPP is not modified — only test inputs were made deterministic.
- No impact on node stability, data integrity, concurrency, or error handling in runtime code. The change reduces nondeterminism in tests, improving reliability of integration test outcomes.

Test results
- Targeted test loop: 20/20 passes locally (~270s). Full package tests passed locally. CI run pending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->