### PR TITLE
[KLC-2355] interceptors: use errors.Is for sentinel comparisons

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,14 @@ linters:
     - staticcheck
     - ineffassign
     - errcheck
+    - errorlint
+  settings:
+    errorlint:
+      # Only catch err==sentinel / err!=sentinel patterns. Leave fmt.Errorf
+      # %w hygiene and type-assertion checks alone to keep this PR focused.
+      comparison: true
+      asserts: false
+      errorf: false
   exclusions:
     generated: strict
     rules:

--- a/core/kapp/accounts/accounts.go
+++ b/core/kapp/accounts/accounts.go
@@ -1559,7 +1559,7 @@ func (a *accountsKapp) ClaimStaking(sender []byte, tc *transaction.ClaimContract
 	if err != nil {
 		ctx.Receipts().AddError(ctx.ContractID(), common.ErrFieldClaimNotAvailable, err.Error())
 		var resultCode transaction.Transaction_TXResultCode
-		if err == common.ErrMaxSupplyExceeded {
+		if errors.Is(err, common.ErrMaxSupplyExceeded) {
 			resultCode = transaction.Transaction_MaxSupplyExceeded
 		} else {
 			resultCode = transaction.Transaction_ClaimError
@@ -1686,7 +1686,7 @@ func (a *accountsKapp) ClaimAllowance(sender []byte, tc *transaction.ClaimContra
 	if err != nil {
 		ctx.Receipts().AddError(ctx.ContractID(), common.ErrFieldClaimNotAvailable, err.Error())
 		resultCode := transaction.Transaction_ClaimError
-		if err == common.ErrMaxSupplyExceeded {
+		if errors.Is(err, common.ErrMaxSupplyExceeded) {
 			resultCode = transaction.Transaction_MaxSupplyExceeded
 		}
 		return resultCode, err

--- a/core/kapp/accounts/accounts.go
+++ b/core/kapp/accounts/accounts.go
@@ -1558,13 +1558,7 @@ func (a *accountsKapp) ClaimStaking(sender []byte, tc *transaction.ClaimContract
 	gains, err := a.ClaimBalance(transaction.ClaimContract_StakingClaim, assetID, ctx.Block(), ownerAcc, staking, kda, userKDA)
 	if err != nil {
 		ctx.Receipts().AddError(ctx.ContractID(), common.ErrFieldClaimNotAvailable, err.Error())
-		var resultCode transaction.Transaction_TXResultCode
-		if errors.Is(err, common.ErrMaxSupplyExceeded) {
-			resultCode = transaction.Transaction_MaxSupplyExceeded
-		} else {
-			resultCode = transaction.Transaction_ClaimError
-		}
-		return resultCode, err
+		return claimErrorResultCode(err, transaction.Transaction_ClaimError), err
 	}
 
 	validClaims := 0
@@ -1685,11 +1679,7 @@ func (a *accountsKapp) ClaimAllowance(sender []byte, tc *transaction.ClaimContra
 	gains, err := a.ClaimBalance(transaction.ClaimContract_AllowanceClaim, kdautils.KLVIdentifier, ctx.Block(), ownerAcc, nil, nil, userKDA)
 	if err != nil {
 		ctx.Receipts().AddError(ctx.ContractID(), common.ErrFieldClaimNotAvailable, err.Error())
-		resultCode := transaction.Transaction_ClaimError
-		if errors.Is(err, common.ErrMaxSupplyExceeded) {
-			resultCode = transaction.Transaction_MaxSupplyExceeded
-		}
-		return resultCode, err
+		return claimErrorResultCode(err, transaction.Transaction_ClaimError), err
 	}
 
 	for key, value := range gains {
@@ -1928,4 +1918,14 @@ func claimAddress(interestType kapps.StakingData_EnumInterestType) []byte {
 	}
 	// return StakingKApp address
 	return kapps.StakingKAppAddress
+}
+
+// claimErrorResultCode maps a ClaimBalance failure to a transaction result code.
+// ErrMaxSupplyExceeded surfaces a dedicated code so it can be distinguished from
+// generic claim errors by downstream receipts and clients.
+func claimErrorResultCode(err error, defaultCode transaction.Transaction_TXResultCode) transaction.Transaction_TXResultCode {
+	if errors.Is(err, common.ErrMaxSupplyExceeded) {
+		return transaction.Transaction_MaxSupplyExceeded
+	}
+	return defaultCode
 }

--- a/core/kapp/accounts/accounts_test.go
+++ b/core/kapp/accounts/accounts_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 
@@ -5502,4 +5503,143 @@ func Test_ClaimStaking_LoadAccountError(t *testing.T) {
 	code, err := accountsKapp.ClaimStaking(txSender, tc)
 	require.Error(t, err)
 	assert.Equal(t, transaction.Transaction_LoadAccountError, code)
+}
+
+func Test_ClaimStaking_MaxSupplyExceeded(t *testing.T) {
+	accountsKapp := setupAccountsKapp(t, config.EnableEpochs{})
+
+	receiptsCtx := &commonMock.ReceiptsContextStub{}
+	ctx := &commonMock.KAppContextStub{
+		ReceiptsCalled:   func() kapp.ReceiptsContext { return receiptsCtx },
+		ContractIDCalled: func() int { return 1 },
+		BlockCalled: func() *block.Block {
+			return &block.Block{Header: &block.BlockHeader{Timestamp: 1000, Epoch: 1}}
+		},
+	}
+
+	_ = accountsKapp.SetKAppController(&kvmStub.KAppControllerStub{
+		GetCurrentKAppContextCalled: func() kapp.KappContext { return ctx },
+		GetKDAKAppCalled: func() kapp.KDAKapp {
+			return &kvmStub.KDAKappStub{
+				GetStakingCalled: func(assetID []byte) (state.KAppAccountHandler, *kapps.StakingData, error) {
+					return nil, &kapps.StakingData{}, nil
+				},
+				GetKDACalled: func(assetID []byte) (state.KAppAccountHandler, *kapps.KDAData, error) {
+					return nil, &kapps.KDAData{AssetType: kapps.KDAData_Fungible}, nil
+				},
+			}
+		},
+	})
+
+	_ = accountsKapp.SetAccountsCacher(&commonMock.AccountsCacherStub{
+		GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+			return &commonMock.UserAccountHandlerStub{
+				GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+					return &kapps.UserKDA{}, nil
+				},
+				ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+					return nil, common.ErrMaxSupplyExceeded
+				},
+			}, nil
+		},
+	})
+
+	tc := &transaction.ClaimContract{
+		ClaimType: transaction.ClaimContract_StakingClaim,
+		ID:        kdautils.KLVIdentifier,
+	}
+
+	code, err := accountsKapp.ClaimStaking(txSender, tc)
+	require.ErrorIs(t, err, common.ErrMaxSupplyExceeded)
+	assert.Equal(t, transaction.Transaction_MaxSupplyExceeded, code)
+}
+
+func Test_ClaimStaking_MaxSupplyExceeded_Wrapped(t *testing.T) {
+	accountsKapp := setupAccountsKapp(t, config.EnableEpochs{})
+	wrapped := fmt.Errorf("ctx: %w", common.ErrMaxSupplyExceeded)
+
+	receiptsCtx := &commonMock.ReceiptsContextStub{}
+	ctx := &commonMock.KAppContextStub{
+		ReceiptsCalled:   func() kapp.ReceiptsContext { return receiptsCtx },
+		ContractIDCalled: func() int { return 1 },
+		BlockCalled: func() *block.Block {
+			return &block.Block{Header: &block.BlockHeader{Timestamp: 1000, Epoch: 1}}
+		},
+	}
+
+	_ = accountsKapp.SetKAppController(&kvmStub.KAppControllerStub{
+		GetCurrentKAppContextCalled: func() kapp.KappContext { return ctx },
+		GetKDAKAppCalled: func() kapp.KDAKapp {
+			return &kvmStub.KDAKappStub{
+				GetStakingCalled: func(assetID []byte) (state.KAppAccountHandler, *kapps.StakingData, error) {
+					return nil, &kapps.StakingData{}, nil
+				},
+				GetKDACalled: func(assetID []byte) (state.KAppAccountHandler, *kapps.KDAData, error) {
+					return nil, &kapps.KDAData{AssetType: kapps.KDAData_Fungible}, nil
+				},
+			}
+		},
+	})
+
+	_ = accountsKapp.SetAccountsCacher(&commonMock.AccountsCacherStub{
+		GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+			return &commonMock.UserAccountHandlerStub{
+				GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
+					return &kapps.UserKDA{}, nil
+				},
+				ClaimCalled: func(claimType transaction.ClaimContract_EnumClaimType, assetID []byte, epoch uint32, blockTime int64, staking *kapps.StakingData, kda *kapps.KDAData, userKDA *kapps.UserKDA, forkController core.ForkController) (map[string]int64, error) {
+					return nil, wrapped
+				},
+			}, nil
+		},
+	})
+
+	tc := &transaction.ClaimContract{
+		ClaimType: transaction.ClaimContract_StakingClaim,
+		ID:        kdautils.KLVIdentifier,
+	}
+
+	code, err := accountsKapp.ClaimStaking(txSender, tc)
+	require.ErrorIs(t, err, common.ErrMaxSupplyExceeded)
+	assert.Equal(t, transaction.Transaction_MaxSupplyExceeded, code)
+}
+
+func Test_claimErrorResultCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		fallback transaction.Transaction_TXResultCode
+		want     transaction.Transaction_TXResultCode
+	}{
+		{
+			name:     "direct ErrMaxSupplyExceeded -> MaxSupplyExceeded",
+			err:      common.ErrMaxSupplyExceeded,
+			fallback: transaction.Transaction_ClaimError,
+			want:     transaction.Transaction_MaxSupplyExceeded,
+		},
+		{
+			name:     "wrapped ErrMaxSupplyExceeded -> MaxSupplyExceeded",
+			err:      errWrap("ctx", common.ErrMaxSupplyExceeded),
+			fallback: transaction.Transaction_ClaimError,
+			want:     transaction.Transaction_MaxSupplyExceeded,
+		},
+		{
+			name:     "unrelated error -> fallback",
+			err:      errors.New("something else"),
+			fallback: transaction.Transaction_ClaimError,
+			want:     transaction.Transaction_ClaimError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, claimErrorResultCode(tt.err, tt.fallback))
+		})
+	}
+}
+
+func errWrap(msg string, err error) error {
+	return fmt.Errorf("%s: %w", msg, err)
 }

