### PR TITLE
[KLC-2383] peerHonesty: await decay goroutine in Close()

### DIFF
--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -988,8 +988,14 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		return err
 	}
 
-	// Pollers are independent; order doesn't matter.
-	pollingClosers := []io.Closer{statusPollingCloser, machineStatsCloser, nodeMetricsCloser}
+	// Background goroutines that must be drained before component teardown.
+	// Order within the slice doesn't matter; they're independent of each other.
+	backgroundClosers := []io.Closer{
+		statusPollingCloser,
+		machineStatsCloser,
+		nodeMetricsCloser,
+		currentNode.GetPeerHonestyHandler(),
+	}
 
 	log.Trace("creating klever node facade")
 	restAPIServerDebugMode := ctx.GlobalBool(restAPIDebug.Name)
@@ -1044,7 +1050,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 
 	chanCloseComponents := make(chan struct{})
 	go func() {
-		closeAllComponents(log, healthService, dataComponents, triesComponents, networkComponents, pollingClosers, chanCloseComponents)
+		closeAllComponents(log, healthService, dataComponents, triesComponents, networkComponents, backgroundClosers, chanCloseComponents)
 	}()
 
 	_ = tracing.Shutdown() // errors logged internally
@@ -1137,12 +1143,13 @@ func closeAllComponents(
 	dataComponents *factory.DataComponents,
 	triesComponents *factory.TriesComponents,
 	networkComponents *factory.NetworkComponents,
-	pollingClosers []io.Closer,
+	backgroundClosers []io.Closer,
 	chanCloseComponents chan struct{},
 ) {
-	// Stop polling first so handlers cannot fire against components being torn down below.
-	log.Debug("closing status polling goroutines...")
-	for _, c := range pollingClosers {
+	// Drain background goroutines first so their handlers cannot fire
+	// against components being torn down below.
+	log.Debug("closing background goroutines...")
+	for _, c := range backgroundClosers {
 		if c == nil {
 			continue
 		}

--- a/common/mock/peerHonestyHandlerStub.go
+++ b/common/mock/peerHonestyHandlerStub.go
@@ -3,6 +3,7 @@ package mock
 // PeerHonestyHandlerStub -
 type PeerHonestyHandlerStub struct {
 	ChangeScoreCalled func(pk string, topic string, units int)
+	CloseCalled      func() error
 }
 
 // ChangeScore -
@@ -10,6 +11,14 @@ func (phhs *PeerHonestyHandlerStub) ChangeScore(pk string, topic string, units i
 	if phhs.ChangeScoreCalled != nil {
 		phhs.ChangeScoreCalled(pk, topic, units)
 	}
+}
+
+// Close -
+func (phhs *PeerHonestyHandlerStub) Close() error {
+	if phhs.CloseCalled != nil {
+		return phhs.CloseCalled()
+	}
+	return nil
 }
 
 // IsInterfaceNil -

--- a/common/mock/peerHonestyHandlerStub.go
+++ b/common/mock/peerHonestyHandlerStub.go
@@ -3,7 +3,7 @@ package mock
 // PeerHonestyHandlerStub -
 type PeerHonestyHandlerStub struct {
 	ChangeScoreCalled func(pk string, topic string, units int)
-	CloseCalled      func() error
+	CloseCalled       func() error
 }
 
 // ChangeScore -

--- a/core/consensus/interface.go
+++ b/core/consensus/interface.go
@@ -73,6 +73,7 @@ type HeadersPoolSubscriber interface {
 // participating in consensus
 type PeerHonestyHandler interface {
 	ChangeScore(pk string, topic string, units int)
+	Close() error
 	IsInterfaceNil() bool
 }
 

--- a/core/process/rating/peerHonesty/export_test.go
+++ b/core/process/rating/peerHonesty/export_test.go
@@ -24,12 +24,16 @@ func NewP2pPeerHonestyWithCustomExecuteDelayFunction(
 		unitValue:              peerHonestyConfig.UnitValue,
 		cache:                  cache,
 		blackListedPkCache:     blackListedPkCache,
+		done:                   make(chan struct{}),
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	instance.cancelFunc = cancelFunc
 
-	go instance.executeDecayContinuously(ctx, handler)
+	go func() {
+		defer close(instance.done)
+		instance.executeDecayContinuously(ctx, handler)
+	}()
 
 	return instance, nil
 }

--- a/core/process/rating/peerHonesty/peerHonesty.go
+++ b/core/process/rating/peerHonesty/peerHonesty.go
@@ -36,6 +36,7 @@ type p2pPeerHonesty struct {
 	mut                    sync.RWMutex
 	blackListedPkCache     process.TimeCacher
 	cancelFunc             func()
+	done                   chan struct{}
 }
 
 // NewP2pPeerHonesty creates a new peer honesty handler able to manage a provided set of public keys withing
@@ -59,12 +60,16 @@ func NewP2pPeerHonesty(
 		unitValue:              peerHonestyConfig.UnitValue,
 		cache:                  cache,
 		blackListedPkCache:     blackListedPkCache,
+		done:                   make(chan struct{}),
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	instance.cancelFunc = cancelFunc
 
-	go instance.executeDecayContinuously(ctx, instance.applyDecay)
+	go func() {
+		defer close(instance.done)
+		instance.executeDecayContinuously(ctx, instance.applyDecay)
+	}()
 
 	return instance, nil
 }
@@ -247,9 +252,11 @@ func (pph *p2pPeerHonesty) checkBlacklistNoLock(ps *peerScore) {
 	}
 }
 
-// Close closes the running go routines related to this instance
+// Close stops the decay goroutine and blocks until it has exited.
+// Safe to call multiple times.
 func (pph *p2pPeerHonesty) Close() error {
 	pph.cancelFunc()
+	<-pph.done
 	return nil
 }
 

--- a/core/process/rating/peerHonesty/peerHonesty_test.go
+++ b/core/process/rating/peerHonesty/peerHonesty_test.go
@@ -249,7 +249,18 @@ func TestP2pPeerHonesty_ConcurrentCloseShouldNotPanic(t *testing.T) {
 			errs <- pph.Close()
 		}()
 	}
-	wg.Wait()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for concurrent Close calls to return")
+	}
+
 	close(errs)
 	for closeErr := range errs {
 		assert.Nil(t, closeErr)

--- a/core/process/rating/peerHonesty/peerHonesty_test.go
+++ b/core/process/rating/peerHonesty/peerHonesty_test.go
@@ -162,24 +162,49 @@ func TestP2pPeerHonesty_Close(t *testing.T) {
 
 	cfg := createMockPeerHonestyConfig()
 	cfg.DecayUpdateIntervalInSeconds = 1
+
+	// Signal each handler invocation through a buffered channel so the test
+	// synchronizes on events instead of wall-clock sleeps.
+	const expectedTicks = 2
+	called := make(chan struct{}, 16)
 	numCalls := int32(0)
 	handler := func() {
 		atomic.AddInt32(&numCalls, 1)
+		select {
+		case called <- struct{}{}:
+		default:
+		}
 	}
-	pph, _ := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
+	pph, err := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
 		cfg,
 		&mock.TimeCacheStub{},
 		&testscommon.CacherStub{},
 		handler,
 	)
-
-	time.Sleep(time.Second*2 + time.Millisecond*100) //this will call the handler 2 times
-
-	err := pph.Close()
 	assert.Nil(t, err)
+	assert.NotNil(t, pph)
 
-	time.Sleep(time.Second*2 + time.Millisecond*100)
-	assert.Equal(t, int32(2), atomic.LoadInt32(&numCalls))
+	tickerWindow := time.Duration(cfg.DecayUpdateIntervalInSeconds) * time.Second
+	tickTimeout := tickerWindow*expectedTicks + time.Second
+	for range expectedTicks {
+		select {
+		case <-called:
+		case <-time.After(tickTimeout):
+			t.Fatalf("handler not invoked %d times within %s", expectedTicks, tickTimeout)
+		}
+	}
+
+	assert.Nil(t, pph.Close())
+
+	// After Close returns, the goroutine has exited (happens-before via done).
+	// Confirm no further signals arrive within a full ticker window.
+	select {
+	case <-called:
+		t.Fatal("handler was invoked after Close returned")
+	case <-time.After(tickerWindow + 500*time.Millisecond):
+	}
+
+	assert.Equal(t, int32(expectedTicks), atomic.LoadInt32(&numCalls))
 }
 
 func TestP2pPeerHonesty_DoubleCloseShouldNotPanic(t *testing.T) {
@@ -187,12 +212,14 @@ func TestP2pPeerHonesty_DoubleCloseShouldNotPanic(t *testing.T) {
 
 	cfg := createMockPeerHonestyConfig()
 	cfg.DecayUpdateIntervalInSeconds = 1
-	pph, _ := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
+	pph, err := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
 		cfg,
 		&mock.TimeCacheStub{},
 		&testscommon.CacherStub{},
 		func() {},
 	)
+	assert.Nil(t, err)
+	assert.NotNil(t, pph)
 
 	assert.Nil(t, pph.Close())
 	assert.Nil(t, pph.Close()) // second call must not panic or block
@@ -203,23 +230,30 @@ func TestP2pPeerHonesty_ConcurrentCloseShouldNotPanic(t *testing.T) {
 
 	cfg := createMockPeerHonestyConfig()
 	cfg.DecayUpdateIntervalInSeconds = 1
-	pph, _ := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
+	pph, err := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
 		cfg,
 		&mock.TimeCacheStub{},
 		&testscommon.CacherStub{},
 		func() {},
 	)
+	assert.Nil(t, err)
+	assert.NotNil(t, pph)
 
 	const callers = 4
+	errs := make(chan error, callers)
 	var wg sync.WaitGroup
 	wg.Add(callers)
 	for range callers {
 		go func() {
 			defer wg.Done()
-			assert.Nil(t, pph.Close())
+			errs <- pph.Close()
 		}()
 	}
 	wg.Wait()
+	close(errs)
+	for closeErr := range errs {
+		assert.Nil(t, closeErr)
+	}
 }
 
 func TestP2pPeerHonesty_ChangeScoreShouldWork(t *testing.T) {

--- a/core/process/rating/peerHonesty/peerHonesty_test.go
+++ b/core/process/rating/peerHonesty/peerHonesty_test.go
@@ -2,6 +2,7 @@ package peerHonesty
 
 import (
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -172,13 +173,53 @@ func TestP2pPeerHonesty_Close(t *testing.T) {
 		handler,
 	)
 
-	time.Sleep(time.Second*2 + time.Millisecond*100) //this will call the handler 3 times
+	time.Sleep(time.Second*2 + time.Millisecond*100) //this will call the handler 2 times
 
 	err := pph.Close()
 	assert.Nil(t, err)
 
 	time.Sleep(time.Second*2 + time.Millisecond*100)
-	assert.Equal(t, int32(2), numCalls)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&numCalls))
+}
+
+func TestP2pPeerHonesty_DoubleCloseShouldNotPanic(t *testing.T) {
+	t.Parallel()
+
+	cfg := createMockPeerHonestyConfig()
+	cfg.DecayUpdateIntervalInSeconds = 1
+	pph, _ := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
+		cfg,
+		&mock.TimeCacheStub{},
+		&testscommon.CacherStub{},
+		func() {},
+	)
+
+	assert.Nil(t, pph.Close())
+	assert.Nil(t, pph.Close()) // second call must not panic or block
+}
+
+func TestP2pPeerHonesty_ConcurrentCloseShouldNotPanic(t *testing.T) {
+	t.Parallel()
+
+	cfg := createMockPeerHonestyConfig()
+	cfg.DecayUpdateIntervalInSeconds = 1
+	pph, _ := NewP2pPeerHonestyWithCustomExecuteDelayFunction(
+		cfg,
+		&mock.TimeCacheStub{},
+		&testscommon.CacherStub{},
+		func() {},
+	)
+
+	const callers = 4
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			assert.Nil(t, pph.Close())
+		}()
+	}
+	wg.Wait()
 }
 
 func TestP2pPeerHonesty_ChangeScoreShouldWork(t *testing.T) {

--- a/node/node.go
+++ b/node/node.go
@@ -221,6 +221,12 @@ func (n *Node) GetAppStatusHandler() core.AppStatusHandler {
 	return n.appStatusHandler
 }
 
+// GetPeerHonestyHandler returns the peer honesty handler attached to this node.
+// Returned for shutdown wiring so the caller can Close it on process exit.
+func (n *Node) GetPeerHonestyHandler() consensus.PeerHonestyHandler {
+	return n.peerHonestyHandler
+}
+
 // CreateStores instantiate cachers for Transactions and Headers
 func (n *Node) CreateStores() error {
 	if n.dataPool == nil {


### PR DESCRIPTION
## Summary

`p2pPeerHonesty.Close()` previously called `cancelFunc()` and returned immediately, without waiting for the spawned decay goroutine to exit. This left no happens-before edge between the goroutine's writes and any post-`Close()` read by the caller, and was the root cause of the `go test -race` failure in `TestP2pPeerHonesty_Close`.

This PR makes `Close()` synchronous:

- Adds a `done chan struct{}` to the struct
- Wraps the goroutine spawn in a closure that `defer close(instance.done)` on exit
- `Close()` now blocks on `<-pph.done` after cancelling the context
- Mirrors the same pattern in the test constructor (`export_test.go`)
- Tightens the test's `numCalls` read to `atomic.LoadInt32`
- Adds `TestP2pPeerHonesty_DoubleCloseShouldNotPanic` and `TestP2pPeerHonesty_ConcurrentCloseShouldNotPanic` to lock in the idempotency contract

## Test plan

- [x] `go test -race -count=1 -run TestP2pPeerHonesty_Close ./core/process/rating/peerHonesty/` passes deterministically
- [x] `go test -race -count=5 -run TestP2pPeerHonesty_Close ./core/process/rating/peerHonesty/` — 5 consecutive runs clean
- [x] `go test -race -count=1 ./core/process/rating/peerHonesty/` — full package suite clean
- [x] `go build ./...` clean
- [x] `go vet ./core/process/rating/peerHonesty/` clean
- [x] New tests confirm Close() is safe under double and concurrent invocation

## Jira

https://klever-io.atlassian.net/browse/KLC-2383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Concurrency & Data Race Fix — Network Peer Rating (peerHonesty)

This PR fixes a data race and improves shutdown semantics for the p2p peer reputation subsystem used by the networking layer and wired into node shutdown.

### Affected blockchain‑critical components
- Networking / P2P: p2pPeerHonesty (peer reputation / decay loop) — affects peer scoring used for peer selection and resilience.
- Consensus wiring: consensus.PeerHonestyHandler interface extended with Close() and Node.GetPeerHonestyHandler() added so the handler can be closed during shutdown.
- Node lifecycle / shutdown: startup now drains background goroutines (including the peerHonesty handler) before closing other components.
- Tests & mocks: peerHonesty tests tightened (atomic loads, channel sync) and new idempotency/concurrent-close tests added; PeerHonestyHandlerStub mock gains Close() hook.

### Stability, data integrity, and concurrency impact
- Root cause: Close() previously canceled the context and returned immediately while a background decay goroutine could still write state, producing a data race (no happens‑before edge).
- Fix:
  - p2pPeerHonesty now owns a done chan struct{}; the decay goroutine is started inside a closure that defers close(done) on exit.
  - Close() cancels the context and blocks on <-done, ensuring the decay goroutine has exited before Close() returns.
  - Tests changed to use atomic.LoadInt32 and channel-based synchronization to remove timing-based flakiness.
  - Added tests: TestP2pPeerHonesty_DoubleCloseShouldNotPanic and TestP2pPeerHonesty_ConcurrentCloseShouldNotPanic to verify idempotency and concurrent safety.
  - Consensus interface updated to require Close(); mock/stub updated accordingly and node exposes the handler for shutdown wiring.
- Result: eliminates the race detected by go test -race, makes Close() safe to call concurrently or multiple times, and ensures deterministic teardown of the peerHonesty subsystem. No production runtime performance penalty outside shutdown.

### Cross‑cutting notes for reviewers / operators
- API surface: consensus.PeerHonestyHandler gained Close(), so all implementations must implement it (mocks updated in this PR).
- Operational impact is limited to shutdown ordering — startup/shutdown wiring was adjusted to include the handler among background closers so it is drained first.
- Tests, package build, and vet run clean with the race detector per PR reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->