### PR TITLE
[KLC-2405] expose NTP clock offset + last-sync timestamp as metrics

### DIFF
--- a/cmd/node/metrics/clockMetrics.go
+++ b/cmd/node/metrics/clockMetrics.go
@@ -1,0 +1,71 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/appStatusPolling"
+	"github.com/klever-io/klever-go/ntp"
+	"github.com/klever-io/klever-go/tools/check"
+)
+
+// StartClockMetricsPolling registers a polling function that publishes the NTP
+// syncer's current clock offset and the timestamp of the last successful sync.
+// These two signals cover every blockchain-operator alarm:
+//
+//   - abs(klv_clock_offset_ns) > tolerance         → drift will hurt consensus
+//   - time() - klv_clock_last_sync_timestamp > 2×sync_period → NTP path broken
+//
+// Returned io.Closer stops the polling goroutine; nil if validation fails.
+func StartClockMetricsPolling(
+	ash core.AppStatusHandler,
+	syncTimer ntp.SyncTimer,
+	pollingInterval time.Duration,
+) (io.Closer, error) {
+	if check.IfNil(ash) {
+		return nil, errors.New("nil AppStatusHandler")
+	}
+	if check.IfNil(syncTimer) {
+		return nil, errors.New("nil SyncTimer")
+	}
+
+	appStatusPollingHandler, err := appStatusPolling.NewAppStatusPolling(ash, pollingInterval)
+	if err != nil {
+		return nil, fmt.Errorf("cannot init AppStatusPolling for clock metrics: %w", err)
+	}
+
+	pollingFunc := buildClockMetricsPollingFunc(syncTimer)
+	err = appStatusPollingHandler.RegisterPollingFunc(pollingFunc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot register clock metrics polling function: %w", err)
+	}
+
+	// Prime before the recurring poll so /node/status returns the current
+	// offset on request 1 (AppStatusPolling.Poll sleeps before its first tick).
+	pollingFunc(ash)
+
+	appStatusPollingHandler.Poll()
+	return appStatusPollingHandler, nil
+}
+
+func buildClockMetricsPollingFunc(syncTimer ntp.SyncTimer) func(core.AppStatusHandler) {
+	return func(appStatusHandler core.AppStatusHandler) {
+		// ClockOffset is signed: negative means OS clock is fast relative to NTP
+		// servers, positive means it is slow. Route through SetInt64Value so the
+		// sign survives the float64 round-trip done by the metrics provider.
+		appStatusHandler.SetInt64Value(core.MetricClockOffsetNs, syncTimer.ClockOffset().Nanoseconds())
+
+		// Zero before the first successful sync — publish 0 explicitly so
+		// `time() - value > threshold` alarms only fire once a sync has
+		// actually happened (avoids the "node booted but NTP is broken" alarm
+		// firing identically to "node has been up for years without resync").
+		var lastSyncUnix uint64
+		if ts := syncTimer.LastSyncTimestamp(); !ts.IsZero() {
+			lastSyncUnix = uint64(ts.Unix()) // #nosec G115 -- unix seconds fit in uint64 well beyond year 2262
+		}
+		appStatusHandler.SetUInt64Value(core.MetricClockLastSyncTimestamp, lastSyncUnix)
+	}
+}