--- a/core/kapp/accounts/accounts_test.go
+++ b/core/kapp/accounts/accounts_test.go
@@ -5517,7 +5517,7 @@ func Test_ClaimStaking_MaxSupplyExceeded(t *testing.T) {
 		},
 	}
 
-	_ = accountsKapp.SetKAppController(&kvmStub.KAppControllerStub{
+	require.NoError(t, accountsKapp.SetKAppController(&kvmStub.KAppControllerStub{
 		GetCurrentKAppContextCalled: func() kapp.KappContext { return ctx },
 		GetKDAKAppCalled: func() kapp.KDAKapp {
 			return &kvmStub.KDAKappStub{
@@ -5529,9 +5529,9 @@ func Test_ClaimStaking_MaxSupplyExceeded(t *testing.T) {
 				},
 			}
 		},
-	})
+	}))
 
-	_ = accountsKapp.SetAccountsCacher(&commonMock.AccountsCacherStub{
+	require.NoError(t, accountsKapp.SetAccountsCacher(&commonMock.AccountsCacherStub{
 		GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
 			return &commonMock.UserAccountHandlerStub{
 				GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
@@ -5542,7 +5542,7 @@ func Test_ClaimStaking_MaxSupplyExceeded(t *testing.T) {
 				},
 			}, nil
 		},
-	})
+	}))
 
 	tc := &transaction.ClaimContract{
 		ClaimType: transaction.ClaimContract_StakingClaim,
@@ -5567,7 +5567,7 @@ func Test_ClaimStaking_MaxSupplyExceeded_Wrapped(t *testing.T) {
 		},
 	}
 
-	_ = accountsKapp.SetKAppController(&kvmStub.KAppControllerStub{
+	require.NoError(t, accountsKapp.SetKAppController(&kvmStub.KAppControllerStub{
 		GetCurrentKAppContextCalled: func() kapp.KappContext { return ctx },
 		GetKDAKAppCalled: func() kapp.KDAKapp {
 			return &kvmStub.KDAKappStub{
@@ -5579,9 +5579,9 @@ func Test_ClaimStaking_MaxSupplyExceeded_Wrapped(t *testing.T) {
 				},
 			}
 		},
-	})
+	}))
 
-	_ = accountsKapp.SetAccountsCacher(&commonMock.AccountsCacherStub{
+	require.NoError(t, accountsKapp.SetAccountsCacher(&commonMock.AccountsCacherStub{
 		GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
 			return &commonMock.UserAccountHandlerStub{
 				GetUserKDACalled: func(assetID, nonce []byte, checkDirtData bool) (*kapps.UserKDA, error) {
@@ -5592,7 +5592,7 @@ func Test_ClaimStaking_MaxSupplyExceeded_Wrapped(t *testing.T) {
 				},
 			}, nil
 		},
-	})
+	}))
 
 	tc := &transaction.ClaimContract{
 		ClaimType: transaction.ClaimContract_StakingClaim,

--- a/core/kapp/kda/trigger.go
+++ b/core/kapp/kda/trigger.go
@@ -3,6 +3,7 @@ package kda
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -747,7 +748,7 @@ func (k *kdaKapp) processSplitRoyalties(tc *transaction.AssetTriggerContract) (m
 }
 
 func processErrorCode(err error) (transaction.Transaction_TXResultCode, error) {
-	if err == common.ErrInvalidValue {
+	if errors.Is(err, common.ErrInvalidValue) {
 		return transaction.Transaction_ParameterInvalid, err
 	}
 

--- a/core/kapp/kdaFeesPool/actions.go
+++ b/core/kapp/kdaFeesPool/actions.go
@@ -2,6 +2,7 @@ package kdafeespool
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -109,7 +110,7 @@ func (v *kdaFeesPoolKApp) ChangePoolOwner(assetID []byte, sender []byte, newOwne
 
 	pool, err := v.getPool(app, assetID)
 	if err != nil {
-		if err == common.ErrAssetPoolNotFound {
+		if errors.Is(err, common.ErrAssetPoolNotFound) {
 			return transaction.Transaction_Ok, nil
 		}
 		ctx.Receipts().AddError(ctx.ContractID(), common.ErrFieldAssetNotFound, err.Error())

--- a/core/kapp/systemAccount/systemAcount.go
+++ b/core/kapp/systemAccount/systemAcount.go
@@ -1,6 +1,8 @@
 package systemAccount
 
 import (
+	"errors"
+
 	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
@@ -142,7 +144,7 @@ func (s *systemAccountKApp) SFTAddCirculation(asset, nonce []byte, amount int64)
 
 func (s *systemAccountKApp) SFTGetMeta(asset, nonce []byte) (*kapps.MetaV2, error) {
 	data, err := s.getKDAData(asset, nonce)
-	if err == common.ErrNilTrie {
+	if errors.Is(err, common.ErrNilTrie) {
 		return &kapps.MetaV2{Metadata: &kapps.MetaV2Data{}}, nil
 	}
 

--- a/core/kapp/systemAccount/systemAcount_test.go
+++ b/core/kapp/systemAccount/systemAcount_test.go
@@ -25,11 +25,11 @@ func TestSFTGetMeta_NilTrieReturnsEmptyMeta(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			s := &systemAccountKApp{}
-			_ = s.SetAccountsCacher(&commonMock.AccountsCacherStub{
+			require.NoError(t, s.SetAccountsCacher(&commonMock.AccountsCacherStub{
 				LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
 					return nil, c.err
 				},
-			})
+			}))
 
 			meta, err := s.SFTGetMeta([]byte("ASSET"), nil)
 			require.NoError(t, err)
@@ -44,11 +44,11 @@ func TestSFTGetMeta_OtherErrorPropagates(t *testing.T) {
 
 	other := errors.New("disk failure")
 	s := &systemAccountKApp{}
-	_ = s.SetAccountsCacher(&commonMock.AccountsCacherStub{
+	require.NoError(t, s.SetAccountsCacher(&commonMock.AccountsCacherStub{
 		LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
 			return nil, other
 		},
-	})
+	}))
 
 	meta, err := s.SFTGetMeta([]byte("ASSET"), nil)
 	assert.Nil(t, meta)

--- a/core/kapp/systemAccount/systemAcount_test.go
+++ b/core/kapp/systemAccount/systemAcount_test.go
@@ -1,0 +1,57 @@
+package systemAccount
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/klever-io/klever-go/common"
+	commonMock "github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/data/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSFTGetMeta_NilTrieReturnsEmptyMeta(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"direct ErrNilTrie", common.ErrNilTrie},
+		{"wrapped ErrNilTrie", fmt.Errorf("load: %w", common.ErrNilTrie)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &systemAccountKApp{}
+			_ = s.SetAccountsCacher(&commonMock.AccountsCacherStub{
+				LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
+					return nil, c.err
+				},
+			})
+
+			meta, err := s.SFTGetMeta([]byte("ASSET"), nil)
+			require.NoError(t, err)
+			require.NotNil(t, meta)
+			require.NotNil(t, meta.Metadata)
+		})
+	}
+}
+
+func TestSFTGetMeta_OtherErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	other := errors.New("disk failure")
+	s := &systemAccountKApp{}
+	_ = s.SetAccountsCacher(&commonMock.AccountsCacherStub{
+		LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
+			return nil, other
+		},
+	})
+
+	meta, err := s.SFTGetMeta([]byte("ASSET"), nil)
+	assert.Nil(t, meta)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, other))
+}

--- a/core/process/interceptors/multiDataInterceptor.go
+++ b/core/process/interceptors/multiDataInterceptor.go
@@ -1,6 +1,8 @@
 package interceptors
 
 import (
+	"errors"
+
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/data/batch"
@@ -224,7 +226,8 @@ func (mdi *MultiDataInterceptor) interceptedData(dataBuff []byte, originator cor
 	if err != nil {
 		mdi.processDebugInterceptedData(interceptedData, err)
 
-		isWrongVersion := err == process.ErrInvalidTransactionVersion || err == process.ErrInvalidChainID
+		isWrongVersion := errors.Is(err, process.ErrInvalidTransactionVersion) ||
+			errors.Is(err, process.ErrInvalidChainID)
 		if isWrongVersion {
 			//this situation is so severe that we need to black list de peers
 			reason := "wrong version of received intercepted data, topic " + mdi.topic + ", error " + err.Error()

--- a/core/process/interceptors/multiDataInterceptor_test.go
+++ b/core/process/interceptors/multiDataInterceptor_test.go
@@ -421,6 +421,20 @@ func TestMultiDataInterceptor_InvalidTxChainIDShouldBackList(t *testing.T) {
 	processReceivedMessageMultiDataInvalidVersion(t, process.ErrInvalidChainID)
 }
 
+func TestMultiDataInterceptor_WrappedInvalidTxVersionShouldBackList(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("intercepted-tx: %w", process.ErrInvalidTransactionVersion)
+	processReceivedMessageMultiDataInvalidVersion(t, wrapped)
+}
+
+func TestMultiDataInterceptor_WrappedInvalidChainIDShouldBackList(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("intercepted-tx: %w", process.ErrInvalidChainID)
+	processReceivedMessageMultiDataInvalidVersion(t, wrapped)
+}
+
 func processReceivedMessageMultiDataInvalidVersion(t *testing.T, expectedErr error) {
 	buffData := [][]byte{[]byte("buff1"), []byte("buff2")}
 	marshalizer := &mock.MarshalizerMock{}

--- a/core/process/interceptors/singleDataInterceptor.go
+++ b/core/process/interceptors/singleDataInterceptor.go
@@ -1,6 +1,8 @@
 package interceptors
 
 import (
+	"errors"
+
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/network/p2p"
@@ -116,7 +118,8 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P,
 	if err != nil {
 		sdi.processDebugInterceptedData(interceptedData, err)
 
-		isWrongVersion := err == process.ErrInvalidTransactionVersion || err == process.ErrInvalidChainID
+		isWrongVersion := errors.Is(err, process.ErrInvalidTransactionVersion) ||
+			errors.Is(err, process.ErrInvalidChainID)
 		if isWrongVersion {
 			//this situation is so severe that we need to black list de peers
 			reason := "wrong version of received intercepted data, topic " + sdi.topic + ", error " + err.Error()

--- a/core/process/interceptors/singleDataInterceptor_test.go
+++ b/core/process/interceptors/singleDataInterceptor_test.go
@@ -2,6 +2,7 @@ package interceptors_test
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -297,7 +298,21 @@ func TestSingleDataInterceptor_InvalidTxVersionShouldBlackList(t *testing.T) {
 func TestSingleDataInterceptor_InvalidTxChainIDShouldBlackList(t *testing.T) {
 	t.Parallel()
 
-	processReceivedMessageSingleDataInvalidVersion(t, process.ErrInvalidTransactionVersion)
+	processReceivedMessageSingleDataInvalidVersion(t, process.ErrInvalidChainID)
+}
+
+func TestSingleDataInterceptor_WrappedInvalidTxVersionShouldBlackList(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("intercepted-tx: %w", process.ErrInvalidTransactionVersion)
+	processReceivedMessageSingleDataInvalidVersion(t, wrapped)
+}
+
+func TestSingleDataInterceptor_WrappedInvalidChainIDShouldBlackList(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("intercepted-tx: %w", process.ErrInvalidChainID)
+	processReceivedMessageSingleDataInvalidVersion(t, wrapped)
 }
 
 func processReceivedMessageSingleDataInvalidVersion(t *testing.T, expectedErr error) {

--- a/core/process/smartContract/hooks/blockChainHook.go
+++ b/core/process/smartContract/hooks/blockChainHook.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 	"path"
@@ -230,7 +231,7 @@ func (bh *BlockChainHookImpl) GetStorageData(accountAddress []byte, index []byte
 	}
 
 	userAcc, err := bh.GetUserAccount(accountAddress)
-	if err == common.ErrAccNotFound {
+	if errors.Is(err, common.ErrAccNotFound) {
 		return make([]byte, 0), 0, nil
 	}
 	if err != nil {

--- a/core/process/smartContract/hooks/blockChainHook_test.go
+++ b/core/process/smartContract/hooks/blockChainHook_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klever-io/klever-go/common"
 	commonMock "github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/config"
 	"github.com/klever-io/klever-go/core"
@@ -34,6 +35,7 @@ import (
 	"github.com/klever-io/klever-go/storage/memorydb"
 	"github.com/klever-io/klever-go/storage/storageUnit"
 	"github.com/klever-io/klever-go/tools/marshal"
+	"github.com/klever-io/klever-go/vmcommon"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -711,6 +713,51 @@ func TestBlockChainHookImpl_GetKDAToken(t *testing.T) {
 			}
 			assert.Equal(t, tt.expectedKDA, actualKDA)
 			assert.Equal(t, tt.expectedUserKDA, actualUserKDA)
+		})
+	}
+}
+
+// blockChainHookCounterPassthroughStub is a minimal BlockChainHookCounter that
+// reports no errors and no-ops everything else, used to isolate higher-layer
+// branches under test.
+type blockChainHookCounterPassthroughStub struct{}
+
+func (s *blockChainHookCounterPassthroughStub) ProcessCrtNumberOfTrieReadsCounter() error {
+	return nil
+}
+func (s *blockChainHookCounterPassthroughStub) ProcessMaxBuiltInCounters(_ *vmcommon.ContractCallInput) error {
+	return nil
+}
+func (s *blockChainHookCounterPassthroughStub) ResetCounters()                       {}
+func (s *blockChainHookCounterPassthroughStub) SetMaximumValues(_ map[string]uint64) {}
+func (s *blockChainHookCounterPassthroughStub) GetCounterValues() map[string]uint64  { return nil }
+func (s *blockChainHookCounterPassthroughStub) IsInterfaceNil() bool                 { return s == nil }
+
+func TestGetStorageData_AccNotFoundReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"direct ErrAccNotFound", common.ErrAccNotFound},
+		{"wrapped ErrAccNotFound", fmt.Errorf("load: %w", common.ErrAccNotFound)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bh := &BlockChainHookImpl{
+				counter: &blockChainHookCounterPassthroughStub{},
+				accountsCacher: &commonMock.AccountsCacherStub{
+					GetExistingUserCalled: func(address []byte) (state.UserAccountHandler, error) {
+						return nil, c.err
+					},
+				},
+			}
+
+			value, code, err := bh.GetStorageData([]byte("addr"), []byte("key"))
+			assert.NoError(t, err)
+			assert.Equal(t, uint32(0), code)
+			assert.Equal(t, []byte{}, value)
 		})
 	}
 }

--- a/kvm/mock/world/worldCallbacks.go
+++ b/kvm/mock/world/worldCallbacks.go
@@ -66,7 +66,7 @@ func (b *MockWorld) GetStorageData(accountAddress []byte, key []byte) ([]byte, u
 	}
 
 	value, err := userAcc.DataTrieTracker().RetrieveValue(key)
-	if err == common.ErrNilTrie {
+	if errors.Is(err, common.ErrNilTrie) {
 		return make([]byte, 0), 0, nil
 
 	}

--- a/kvm/vmhost/hostCore/host.go
+++ b/kvm/vmhost/hostCore/host.go
@@ -2,6 +2,7 @@ package hostCore
 
 import (
 	"context"
+	"errors"
 	"math"
 	"runtime/debug"
 	"sync"
@@ -492,7 +493,7 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 		elapsedTime := time.Since(startTime)
 		log.Trace("RunSmartContractCreate execTime",
 			"time [ms]", elapsedTime.Milliseconds(),
-			"timedOut", err == vmhost.ErrExecutionFailedWithTimeout)
+			"timedOut", errors.Is(err, vmhost.ErrExecutionFailedWithTimeout))
 	}()
 
 	done := make(chan struct{})
@@ -565,7 +566,7 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 		log.Trace("RunSmartContractCall execTime",
 			"function", input.Function,
 			"time [ms]", elapsedTime.Milliseconds(),
-			"timedOut", err == vmhost.ErrExecutionFailedWithTimeout)
+			"timedOut", errors.Is(err, vmhost.ErrExecutionFailedWithTimeout))
 	}()
 
 	done := make(chan struct{})

--- a/node/nodeAccount.go
+++ b/node/nodeAccount.go
@@ -27,7 +27,7 @@ func (n *Node) GetAccount(address string) (state.UserAccountHandler, error) {
 
 	accWrp, err := n.accounts.GetExistingAccount(addr)
 	if err != nil {
-		if err == common.ErrAccNotFound {
+		if errors.Is(err, common.ErrAccNotFound) {
 			return state.NewUserAccount(addr)
 		}
 		return nil, errors.New("could not fetch sender address from provided param: " + err.Error())
@@ -70,7 +70,7 @@ func (n *Node) GetNextNonce(address string) (uint64, uint64, uint64, error) {
 
 	accWrp, err := n.accounts.GetExistingAccount(addr)
 	if err != nil {
-		if err == common.ErrAccNotFound {
+		if errors.Is(err, common.ErrAccNotFound) {
 			return 0, 0, 0, nil
 		}
 		return 0, 0, 0, errors.New("could not fetch sender address from provided param: " + err.Error())

--- a/node/nodeAccount.go
+++ b/node/nodeAccount.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
@@ -30,7 +31,7 @@ func (n *Node) GetAccount(address string) (state.UserAccountHandler, error) {
 		if errors.Is(err, common.ErrAccNotFound) {
 			return state.NewUserAccount(addr)
 		}
-		return nil, errors.New("could not fetch sender address from provided param: " + err.Error())
+		return nil, fmt.Errorf("could not fetch sender address from provided param: %w", err)
 	}
 
 	account, ok := n.castAccountToUserAccount(accWrp)
@@ -73,7 +74,7 @@ func (n *Node) GetNextNonce(address string) (uint64, uint64, uint64, error) {
 		if errors.Is(err, common.ErrAccNotFound) {
 			return 0, 0, 0, nil
 		}
-		return 0, 0, 0, errors.New("could not fetch sender address from provided param: " + err.Error())
+		return 0, 0, 0, fmt.Errorf("could not fetch sender address from provided param: %w", err)
 	}
 
 	accNonce := accWrp.GetNonce()

--- a/node/nodeAccount_test.go
+++ b/node/nodeAccount_test.go
@@ -2,6 +2,7 @@ package node_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/klever-io/klever-go/common"
@@ -281,6 +282,93 @@ func TestGetAccount(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, addToAllowanceCalled, "AddToAllowance should not be called when pending rewards is 0")
 	})
+
+	t.Run("returns new account when ErrAccNotFound (also via wrapped error)", func(t *testing.T) {
+		cases := []struct {
+			name string
+			err  error
+		}{
+			{"direct sentinel", common.ErrAccNotFound},
+			{"wrapped sentinel", fmt.Errorf("lookup: %w", common.ErrAccNotFound)},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				accDB := &mock.AccountsStub{
+					GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+						return nil, c.err
+					},
+				}
+				n, err := createNodeWithKAppController(t, accDB, &stub.KAppControllerStub{})
+				require.NoError(t, err)
+
+				account, err := n.GetAccount("AABB")
+				require.NoError(t, err)
+				require.NotNil(t, account)
+			})
+		}
+	})
+
+	t.Run("wraps non-sentinel errors with %w", func(t *testing.T) {
+		underlying := errors.New("disk failure")
+		accDB := &mock.AccountsStub{
+			GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+				return nil, underlying
+			},
+		}
+		n, err := createNodeWithKAppController(t, accDB, &stub.KAppControllerStub{})
+		require.NoError(t, err)
+
+		account, err := n.GetAccount("AABB")
+		require.Nil(t, account)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, underlying), "underlying error must remain in the chain")
+	})
+}
+
+func TestGetNextNonce_AccountNotFound(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"direct sentinel", common.ErrAccNotFound},
+		{"wrapped sentinel", fmt.Errorf("lookup: %w", common.ErrAccNotFound)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			accDB := &mock.AccountsStub{
+				GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+					return nil, c.err
+				},
+			}
+			n, err := createNodeWithKAppController(t, accDB, &stub.KAppControllerStub{})
+			require.NoError(t, err)
+
+			nonce, firstPending, numPending, err := n.GetNextNonce("AABB")
+			require.NoError(t, err)
+			require.Zero(t, nonce)
+			require.Zero(t, firstPending)
+			require.Zero(t, numPending)
+		})
+	}
+}
+
+func TestGetNextNonce_WrapsNonSentinelError(t *testing.T) {
+	t.Parallel()
+
+	underlying := errors.New("disk failure")
+	accDB := &mock.AccountsStub{
+		GetExistingAccountCalled: func(address []byte) (state.AccountHandler, error) {
+			return nil, underlying
+		},
+	}
+	n, err := createNodeWithKAppController(t, accDB, &stub.KAppControllerStub{})
+	require.NoError(t, err)
+
+	_, _, _, err = n.GetNextNonce("AABB")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, underlying), "underlying error must remain in the chain")
 }
 
 func TestGetAvailableClaim(t *testing.T) {

--- a/storage/latestData/latestDataProvider.go
+++ b/storage/latestData/latestDataProvider.go
@@ -2,6 +2,7 @@ package latestData
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -77,7 +78,7 @@ func (ldp *latestDataProvider) Get() (storage.LatestDataFromStorage, error) {
 	}
 
 	ldfs, err := ldp.getLastEpochAndSlotFromStorage(parentDir, lastEpoch)
-	if err == storage.ErrBootstrapDataNotFoundInStorage && lastEpoch > 0 {
+	if errors.Is(err, storage.ErrBootstrapDataNotFoundInStorage) && lastEpoch > 0 {
 		// retry with epoch before
 		return ldp.getLastEpochAndSlotFromStorage(parentDir, lastEpoch-1)
 	}

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -2,6 +2,7 @@ package leveldb
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -144,7 +145,7 @@ func (s *DB) Get(key []byte) ([]byte, error) {
 	}
 
 	data, err := s.db.Get(key, nil)
-	if err == leveldb.ErrNotFound {
+	if errors.Is(err, leveldb.ErrNotFound) {
 		return nil, storage.ErrKeyNotFound
 	}
 	if err != nil {

--- a/storage/leveldb/leveldbSerial.go
+++ b/storage/leveldb/leveldbSerial.go
@@ -3,6 +3,7 @@ package leveldb
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -155,7 +156,7 @@ func (s *SerialDB) Get(key []byte) ([]byte, error) {
 	result := <-ch
 	close(ch)
 
-	if result.err == leveldb.ErrNotFound {
+	if errors.Is(result.err, leveldb.ErrNotFound) {
 		return nil, storage.ErrKeyNotFound
 	}
 	if result.err != nil {


### PR DESCRIPTION
## Summary

Replaces `==` with `errors.Is` for sentinel error comparisons in the P2P interceptors and across the rest of the codebase. Fixes a latent security issue in the wrong-version blacklist: future `%w` wrapping in the factory chain would silently disable the blacklist, letting attackers spam invalid-version messages without consequence.

- **Interceptors (the original finding):** `MultiDataInterceptor.interceptedData` and `SingleDataInterceptor.ProcessReceivedMessage` compared `CheckValidity()` errors with `==` against `ErrInvalidTransactionVersion` / `ErrInvalidChainID`. Wrapping silently disabled the blacklist path.
- **Codebase audit expansion:** the same `err == sentinel` shape was converted in the rest of the codebase, notably `ErrMaxSupplyExceeded` in `core/kapp/accounts/accounts.go` which gates token supply caps and would silently fail open under wrapping.
- **CI:** `errorlint` (comparison check only) enabled in `.golangci.yml` to prevent regression. `errorf` and `asserts` checks left disabled to keep this change focused.

`errors.Is(err, X)` is a strict superset of `err == X`, so behavior on currently-unwrapped errors is unchanged.

## Changes by area

| Area | Files | Sentinels |
|---|---|---|
| Interceptors (security fix) | `multiDataInterceptor.go`, `singleDataInterceptor.go` + tests | `ErrInvalidTransactionVersion`, `ErrInvalidChainID` |
| Token accounts | `core/kapp/accounts/accounts.go` | `ErrMaxSupplyExceeded` |
| KDA / fees / system account | `core/kapp/kda/trigger.go`, `core/kapp/kdaFeesPool/actions.go`, `core/kapp/systemAccount/systemAcount.go` | `ErrInvalidValue`, `ErrAssetPoolNotFound`, `ErrNilTrie` |
| Account lookups | `node/nodeAccount.go`, `core/process/smartContract/hooks/blockChainHook.go` | `ErrAccNotFound` |
| KVM | `kvm/vmhost/hostCore/host.go`, `kvm/mock/world/worldCallbacks.go` | `ErrExecutionFailedWithTimeout`, `ErrNilTrie` |
| Storage | `storage/leveldb/{leveldb,leveldbSerial}.go`, `storage/latestData/latestDataProvider.go` | `leveldb.ErrNotFound`, `ErrBootstrapDataNotFoundInStorage` |
| CI | `.golangci.yml` | errorlint enabled (comparison check) |

## Regression tests

Wrapped-sentinel tests added in `core/process/interceptors` for both `MultiDataInterceptor` and `SingleDataInterceptor`, covering `ErrInvalidTransactionVersion` and `ErrInvalidChainID`. Each test wraps the sentinel with `fmt.Errorf("...%w", sentinel)` and asserts the blacklist path fires. Verified to fail against the original `==` code and pass after the fix.

Also fixes a pre-existing copy-paste bug in `TestSingleDataInterceptor_InvalidTxChainIDShouldBlackList` — it was passing `ErrInvalidTransactionVersion` instead of `ErrInvalidChainID`.

## Test plan

- [x] CI: `go vet`, `goimports`, `golangci-lint` (errorlint, staticcheck, etc.)
- [x] CI: full test suite
- [x] Regression tests verified against pre-fix code (fail) and post-fix code (pass)

## References

- CWE-697 (Incorrect Comparison)
- Go errors documentation: `errors.Is` for sentinel comparison

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR replaces direct sentinel error comparisons (`err == sentinel`) with `errors.Is(err, sentinel)` across the codebase to fix a latent security and correctness issue where wrapped errors (using `fmt.Errorf(...%w...)`) could bypass critical sentinel-based validation logic.

## Blockchain-Critical Components Affected

**Transaction Processing & Consensus**
- `multiDataInterceptor.go` and `singleDataInterceptor.go`: Updated version/chainID validation to use `errors.Is` for `ErrInvalidTransactionVersion` and `ErrInvalidChainID`. This prevents peer blacklisting from being bypassed if these sentinel errors are wrapped during propagation.
- Tests added to verify blacklist behavior is maintained when sentinels are wrapped.

**State Management & Accounts**
- `core/kapp/accounts/accounts.go`: `ClaimStaking` and `ClaimAllowance` now detect `ErrMaxSupplyExceeded` via `errors.Is` to maintain token supply cap enforcement even when errors are wrapped.
- `node/nodeAccount.go`: `GetAccount` and `GetNextNonce` updated to properly detect account-not-found conditions with wrapped errors and return properly formatted error chains.

**Smart Contract Execution**
- `blockChainHook.go`: `GetStorageData` now correctly handles wrapped account-not-found errors.
- `kvm/vmhost/hostCore/host.go`: Timeout detection in smart contract execution updated to handle wrapped timeout errors.
- `kvm/mock/world/worldCallbacks.go`: Storage retrieval updated to properly detect wrapped nil-trie conditions.

**Storage & Data Integrity**
- `storage/leveldb/leveldb.go` and `storage/leveldb/leveldbSerial.go`: Key lookup error detection updated to handle wrapped `leveldb.ErrNotFound` errors.
- `storage/latestData/latestDataProvider.go`: Bootstrap data retrieval now correctly detects wrapped "data not found" errors before retrying with earlier epochs.

**Account & Pool Management**
- `core/kapp/kda/trigger.go`: Invalid value error classification updated.
- `core/kapp/kdaFeesPool/actions.go`: Pool lookup error handling updated.
- `core/kapp/systemAccount/systemAcount.go`: SFT metadata retrieval updated to handle wrapped nil-trie errors.

## Safety & Testing

- `errors.Is` is a strict superset of `==`; behavior on currently-unwrapped errors is unchanged.
- Comprehensive regression tests added across interceptors and core components that verify sentinel detection works correctly when errors are wrapped with `fmt.Errorf("%w")`.
- Test fix in `singleDataInterceptor_test.go`: Corrected `TestSingleDataInterceptor_InvalidTxChainIDShouldBlackList` to use correct `ErrInvalidChainID` sentinel (was incorrectly using `ErrInvalidTransactionVersion`).
- CI: `.golangci.yml` updated to enable `errorlint` linter with comparison-only checking to prevent regressions.

## Impact Assessment

This change fixes a latent correctness issue that could manifest as:
- Disabled peer blacklisting for invalid transaction versions/chainIDs if errors are wrapped during processing
- Bypassed maximum supply enforcement on token claims
- Incorrect account-not-found handling in contract execution and account lookups
- Improper error handling in storage operations

The fix ensures all sentinel-based validation paths remain effective regardless of how errors are wrapped or propagated through the call stack.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->