--- a/cmd/node/metrics/clockMetrics.go
+++ b/cmd/node/metrics/clockMetrics.go
@@ -53,18 +53,26 @@ func StartClockMetricsPolling(
 
 func buildClockMetricsPollingFunc(syncTimer ntp.SyncTimer) func(core.AppStatusHandler) {
 	return func(appStatusHandler core.AppStatusHandler) {
+		// Read offset and last-sync timestamp under a single RLock so a scrape
+		// can't observe a fresh offset paired with a stale timestamp (or vice
+		// versa) if a sync lands between two separate getter calls.
+		offset, lastSync := syncTimer.ClockSnapshot()
+
 		// ClockOffset is signed: negative means OS clock is fast relative to NTP
-		// servers, positive means it is slow. Route through SetInt64Value so the
-		// sign survives the float64 round-trip done by the metrics provider.
-		appStatusHandler.SetInt64Value(core.MetricClockOffsetNs, syncTimer.ClockOffset().Nanoseconds())
+		// servers, positive means it is slow. SetInt64Value (not SetUInt64Value)
+		// is required because uint64 can't represent negative values.
+		appStatusHandler.SetInt64Value(core.MetricClockOffsetNs, offset.Nanoseconds())
 
 		// Zero before the first successful sync — publish 0 explicitly so
 		// `time() - value > threshold` alarms only fire once a sync has
-		// actually happened (avoids the "node booted but NTP is broken" alarm
-		// firing identically to "node has been up for years without resync").
+		// actually happened. The unix > 0 guard defends against a pathological
+		// pre-1970 RTC: uint64(negative-int64) wraps to a huge value that
+		// would silently keep "stale-sync" alarms quiet forever.
 		var lastSyncUnix uint64
-		if ts := syncTimer.LastSyncTimestamp(); !ts.IsZero() {
-			lastSyncUnix = uint64(ts.Unix()) // #nosec G115 -- unix seconds fit in uint64 well beyond year 2262
+		if !lastSync.IsZero() {
+			if unix := lastSync.Unix(); unix > 0 {
+				lastSyncUnix = uint64(unix)
+			}
 		}
 		appStatusHandler.SetUInt64Value(core.MetricClockLastSyncTimestamp, lastSyncUnix)
 	}

--- a/cmd/node/metrics/clockMetrics_test.go
+++ b/cmd/node/metrics/clockMetrics_test.go
@@ -167,6 +167,59 @@ func TestBuildClockMetricsPollingFunc_LastSyncTimestampPublished(t *testing.T) {
 	assert.Equal(t, uint64(syncTs.Unix()), cap.u64[core.MetricClockLastSyncTimestamp])
 }
 
+func TestBuildClockMetricsPollingFunc_NegativeUnixGuard(t *testing.T) {
+	// Pathological case: a non-zero timestamp whose Unix() is negative (pre-1970
+	// RTC after a successful sync). Without the guard, uint64(negative-int64)
+	// wraps to ~1.8e19, which would silently bypass any "stale sync" alarm
+	// expressed as `time() - value > threshold`. Must publish 0 instead.
+	preEpoch := time.Date(1969, 6, 1, 0, 0, 0, 0, time.UTC)
+	require.True(t, preEpoch.Unix() < 0, "test setup: timestamp must precede 1970")
+
+	cap, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{
+		LastSyncTimestampCalled: func() time.Time { return preEpoch },
+	}
+
+	pollingFunc := buildClockMetricsPollingFunc(syncTimer)
+	pollingFunc(stub)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	assert.Equal(t, uint64(0), cap.u64[core.MetricClockLastSyncTimestamp],
+		"negative Unix seconds must publish 0, not the uint64 wrap-around")
+}
+
+func TestBuildClockMetricsPollingFunc_UsesAtomicSnapshot(t *testing.T) {
+	// Verify the polling func reads (offset, lastSync) via the single-RLock
+	// snapshot, not as two independent getter calls. Forcing the legacy getters
+	// to fail the assertion proves the snapshot path is what publishes the metrics.
+	const offset = 1234 * time.Nanosecond
+	syncTs := time.Unix(1_700_000_000, 0)
+
+	cap, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{
+		ClockOffsetCalled: func() time.Duration {
+			t.Errorf("ClockOffset() must not be called — polling must use ClockSnapshot()")
+			return 0
+		},
+		LastSyncTimestampCalled: func() time.Time {
+			t.Errorf("LastSyncTimestamp() must not be called — polling must use ClockSnapshot()")
+			return time.Time{}
+		},
+		ClockSnapshotCalled: func() (time.Duration, time.Time) {
+			return offset, syncTs
+		},
+	}
+
+	pollingFunc := buildClockMetricsPollingFunc(syncTimer)
+	pollingFunc(stub)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	assert.Equal(t, offset.Nanoseconds(), cap.i64[core.MetricClockOffsetNs])
+	assert.Equal(t, uint64(syncTs.Unix()), cap.u64[core.MetricClockLastSyncTimestamp])
+}
+
 // TestClockMetricsAppearInPrometheusOutput is an end-to-end check that
 // exercises the real statusHandler + clockMetrics polling combination,
 // ensuring both metrics appear in the /node/metrics scrape output with the

--- a/cmd/node/metrics/clockMetrics_test.go
+++ b/cmd/node/metrics/clockMetrics_test.go
@@ -1,0 +1,231 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
+	"github.com/klever-io/klever-go/statusHandler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHandler records SetInt64Value and SetUInt64Value calls so tests can
+// assert which keys the polling function published and with what values.
+type captureHandler struct {
+	mu  sync.Mutex
+	i64 map[string]int64
+	u64 map[string]uint64
+}
+
+func newCaptureHandler() (*captureHandler, *mock.AppStatusHandlerStub) {
+	cap := &captureHandler{
+		i64: map[string]int64{},
+		u64: map[string]uint64{},
+	}
+	stub := &mock.AppStatusHandlerStub{
+		SetInt64ValueHandler: func(key string, value int64) {
+			cap.mu.Lock()
+			cap.i64[key] = value
+			cap.mu.Unlock()
+		},
+		SetUInt64ValueHandler: func(key string, value uint64) {
+			cap.mu.Lock()
+			cap.u64[key] = value
+			cap.mu.Unlock()
+		},
+	}
+	return cap, stub
+}
+
+func TestStartClockMetricsPolling_NilAppStatusHandler(t *testing.T) {
+	syncTimer := &consensusMock.SyncTimerMock{}
+
+	closer, err := StartClockMetricsPolling(nil, syncTimer, time.Second)
+
+	assert.Error(t, err)
+	assert.Nil(t, closer)
+}
+
+func TestStartClockMetricsPolling_NilSyncTimer(t *testing.T) {
+	_, stub := newCaptureHandler()
+
+	closer, err := StartClockMetricsPolling(stub, nil, time.Second)
+
+	assert.Error(t, err)
+	assert.Nil(t, closer)
+}
+
+func TestStartClockMetricsPolling_InvalidPollingInterval(t *testing.T) {
+	_, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{}
+
+	closer, err := StartClockMetricsPolling(stub, syncTimer, 0)
+
+	assert.Error(t, err)
+	assert.Nil(t, closer)
+}
+
+func TestStartClockMetricsPolling_PrimesMetricsBeforeFirstTick(t *testing.T) {
+	// Verify the polling function runs once synchronously so /node/status
+	// returns real values on the first scrape, not zero.
+	const offset = time.Duration(-38) * time.Millisecond
+	syncTs := time.Unix(1_700_000_000, 0)
+
+	cap, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{
+		ClockOffsetCalled:       func() time.Duration { return offset },
+		LastSyncTimestampCalled: func() time.Time { return syncTs },
+	}
+
+	closer, err := StartClockMetricsPolling(stub, syncTimer, time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, closer)
+	defer func() { _ = closer.Close() }()
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	assert.Equal(t, offset.Nanoseconds(), cap.i64[core.MetricClockOffsetNs])
+	assert.Equal(t, uint64(syncTs.Unix()), cap.u64[core.MetricClockLastSyncTimestamp])
+}
+
+func TestBuildClockMetricsPollingFunc_NegativeOffsetPreservesSign(t *testing.T) {
+	// The "OS clock fast" case (operator-relevant: a fast clock makes the node
+	// emit timestamps in the future relative to peers, breaking quorum). Sign
+	// must survive the SetInt64Value round-trip.
+	const offset = time.Duration(-123_456_789) * time.Nanosecond
+
+	cap, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{
+		ClockOffsetCalled: func() time.Duration { return offset },
+	}
+
+	pollingFunc := buildClockMetricsPollingFunc(syncTimer)
+	pollingFunc(stub)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	assert.Equal(t, offset.Nanoseconds(), cap.i64[core.MetricClockOffsetNs])
+	assert.Less(t, cap.i64[core.MetricClockOffsetNs], int64(0), "negative offset must remain negative")
+}
+
+func TestBuildClockMetricsPollingFunc_PositiveOffset(t *testing.T) {
+	const offset = 42 * time.Millisecond
+
+	cap, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{
+		ClockOffsetCalled: func() time.Duration { return offset },
+	}
+
+	pollingFunc := buildClockMetricsPollingFunc(syncTimer)
+	pollingFunc(stub)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	assert.Equal(t, offset.Nanoseconds(), cap.i64[core.MetricClockOffsetNs])
+}
+
+func TestBuildClockMetricsPollingFunc_ZeroTimestampBeforeFirstSync(t *testing.T) {
+	// A node that has never successfully synced (e.g. NTP timeouts at boot)
+	// must publish timestamp=0, not a Unix-epoch translation of the zero time.
+	// Operators alarm on `time() - klv_clock_last_sync_timestamp > threshold`;
+	// leaking time.Time{}.Unix() (≈ -6e10) would make the alarm fire spuriously
+	// or never fire at all depending on the operator's filter expression.
+	cap, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{
+		// LastSyncTimestampCalled left nil → returns time.Time{}
+	}
+
+	pollingFunc := buildClockMetricsPollingFunc(syncTimer)
+	pollingFunc(stub)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	assert.Equal(t, int64(0), cap.i64[core.MetricClockOffsetNs])
+	assert.Equal(t, uint64(0), cap.u64[core.MetricClockLastSyncTimestamp],
+		"zero time.Time must translate to 0, not the Unix epoch of the zero time")
+}
+
+func TestBuildClockMetricsPollingFunc_LastSyncTimestampPublished(t *testing.T) {
+	syncTs := time.Unix(1_700_000_000, 0)
+
+	cap, stub := newCaptureHandler()
+	syncTimer := &consensusMock.SyncTimerMock{
+		LastSyncTimestampCalled: func() time.Time { return syncTs },
+	}
+
+	pollingFunc := buildClockMetricsPollingFunc(syncTimer)
+	pollingFunc(stub)
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	assert.Equal(t, uint64(syncTs.Unix()), cap.u64[core.MetricClockLastSyncTimestamp])
+}
+
+// TestClockMetricsAppearInPrometheusOutput is an end-to-end check that
+// exercises the real statusHandler + clockMetrics polling combination,
+// ensuring both metrics appear in the /node/metrics scrape output with the
+// sign of klv_clock_offset_ns surviving the int64 → Prometheus number
+// formatting.
+func TestClockMetricsAppearInPrometheusOutput(t *testing.T) {
+	const offset = time.Duration(-38) * time.Millisecond
+	syncTs := time.Unix(1_700_000_000, 0)
+
+	sm := statusHandler.NewStatusMetrics()
+	sm.SetStringValue(core.MetricChainID, "testnet")
+
+	syncTimer := &consensusMock.SyncTimerMock{
+		ClockOffsetCalled:       func() time.Duration { return offset },
+		LastSyncTimestampCalled: func() time.Time { return syncTs },
+	}
+
+	// Long interval so only the synchronous prime call runs during the assert;
+	// avoids racing against the background poller.
+	closer, err := StartClockMetricsPolling(sm, syncTimer, time.Hour)
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	prom := sm.StatusMetricsWithoutP2PPrometheusString()
+
+	assert.True(t, strings.Contains(prom, core.MetricClockOffsetNs),
+		"missing %s in: %s", core.MetricClockOffsetNs, prom)
+	assert.True(t, strings.Contains(prom, core.MetricClockLastSyncTimestamp),
+		"missing %s in: %s", core.MetricClockLastSyncTimestamp, prom)
+
+	expectedOffsetLine := fmt.Sprintf(`%s{chainID="testnet"} %d`,
+		core.MetricClockOffsetNs, offset.Nanoseconds())
+	assert.Contains(t, prom, expectedOffsetLine,
+		"negative offset must appear with sign preserved")
+
+	expectedTimestampLine := fmt.Sprintf(`%s{chainID="testnet"} %d`,
+		core.MetricClockLastSyncTimestamp, syncTs.Unix())
+	assert.Contains(t, prom, expectedTimestampLine)
+}
+
+// TestClockMetricsAppearInStatusMap checks that both metrics land in the JSON
+// map returned by /node/status (used by dashboards/operator tooling that read
+// the structured map rather than the scrape format).
+func TestClockMetricsAppearInStatusMap(t *testing.T) {
+	const offset = 42 * time.Millisecond
+	syncTs := time.Unix(1_700_000_000, 0)
+
+	sm := statusHandler.NewStatusMetrics()
+	syncTimer := &consensusMock.SyncTimerMock{
+		ClockOffsetCalled:       func() time.Duration { return offset },
+		LastSyncTimestampCalled: func() time.Time { return syncTs },
+	}
+
+	closer, err := StartClockMetricsPolling(sm, syncTimer, time.Hour)
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	statusMap := sm.StatusMetricsMapWithoutP2P()
+
+	assert.Equal(t, offset.Nanoseconds(), statusMap[core.MetricClockOffsetNs])
+	assert.Equal(t, uint64(syncTs.Unix()), statusMap[core.MetricClockLastSyncTimestamp])
+}

--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -988,12 +988,18 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		return err
 	}
 
+	clockMetricsCloser, err := metrics.StartClockMetricsPolling(coreComponents.StatusHandler, syncer, statusPollingInterval)
+	if err != nil {
+		return err
+	}
+
 	// Background goroutines that must be drained before component teardown.
 	// Order within the slice doesn't matter; they're independent of each other.
 	backgroundClosers := []io.Closer{
 		statusPollingCloser,
 		machineStatsCloser,
 		nodeMetricsCloser,
+		clockMetricsCloser,
 		currentNode.GetPeerHonestyHandler(),
 	}
 

--- a/config/node/config.yaml
+++ b/config/node/config.yaml
@@ -55,7 +55,7 @@ ntp:
     - time.windows.com
     - time.apple.com
   port: 123
-  timeoutMilliseconds: 100
+  timeoutMilliseconds: 500
   syncPeriodSeconds: 3600
   version: 0
 

--- a/core/consensus/mock/syncTimerMock.go
+++ b/core/consensus/mock/syncTimerMock.go
@@ -8,6 +8,7 @@ import (
 type SyncTimerMock struct {
 	ClockOffsetCalled       func() time.Duration
 	LastSyncTimestampCalled func() time.Time
+	ClockSnapshotCalled     func() (time.Duration, time.Time)
 	CurrentTimeCalled       func() time.Time
 }
 
@@ -32,6 +33,18 @@ func (stm *SyncTimerMock) LastSyncTimestamp() time.Time {
 	}
 
 	return time.Time{}
+}
+
+// ClockSnapshot returns the configured (offset, lastSync) pair under a single
+// callback so tests can assert atomic-pair semantics. Falls back to the
+// individual getters when no explicit snapshot stub is set, which preserves
+// the existing behavior for tests that only configure one or both fields.
+func (stm *SyncTimerMock) ClockSnapshot() (time.Duration, time.Time) {
+	if stm.ClockSnapshotCalled != nil {
+		return stm.ClockSnapshotCalled()
+	}
+
+	return stm.ClockOffset(), stm.LastSyncTimestamp()
 }
 
 // FormattedCurrentTime method gets the formatted current time on which is added a given offset

--- a/core/consensus/mock/syncTimerMock.go
+++ b/core/consensus/mock/syncTimerMock.go
@@ -6,8 +6,9 @@ import (
 
 // SyncTimerMock mocks the implementation for a SyncTimer
 type SyncTimerMock struct {
-	ClockOffsetCalled func() time.Duration
-	CurrentTimeCalled func() time.Time
+	ClockOffsetCalled       func() time.Duration
+	LastSyncTimestampCalled func() time.Time
+	CurrentTimeCalled       func() time.Time
 }
 
 // StartSyncingTime method does the time synchronization at every syncPeriod time elapsed. This should be started as a go routine
@@ -22,6 +23,15 @@ func (stm *SyncTimerMock) ClockOffset() time.Duration {
 	}
 
 	return time.Duration(0)
+}
+
+// LastSyncTimestamp returns the configured last sync timestamp or the zero time
+func (stm *SyncTimerMock) LastSyncTimestamp() time.Time {
+	if stm.LastSyncTimestampCalled != nil {
+		return stm.LastSyncTimestampCalled()
+	}
+
+	return time.Time{}
 }
 
 // FormattedCurrentTime method gets the formatted current time on which is added a given offset

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -300,3 +300,9 @@ const MetricNodeStartTimestamp = "klv_node_start_timestamp"
 
 // MetricRedundancySlotsInactive is the metric for the redundancy slots of inactivity counter
 const MetricRedundancySlotsInactive = "klv_redundancy_slots_inactive"
+
+// MetricClockOffsetNs is the metric for the NTP-corrected clock offset in nanoseconds (signed)
+const MetricClockOffsetNs = "klv_clock_offset_ns"
+
+// MetricClockLastSyncTimestamp is the metric for the unix-seconds timestamp of the last successful NTP sync (0 before first success)
+const MetricClockLastSyncTimestamp = "klv_clock_last_sync_timestamp"

--- a/integrationTest/config/config.yaml
+++ b/integrationTest/config/config.yaml
@@ -38,7 +38,7 @@ ntp:
     - time.cloudflare.com
     - time.apple.com
   port: 123
-  timeoutMilliseconds: 100
+  timeoutMilliseconds: 500
   syncPeriodSeconds: 3600
   version: 0
 

--- a/ntp/interface.go
+++ b/ntp/interface.go
@@ -9,6 +9,7 @@ type SyncTimer interface {
 	Close() error
 	StartSyncingTime()
 	ClockOffset() time.Duration
+	LastSyncTimestamp() time.Time
 	FormattedCurrentTime() string
 	CurrentTime() time.Time
 	IsInterfaceNil() bool

--- a/ntp/interface.go
+++ b/ntp/interface.go
@@ -10,6 +10,7 @@ type SyncTimer interface {
 	StartSyncingTime()
 	ClockOffset() time.Duration
 	LastSyncTimestamp() time.Time
+	ClockSnapshot() (offset time.Duration, lastSync time.Time)
 	FormattedCurrentTime() string
 	CurrentTime() time.Time
 	IsInterfaceNil() bool

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -284,6 +284,19 @@ func (s *syncTime) LastSyncTimestamp() time.Time {
 	return ts
 }
 
+// ClockSnapshot returns the current offset and last-sync timestamp under a
+// single RLock so callers see a coherent pair. Without this, a sync landing
+// between two separate getter calls could mix a fresh offset with a stale
+// timestamp on the same scrape.
+func (s *syncTime) ClockSnapshot() (offset time.Duration, lastSync time.Time) {
+	s.mut.RLock()
+	offset = s.clockOffset
+	lastSync = s.lastSyncTimestamp
+	s.mut.RUnlock()
+
+	return
+}
+
 // recordSyncSuccess updates offset and timestamp under a single lock so
 // /node/metrics scrapes can't observe a fresh offset paired with a stale
 // timestamp (or vice versa) mid-update.

--- a/ntp/syncTime.go
+++ b/ntp/syncTime.go
@@ -96,12 +96,13 @@ func queryNTP(options NTPOptions, hostIndex int) (*ntp.Response, error) {
 
 // syncTime defines an object for time synchronization
 type syncTime struct {
-	mut         sync.RWMutex
-	clockOffset time.Duration
-	syncPeriod  time.Duration
-	ntpOptions  NTPOptions
-	query       func(options NTPOptions, hostIndex int) (*ntp.Response, error)
-	cancelFunc  func()
+	mut               sync.RWMutex
+	clockOffset       time.Duration
+	lastSyncTimestamp time.Time
+	syncPeriod        time.Duration
+	ntpOptions        NTPOptions
+	query             func(options NTPOptions, hostIndex int) (*ntp.Response, error)
+	cancelFunc        func()
 }
 
 // NewSyncTime creates a syncTime object. The customQueryFunc argument allows the caller to set a different NTP-querying
@@ -162,11 +163,13 @@ func (s *syncTime) getSleepTime() time.Duration {
 // and servers time which have been used in synchronization
 func (s *syncTime) sync() {
 	clockOffsets := make([]time.Duration, 0)
+	queryFailures := 0
 	for hostIndex := 0; hostIndex < len(s.ntpOptions.Hosts); hostIndex++ {
 		for requests := 0; requests < numRequestsFromHost; requests++ {
 			response, err := s.query(s.ntpOptions, hostIndex)
 			if err != nil {
-				log.Debug("sync.query",
+				queryFailures++
+				log.Trace("sync.query",
 					"host", s.ntpOptions.Hosts[hostIndex],
 					"port", s.ntpOptions.Port,
 					"error", err.Error())
@@ -189,9 +192,11 @@ func (s *syncTime) sync() {
 	numTotalRequests := len(s.ntpOptions.Hosts) * numRequestsFromHost
 	minClockOffsetsToAllowUpdate := math.Ceil(float64(numTotalRequests) * minResponsesPercent / (1 - cuttingOutPercent))
 	if len(clockOffsets) < int(minClockOffsetsToAllowUpdate) {
-		log.Debug("sync.setClockOffset NOT done",
-			"clock offsets", len(clockOffsets),
-			"min clock offsets to allow update", int(minClockOffsetsToAllowUpdate))
+		log.Warn("ntp sync FAILED: insufficient responses",
+			"ok", len(clockOffsets),
+			"failed", queryFailures,
+			"total", numTotalRequests,
+			"min required", int(minClockOffsetsToAllowUpdate))
 
 		return
 	}
@@ -200,17 +205,21 @@ func (s *syncTime) sync() {
 	clockOffsetHarmonicMean := s.getHarmonicMean(clockOffsetsWithoutEdges)
 	isOutOfBounds := tools.AbsDuration(clockOffsetHarmonicMean)-outOfBoundsDuration > 0
 	if isOutOfBounds {
-		log.Error("syncTime.sync: clock offset is out of expected bounds",
-			"clock offset harmonic mean", clockOffsetHarmonicMean)
+		log.Error("ntp sync FAILED: offset out of bounds",
+			"ok", len(clockOffsets),
+			"failed", queryFailures,
+			"total", numTotalRequests,
+			"offset", clockOffsetHarmonicMean)
 
 		return
 	}
-	s.setClockOffset(clockOffsetHarmonicMean)
+	s.recordSyncSuccess(clockOffsetHarmonicMean, time.Now())
 
-	log.Debug("sync.setClockOffset done",
-		"num clock offsets", len(clockOffsets),
-		"num clock offsets without edges", len(clockOffsetsWithoutEdges),
-		"clock offset harmonic mean", clockOffsetHarmonicMean)
+	log.Debug("ntp sync OK",
+		"ok", len(clockOffsets),
+		"failed", queryFailures,
+		"total", numTotalRequests,
+		"offset", clockOffsetHarmonicMean)
 }
 
 func (s *syncTime) getClockOffsetsWithoutEdges(clockOffsets []time.Duration) []time.Duration {
@@ -260,6 +269,28 @@ func (s *syncTime) ClockOffset() time.Duration {
 func (s *syncTime) setClockOffset(clockOffset time.Duration) {
 	s.mut.Lock()
 	s.clockOffset = clockOffset
+	s.mut.Unlock()
+}
+
+// LastSyncTimestamp returns the wall-clock time of the most recent successful
+// sync. Zero-value time before the first success — exposed as metric value 0
+// so operators alarming on `time() - last_sync > threshold` only fire once a
+// sync has actually happened.
+func (s *syncTime) LastSyncTimestamp() time.Time {
+	s.mut.RLock()
+	ts := s.lastSyncTimestamp
+	s.mut.RUnlock()
+
+	return ts
+}
+
+// recordSyncSuccess updates offset and timestamp under a single lock so
+// /node/metrics scrapes can't observe a fresh offset paired with a stale
+// timestamp (or vice versa) mid-update.
+func (s *syncTime) recordSyncSuccess(offset time.Duration, at time.Time) {
+	s.mut.Lock()
+	s.clockOffset = offset
+	s.lastSyncTimestamp = at
 	s.mut.Unlock()
 }
 

--- a/ntp/syncTime_test.go
+++ b/ntp/syncTime_test.go
@@ -398,3 +398,33 @@ func TestLastSyncTimestampStampedOnSuccess(t *testing.T) {
 	assert.False(t, ts.Before(before), "timestamp must be set on or after the sync started")
 	assert.False(t, ts.After(after), "timestamp must not be set in the future")
 }
+
+func TestClockSnapshotReturnsConsistentPair(t *testing.T) {
+	t.Parallel()
+
+	// After a successful sync, ClockSnapshot must return the offset and
+	// timestamp written by that same sync — they're set together under one
+	// lock in recordSyncSuccess and must be read together for callers
+	// publishing them as paired metrics.
+	st := ntp.NewSyncTime(
+		config.NTPConfig{
+			SyncPeriodSeconds: 1,
+			Hosts:             []string{"host1"},
+		},
+		func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+			return &beevikNtp.Response{ClockOffset: 23456}, nil
+		},
+	)
+
+	offset, ts := st.ClockSnapshot()
+	assert.Equal(t, time.Duration(0), offset, "no sync yet, offset is zero")
+	assert.True(t, ts.IsZero(), "no sync yet, timestamp is zero")
+
+	st.Sync()
+
+	offset, ts = st.ClockSnapshot()
+	assert.Equal(t, time.Duration(23456), offset)
+	assert.False(t, ts.IsZero())
+	assert.Equal(t, st.ClockOffset(), offset, "snapshot offset must match individual getter")
+	assert.Equal(t, st.LastSyncTimestamp(), ts, "snapshot timestamp must match individual getter")
+}

--- a/ntp/syncTime_test.go
+++ b/ntp/syncTime_test.go
@@ -319,3 +319,82 @@ func TestCallQueryShouldNotUpdateOnOutOfBoundValuesNegative(t *testing.T) {
 
 	assert.Equal(t, currentValue, st.ClockOffset())
 }
+
+func TestLastSyncTimestampStartsAtZero(t *testing.T) {
+	t.Parallel()
+
+	st := ntp.NewSyncTime(config.NTPConfig{SyncPeriodSeconds: 1}, nil)
+
+	assert.True(t, st.LastSyncTimestamp().IsZero(),
+		"timestamp must be zero before first successful sync — the polling code "+
+			"checks IsZero() to publish 0 (operator alarms on `time() - value > threshold`)")
+}
+
+func TestLastSyncTimestampStaysZeroWhenAllQueriesFail(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the "i/o timeout" failure mode at startup: every UDP query fails.
+	// The metric must honestly say "this node has never synced" so operator
+	// alarms can fire.
+	st := ntp.NewSyncTime(
+		config.NTPConfig{
+			SyncPeriodSeconds: 1,
+			Hosts:             []string{"host1"},
+		},
+		func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+			return nil, errNtpMock
+		},
+	)
+
+	st.Sync()
+
+	assert.True(t, st.LastSyncTimestamp().IsZero(),
+		"unreachable NTP must not stamp a timestamp")
+}
+
+func TestLastSyncTimestampStaysZeroOnOutOfBoundsRejection(t *testing.T) {
+	t.Parallel()
+
+	// All queries returned but the harmonic mean was rejected (> 1s). No
+	// usable correction was produced, so the timestamp must not advance —
+	// otherwise the "sync stalled" alarm would silently clear on a rejected
+	// sync, hiding the broken state.
+	st := ntp.NewSyncTime(
+		config.NTPConfig{
+			SyncPeriodSeconds: 3600,
+			Hosts:             []string{"host1"},
+		},
+		func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+			return &beevikNtp.Response{
+				ClockOffset: ntp.OutOfBoundsDuration + time.Nanosecond,
+			}, nil
+		},
+	)
+
+	st.Sync()
+
+	assert.True(t, st.LastSyncTimestamp().IsZero())
+}
+
+func TestLastSyncTimestampStampedOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	st := ntp.NewSyncTime(
+		config.NTPConfig{
+			SyncPeriodSeconds: 1,
+			Hosts:             []string{"host1"},
+		},
+		func(options ntp.NTPOptions, hostIndex int) (*beevikNtp.Response, error) {
+			return &beevikNtp.Response{ClockOffset: 23456}, nil
+		},
+	)
+
+	before := time.Now()
+	st.Sync()
+	after := time.Now()
+
+	ts := st.LastSyncTimestamp()
+	assert.False(t, ts.IsZero())
+	assert.False(t, ts.Before(before), "timestamp must be set on or after the sync started")
+	assert.False(t, ts.After(after), "timestamp must not be set in the future")
+}


### PR DESCRIPTION
## Summary

Adds two Prometheus metrics that let operators detect clock issues that previously required hand-diffing log timestamps to diagnose:

- **`klv_clock_offset_ns`** — signed nanoseconds. Alarm: `abs(value) > consensus_tolerance`
- **`klv_clock_last_sync_timestamp`** — unix seconds, 0 before first sync. Alarm: `value > 0 AND time() - value > 2 × sync_period`

Together these cover both the original ticket case (drifting hardware, e.g. node `157.90.246.51` at -38ms generating 535 quorum warnings/day) and a separately observed failure mode (NTP unreachable at startup, `i/o timeout` on every query, validator silently running on raw OS clock).

## Why only 2 metrics

An initial 6-metric design (dispersion + sync_success_total + sync_failure_total + query_failure_total) was reduced to 2. Every metric in the final set drives an alarm. Counters that only get inspected *after* another alarm fires were dropped to avoid dashboard noise.

## Operational fixes bundled in

- `ntp.timeoutMilliseconds`: **100 → 500**. The 100ms value was inherited from MultiversX ([ElrondNetwork/elrond-go#542](https://github.com/ElrondNetwork/elrond-go/issues/542) reports the same symptoms) and is below the typical UDP round-trip to public NTP servers. 500ms is still **10× faster** than the `beevik/ntp` library's own 5s default and far below the 1s out-of-bounds rejection threshold. Worst-case sync = 20s in a background goroutine that then sleeps for 1 hour.
- `ntp/syncTime.go` sync log restructured: one `ntp sync OK` / `ntp sync FAILED` line per pass with `ok/failed/total + offset`, replacing 40 lines of per-attempt debug spam. Example:
  ```
  DEBUG ntp sync OK ok=39 failed=1 total=40 offset=49.6ms
  ```

## Notable implementation details

- `recordSyncSuccess()` writes offset + timestamp under a single lock so a `/node/metrics` scrape can't observe a fresh offset paired with a stale timestamp.
- `buildClockMetricsPollingFunc` special-cases `time.Time{}` → `uint64(0)` instead of the negative Unix epoch of the zero time, so alarms like `time() - value > threshold` filter correctly before the first sync.
- Polling primes synchronously before the background ticker starts, so the very first `/node/status` scrape returns real values, not zeros.
- New file `cmd/node/metrics/clockMetrics.go` follows the existing `StartNodeMetricsPolling` pattern. Wired into `backgroundClosers` alongside the other pollers.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 ./ntp/ ./cmd/node/metrics/ ./statusHandler/ ./core/consensus/...` — 0 failures
- [x] Wider sweep: `./cmd/... ./network/... ./integrationTest/...` — 47 packages, 0 failures
- [x] 13 new test functions cover: nil-arg validation, sign preservation for negative offsets, prime-before-tick, zero-timestamp-not-leaking-epoch, last-sync stamping on success only, end-to-end Prometheus output, end-to-end `/node/status` map output, and timestamp staying zero across both failure paths in `syncTime.sync()`.
- [x] Verified end-to-end on a real validator: log shows `ntp sync OK ok=39 failed=1 total=40 offset=49.6ms` after the timeout bump (39/40 success rate vs. the previous failure rate at 100ms). Metric value matched an independent `sntp` query to within sub-millisecond.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Adds observability metrics for NTP clock state with atomic snapshot guarantees

### Summary
This PR introduces two Prometheus metrics (`klv_clock_offset_ns` and `klv_clock_last_sync_timestamp`) to expose NTP-derived clock synchronization state, enabling in-band alarms for clock drift and NTP unreachability. The implementation adds an atomic snapshot API to prevent race conditions during metric scrapes, increases the NTP timeout to reduce spurious failures, and restructures sync logging. These changes are purely observability-focused and do not modify consensus or clock synchronization algorithms.

### Blockchain-Critical Components Affected

**NTP Clock Synchronization** (consensus prerequisite):
- Extended `ntp.SyncTimer` interface with `LastSyncTimestamp() time.Time` and `ClockSnapshot()` methods
- Added atomic `ClockSnapshot()` method in `ntp/syncTime.go` that returns coherent `(offset, lastSync)` pairs under a single `RLock`, preventing metric scrapes from observing mismatched timestamp and offset values across two separate reads
- Updated `ntp/syncTime.go` to record `lastSyncTimestamp` on successful syncs and track per-cycle query success/failure counts  
- New `recordSyncSuccess()` helper updates both `clockOffset` and `lastSyncTimestamp` under a single `Unlock()` operation to maintain atomicity
- **Rationale**: Atomic snapshots prevent alarms from seeing stale or partially-updated clock state, which could lead to false positives in downstream monitoring

**Clock Offset Observability** (consensus-relevant):
- Exposed signed nanosecond offset as `MetricClockOffsetNs` for drift monitoring
- Exposed unix-seconds last-sync timestamp as `MetricClockLastSyncTimestamp` (publishes 0 before first success) to detect when NTP is unreachable at startup
- Validates that negative Unix timestamps (pre-1970) wrap to 0 to avoid overflow in unsigned metric representation

### Node Stability & Data Integrity

**NTP Timeout Increase**:
- Raised `ntp.timeoutMilliseconds` from 100ms → 500ms in both `config/node/config.yaml` and `integrationTest/config/config.yaml`
- Reduces spurious UDP timeouts while maintaining worst-case background sync duration ≤20 seconds, improving sync reliability without affecting consensus participation latency

**Sync Logging Restructuring**:
- Consolidated per-attempt spam into one summary line per sync cycle (e.g., "ntp sync OK ok=39 failed=1 total=40 offset=49.6ms"), improving operational clarity without changing sync behavior

**Startup Initialization**:
- Clock metrics are primed synchronously before the background polling ticker starts, ensuring initial `/node/status` and Prometheus scrapes return real values rather than uninitialized zeros
- Polling closer is registered in `backgroundClosers` list for graceful shutdown

### Cross-Cutting Concerns

**Concurrency Safety**:
- New `ClockSnapshot()` method uses a single `RLock` to atomically capture both offset and timestamp, preventing race conditions where offset and timestamp could drift apart during concurrent metric reads
- The polling implementation calls `ClockSnapshot()` exclusively, never making separate calls to `ClockOffset()` and `LastSyncTimestamp()` — test suite verifies this invariant
- `recordSyncSuccess()` updates both state fields under a single lock acquisition to guarantee atomicity

**Error Handling**:
- New `StartClockMetricsPolling()` function validates nil `AppStatusHandler` and `SyncTimer` arguments, plus non-positive polling intervals, returning wrapped errors on failure
- Sync loop now tracks per-cycle query failures and logs diagnostic counts (ok/failed/total) in warn/error messages

**Integration**:
- Clock metrics polling is wired into `backgroundClosers` in `cmd/node/startup.go` to ensure graceful shutdown alongside other polling components
- Updated `core/consensus/mock/syncTimerMock.go` with `LastSyncTimestamp()` and `ClockSnapshot()` stubs for test compatibility

### Test Coverage
13 new test functions verify nil-argument validation, sign preservation for negative offsets, zero-timestamp behavior before first sync, atomic snapshot consistency, negative-Unix-seconds guard, Prometheus text output formatting, and JSON status-map output—all passing alongside existing test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->