### PR TITLE
[KLC-2357] sanitize BlacklistPeer reasons to defeat log injection

### DIFF
--- a/core/consensus/slot/worker.go
+++ b/core/consensus/slot/worker.go
@@ -353,9 +353,11 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		if errNotCritical == nil && wrk.shouldBlacklistPeer(err) {
 			//this situation is so severe that we have to black list both the message originator and the connected peer
 			//that disseminated this message.
-			reason := fmt.Sprintf("blacklisted due to invalid consensus message: %s", err.Error())
-			wrk.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-			wrk.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+			log.Debug("Worker: invalid consensus message",
+				"originator", message.Peer().Pretty(),
+				"err", process.SanitizeBlacklistReason(err.Error()))
+			wrk.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonInvalidConsensus, core.InvalidMessageBlacklistDuration)
+			wrk.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonInvalidConsensus, core.InvalidMessageBlacklistDuration)
 		}
 	}()
 

--- a/core/consensus/slot/worker_security_test.go
+++ b/core/consensus/slot/worker_security_test.go
@@ -1,0 +1,68 @@
+package slot_test
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cMock "github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/consensus/slot"
+	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/network/p2p"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// KLC-2357 (M5): blacklist reason must be a fixed enumerator, never the raw
+// err.Error() which the attacker controls.
+func TestWorker_BlacklistReasonOnInvalidConsensusMessage_IsSanitized(t *testing.T) {
+	t.Parallel()
+
+	const injectionPayload = "\r\n2026-05-03 INFO  fake admin login from 10.0.0.1\r\n\x1b[31malert: pwn\x1b[0m"
+	errPoison := errors.New("unmarshal failed: " + injectionPayload)
+
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	antifloodHandler := &cMock.P2PAntifloodHandlerStub{
+		CanProcessMessageCalled: func(p2p.MessageP2P, core.PeerID) error { return nil },
+		CanProcessMessagesOnTopicCalled: func(core.PeerID, string, uint32, uint64, []byte) error {
+			return nil
+		},
+		BlacklistPeerCalled: func(_ core.PeerID, reason string, _ time.Duration) {
+			mu.Lock()
+			defer mu.Unlock()
+			reasons = append(reasons, reason)
+		},
+	}
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.AntifloodHandler = antifloodHandler
+	workerArgs.Marshalizer = &cMock.MarshalizerStub{
+		UnmarshalCalled: func(_ interface{}, _ []byte) error { return errPoison },
+	}
+
+	wrk, err := slot.NewWorker(workerArgs)
+	require.NoError(t, err)
+
+	msg := &cMock.P2PMessageMock{
+		DataField: []byte("payload"),
+		PeerField: core.PeerID("originator"),
+	}
+
+	procErr := wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+	require.Equal(t, errPoison, procErr)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, reasons, 2)
+	for i, r := range reasons {
+		assert.Equal(t, process.BlacklistReasonInvalidConsensus, r)
+		assert.NotContains(t, r, "fake admin login", "reason[%d] must not carry attacker err string", i)
+		assert.False(t, strings.ContainsAny(r, "\r\n\x1b"), "reason[%d] must not contain control chars", i)
+	}
+}

--- a/core/process/interceptors/multiDataInterceptor.go
+++ b/core/process/interceptors/multiDataInterceptor.go
@@ -1,8 +1,6 @@
 package interceptors
 
 import (
-	"errors"
-
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/data/batch"
@@ -116,9 +114,12 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 	err = mdi.marshalizer.Unmarshal(&b, message.Data())
 	if err != nil {
 		//this situation is so severe that we need to black list de peers
-		reason := "unmarshalable data got on topic " + mdi.topic
-		mdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+		log.Debug("MultiDataInterceptor.ProcessReceivedMessage unmarshal failed",
+			"topic", mdi.topic,
+			"originator", p2p.PeerIDToShortString(message.Peer()),
+			"err", process.SanitizeBlacklistReason(err.Error()))
+		mdi.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonUnmarshalable, core.InvalidMessageBlacklistDuration)
+		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonUnmarshalable, core.InvalidMessageBlacklistDuration)
 
 		return err
 	}
@@ -137,10 +138,12 @@ func (mdi *MultiDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P, 
 			// data we can never act on; treat it the same as the unmarshal-error
 			// path and blacklist both the originator and the connected peer
 			// (CWE-755 / CWE-703).
-			log.Error("MultiDataInterceptor.ProcessReceivedMessage", "err", err.Error())
-			reason := "decompression failure on topic " + mdi.topic + ", error " + err.Error()
-			mdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-			mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+			log.Debug("MultiDataInterceptor.ProcessReceivedMessage decompress failed",
+				"topic", mdi.topic,
+				"originator", p2p.PeerIDToShortString(message.Peer()),
+				"err", process.SanitizeBlacklistReason(err.Error()))
+			mdi.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonDecompressFailed, core.InvalidMessageBlacklistDuration)
+			mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonDecompressFailed, core.InvalidMessageBlacklistDuration)
 			return err
 		}
 		// Decompress replaces b.Data wholesale, so re-check the cap on the inflated
@@ -213,9 +216,12 @@ func (mdi *MultiDataInterceptor) interceptedData(dataBuff []byte, originator cor
 	interceptedData, err := mdi.factory.Create(dataBuff)
 	if err != nil {
 		//this situation is so severe that we need to black list de peers
-		reason := "can not create object from received bytes, topic " + mdi.topic + ", error " + err.Error()
-		mdi.antifloodHandler.BlacklistPeer(originator, reason, core.InvalidMessageBlacklistDuration)
-		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+		log.Debug("MultiDataInterceptor: factory.Create failed",
+			"topic", mdi.topic,
+			"originator", p2p.PeerIDToShortString(originator),
+			"err", process.SanitizeBlacklistReason(err.Error()))
+		mdi.antifloodHandler.BlacklistPeer(originator, process.BlacklistReasonFactoryCreateFailed, core.InvalidMessageBlacklistDuration)
+		mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonFactoryCreateFailed, core.InvalidMessageBlacklistDuration)
 
 		return nil, err
 	}
@@ -226,13 +232,14 @@ func (mdi *MultiDataInterceptor) interceptedData(dataBuff []byte, originator cor
 	if err != nil {
 		mdi.processDebugInterceptedData(interceptedData, err)
 
-		isWrongVersion := errors.Is(err, process.ErrInvalidTransactionVersion) ||
-			errors.Is(err, process.ErrInvalidChainID)
-		if isWrongVersion {
+		if process.IsWrongVersionError(err) {
 			//this situation is so severe that we need to black list de peers
-			reason := "wrong version of received intercepted data, topic " + mdi.topic + ", error " + err.Error()
-			mdi.antifloodHandler.BlacklistPeer(originator, reason, core.InvalidMessageBlacklistDuration)
-			mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+			log.Debug("MultiDataInterceptor: wrong version of intercepted data",
+				"topic", mdi.topic,
+				"originator", p2p.PeerIDToShortString(originator),
+				"err", process.SanitizeBlacklistReason(err.Error()))
+			mdi.antifloodHandler.BlacklistPeer(originator, process.BlacklistReasonWrongVersion, core.InvalidMessageBlacklistDuration)
+			mdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonWrongVersion, core.InvalidMessageBlacklistDuration)
 		}
 
 		return nil, err

--- a/core/process/interceptors/multiDataInterceptor_security_test.go
+++ b/core/process/interceptors/multiDataInterceptor_security_test.go
@@ -26,7 +26,9 @@ const blacklistInjectionPayload = "\r\n2026-05-03 INFO  fake admin login from 10
 
 func assertCleanBlacklistReason(t *testing.T, reasons []string, want string) {
 	t.Helper()
-	require.NotEmpty(t, reasons, "expected at least one BlacklistPeer call")
+	// Every M5 site blacklists BOTH the originator and the connected peer; a
+	// regression that drops one of the two calls must not slip through.
+	require.Len(t, reasons, 2, "expected exactly two BlacklistPeer calls (originator + connected peer)")
 	for i, r := range reasons {
 		assert.Equal(t, want, r, "reason[%d] must be the fixed enumerator", i)
 		assert.NotContains(t, r, "fake admin login", "reason[%d] must not carry attacker err string", i)

--- a/core/process/interceptors/multiDataInterceptor_security_test.go
+++ b/core/process/interceptors/multiDataInterceptor_security_test.go
@@ -1,0 +1,164 @@
+package interceptors_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/core/process/interceptors"
+	"github.com/klever-io/klever-go/data/batch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// KLC-2357 (M5): blacklist reasons must be fixed enumerators from
+// core/process, never err.Error() concatenations the attacker controls.
+
+// Shared with singleDataInterceptor_security_test.go (same _test package).
+const blacklistInjectionPayload = "\r\n2026-05-03 INFO  fake admin login from 10.0.0.1\r\n\x1b[31malert: pwn\x1b[0m"
+
+func assertCleanBlacklistReason(t *testing.T, reasons []string, want string) {
+	t.Helper()
+	require.NotEmpty(t, reasons, "expected at least one BlacklistPeer call")
+	for i, r := range reasons {
+		assert.Equal(t, want, r, "reason[%d] must be the fixed enumerator", i)
+		assert.NotContains(t, r, "fake admin login", "reason[%d] must not carry attacker err string", i)
+		assert.False(t, strings.ContainsAny(r, "\r\n\x1b"), "reason[%d] must not contain control chars", i)
+	}
+}
+
+func TestMultiDataInterceptor_BlacklistReasonOnFactoryCreateFailure_IsSanitized(t *testing.T) {
+	t.Parallel()
+
+	errPoison := errors.New("decode failed: " + blacklistInjectionPayload)
+
+	var reasons []string
+	arg := createMockArgMultiDataInterceptor()
+	arg.DataFactory = &mock.InterceptedDataFactoryStub{
+		CreateCalled: func(_ []byte) (process.InterceptedData, error) { return nil, errPoison },
+	}
+	arg.AntifloodHandler = &mock.P2PAntifloodHandlerStub{
+		BlacklistPeerCalled: func(_ core.PeerID, reason string, _ time.Duration) {
+			reasons = append(reasons, reason)
+		},
+	}
+	mdi, _ := interceptors.NewMultiDataInterceptor(arg)
+
+	dataField, _ := arg.Marshalizer.Marshal(&batch.Batch{Data: [][]byte{[]byte("payload")}})
+	msg := &mock.P2PMessageMock{DataField: dataField, PeerField: core.PeerID("originator")}
+
+	err := mdi.ProcessReceivedMessage(msg, fromConnectedPeerID)
+	require.Equal(t, errPoison, err)
+
+	assertCleanBlacklistReason(t, reasons, process.BlacklistReasonFactoryCreateFailed)
+}
+
+func TestMultiDataInterceptor_BlacklistReasonOnWrongVersion_IsSanitized(t *testing.T) {
+	t.Parallel()
+
+	// fmt.Errorf with %w preserves the attacker payload in .Error() while
+	// satisfying errors.Is(target) — same shape as production wrapping.
+	wrapped := fmt.Errorf("%s: %w", blacklistInjectionPayload, process.ErrInvalidChainID)
+
+	item := &mock.InterceptedDataStub{
+		CheckValidityCalled: func() error { return wrapped },
+		IdentifiersCalled:   func() [][]byte { return [][]byte{[]byte("id")} },
+	}
+
+	var reasons []string
+	arg := createMockArgMultiDataInterceptor()
+	arg.DataFactory = &mock.InterceptedDataFactoryStub{
+		CreateCalled: func(_ []byte) (process.InterceptedData, error) { return item, nil },
+	}
+	arg.AntifloodHandler = &mock.P2PAntifloodHandlerStub{
+		BlacklistPeerCalled: func(_ core.PeerID, reason string, _ time.Duration) {
+			reasons = append(reasons, reason)
+		},
+	}
+	mdi, _ := interceptors.NewMultiDataInterceptor(arg)
+
+	dataField, _ := arg.Marshalizer.Marshal(&batch.Batch{Data: [][]byte{[]byte("payload")}})
+	msg := &mock.P2PMessageMock{DataField: dataField, PeerField: core.PeerID("originator")}
+
+	err := mdi.ProcessReceivedMessage(msg, fromConnectedPeerID)
+	require.Equal(t, wrapped, err)
+
+	assertCleanBlacklistReason(t, reasons, process.BlacklistReasonWrongVersion)
+}
+
+func TestMultiDataInterceptor_BlacklistReasonOnUnmarshalFailure_IsSanitized(t *testing.T) {
+	t.Parallel()
+
+	errUnmarshal := errors.New("unmarshal failed: " + blacklistInjectionPayload)
+
+	var reasons []string
+	arg := createMockArgMultiDataInterceptor()
+	arg.Marshalizer = &mock.MarshalizerStub{
+		UnmarshalCalled: func(_ interface{}, _ []byte) error { return errUnmarshal },
+	}
+	arg.AntifloodHandler = &mock.P2PAntifloodHandlerStub{
+		BlacklistPeerCalled: func(_ core.PeerID, reason string, _ time.Duration) {
+			reasons = append(reasons, reason)
+		},
+	}
+	mdi, _ := interceptors.NewMultiDataInterceptor(arg)
+
+	msg := &mock.P2PMessageMock{DataField: []byte("payload"), PeerField: core.PeerID("originator")}
+	err := mdi.ProcessReceivedMessage(msg, fromConnectedPeerID)
+	require.Equal(t, errUnmarshal, err)
+
+	assertCleanBlacklistReason(t, reasons, process.BlacklistReasonUnmarshalable)
+}
+
+// TestMultiDataInterceptor_BlacklistReasonOnDecompressFailure_IsEnumerator
+// covers the decompress error branch: an attacker can flip IsCompressed=true
+// and ship malformed compressed bytes. The resulting decompressGzip error
+// must not flow into the BlacklistPeer reason — only the fixed enumerator.
+func TestMultiDataInterceptor_BlacklistReasonOnDecompressFailure_IsEnumerator(t *testing.T) {
+	t.Parallel()
+
+	// Build a Batch with IsCompressed=true and a Stream that is a truncated
+	// gzip header — decompressGzip will fail with "unexpected EOF" or similar.
+	// The exact error string doesn't matter; the assertion is that it does
+	// not reach the blacklist reason.
+	var truncated bytes.Buffer
+	gzw := gzip.NewWriter(&truncated)
+	_, _ = gzw.Write([]byte("anything"))
+	_ = gzw.Close()
+	corrupted := truncated.Bytes()[:3] // gzip magic bytes only — header truncated
+
+	var reasons []string
+	arg := createMockArgMultiDataInterceptor()
+	arg.Marshalizer = &mock.MarshalizerStub{
+		UnmarshalCalled: func(obj interface{}, _ []byte) error {
+			b := obj.(*batch.Batch)
+			b.IsCompressed = true
+			b.Stream = corrupted
+			b.DataSize = 1
+			return nil
+		},
+	}
+	arg.AntifloodHandler = &mock.P2PAntifloodHandlerStub{
+		BlacklistPeerCalled: func(_ core.PeerID, reason string, _ time.Duration) {
+			reasons = append(reasons, reason)
+		},
+	}
+	mdi, _ := interceptors.NewMultiDataInterceptor(arg)
+
+	msg := &mock.P2PMessageMock{DataField: []byte("anything"), PeerField: core.PeerID("originator")}
+	err := mdi.ProcessReceivedMessage(msg, fromConnectedPeerID)
+	require.Error(t, err)
+
+	require.Len(t, reasons, 2)
+	for i, r := range reasons {
+		assert.Equal(t, process.BlacklistReasonDecompressFailed, r)
+		assert.False(t, strings.ContainsAny(r, "\r\n\x1b"), "reason[%d] must not contain control chars", i)
+	}
+}

--- a/core/process/interceptors/singleDataInterceptor.go
+++ b/core/process/interceptors/singleDataInterceptor.go
@@ -1,8 +1,6 @@
 package interceptors
 
 import (
-	"errors"
-
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/network/p2p"
@@ -105,9 +103,12 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P,
 	interceptedData, err := sdi.factory.Create(message.Data())
 	if err != nil {
 		//this situation is so severe that we need to black list the peers
-		reason := "can not create object from received bytes, topic " + sdi.topic + ", error " + err.Error()
-		sdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-		sdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+		log.Debug("SingleDataInterceptor: factory.Create failed",
+			"topic", sdi.topic,
+			"originator", p2p.PeerIDToShortString(message.Peer()),
+			"err", process.SanitizeBlacklistReason(err.Error()))
+		sdi.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonFactoryCreateFailed, core.InvalidMessageBlacklistDuration)
+		sdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonFactoryCreateFailed, core.InvalidMessageBlacklistDuration)
 
 		return err
 	}
@@ -118,13 +119,14 @@ func (sdi *SingleDataInterceptor) ProcessReceivedMessage(message p2p.MessageP2P,
 	if err != nil {
 		sdi.processDebugInterceptedData(interceptedData, err)
 
-		isWrongVersion := errors.Is(err, process.ErrInvalidTransactionVersion) ||
-			errors.Is(err, process.ErrInvalidChainID)
-		if isWrongVersion {
+		if process.IsWrongVersionError(err) {
 			//this situation is so severe that we need to black list de peers
-			reason := "wrong version of received intercepted data, topic " + sdi.topic + ", error " + err.Error()
-			sdi.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-			sdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+			log.Debug("SingleDataInterceptor: wrong version of intercepted data",
+				"topic", sdi.topic,
+				"originator", p2p.PeerIDToShortString(message.Peer()),
+				"err", process.SanitizeBlacklistReason(err.Error()))
+			sdi.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonWrongVersion, core.InvalidMessageBlacklistDuration)
+			sdi.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonWrongVersion, core.InvalidMessageBlacklistDuration)
 		}
 
 		return err

--- a/core/process/interceptors/singleDataInterceptor_security_test.go
+++ b/core/process/interceptors/singleDataInterceptor_security_test.go
@@ -1,0 +1,71 @@
+package interceptors_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/core/process/interceptors"
+	"github.com/stretchr/testify/require"
+)
+
+// KLC-2357 (M5) regressions for SingleDataInterceptor. Helpers
+// (blacklistInjectionPayload, assertCleanBlacklistReason) live in
+// multiDataInterceptor_security_test.go in this same _test package.
+
+func TestSingleDataInterceptor_BlacklistReasonOnFactoryCreateFailure_IsSanitized(t *testing.T) {
+	t.Parallel()
+
+	errPoison := errors.New("decode failed: " + blacklistInjectionPayload)
+
+	var reasons []string
+	arg := createMockArgSingleDataInterceptor()
+	arg.DataFactory = &mock.InterceptedDataFactoryStub{
+		CreateCalled: func(_ []byte) (process.InterceptedData, error) { return nil, errPoison },
+	}
+	arg.AntifloodHandler = &mock.P2PAntifloodHandlerStub{
+		BlacklistPeerCalled: func(_ core.PeerID, reason string, _ time.Duration) {
+			reasons = append(reasons, reason)
+		},
+	}
+	sdi, _ := interceptors.NewSingleDataInterceptor(arg)
+
+	msg := &mock.P2PMessageMock{DataField: []byte("payload"), PeerField: core.PeerID("originator")}
+	err := sdi.ProcessReceivedMessage(msg, fromConnectedPeerID)
+	require.Equal(t, errPoison, err)
+
+	assertCleanBlacklistReason(t, reasons, process.BlacklistReasonFactoryCreateFailed)
+}
+
+func TestSingleDataInterceptor_BlacklistReasonOnWrongVersion_IsSanitized(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("%s: %w", blacklistInjectionPayload, process.ErrInvalidTransactionVersion)
+
+	item := &mock.InterceptedDataStub{
+		CheckValidityCalled: func() error { return wrapped },
+		IdentifiersCalled:   func() [][]byte { return [][]byte{[]byte("id")} },
+	}
+
+	var reasons []string
+	arg := createMockArgSingleDataInterceptor()
+	arg.DataFactory = &mock.InterceptedDataFactoryStub{
+		CreateCalled: func(_ []byte) (process.InterceptedData, error) { return item, nil },
+	}
+	arg.AntifloodHandler = &mock.P2PAntifloodHandlerStub{
+		BlacklistPeerCalled: func(_ core.PeerID, reason string, _ time.Duration) {
+			reasons = append(reasons, reason)
+		},
+	}
+	sdi, _ := interceptors.NewSingleDataInterceptor(arg)
+
+	msg := &mock.P2PMessageMock{DataField: []byte("payload"), PeerField: core.PeerID("originator")}
+	err := sdi.ProcessReceivedMessage(msg, fromConnectedPeerID)
+	require.Equal(t, wrapped, err)
+
+	assertCleanBlacklistReason(t, reasons, process.BlacklistReasonWrongVersion)
+}

--- a/core/process/reasons.go
+++ b/core/process/reasons.go
@@ -24,6 +24,14 @@ const (
 // amplification through the log shipper.
 const MaxSanitizedBlacklistReason = 256
 
+// MaxSanitizeScanRunes caps how many runes SanitizeBlacklistReason will examine
+// in the input. Without this, a long string of all-stripped runes (e.g. all
+// control chars) would force O(len(s)) work even though the output cap never
+// triggers — CPU/time amplification. 4× the output cap allows a generous 75 %
+// strip ratio for legitimate verbose error strings while bounding worst-case
+// work at a constant.
+const MaxSanitizeScanRunes = MaxSanitizedBlacklistReason * 4
+
 // SanitizeBlacklistReason strips control characters and Unicode "format" runes
 // from s and caps the result at MaxSanitizedBlacklistReason runes. The filter
 // removes:
@@ -34,12 +42,21 @@ const MaxSanitizedBlacklistReason = 256
 //     U+FEFF BOM;
 //   - U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR, which some log
 //     shippers treat as record separators.
+//
+// The function bounds total work at MaxSanitizeScanRunes input runes so a
+// pathological input cannot force unbounded iteration even when every rune
+// gets stripped.
 func SanitizeBlacklistReason(s string) string {
 	if s == "" {
 		return s
 	}
 	out := make([]rune, 0, min(len(s), MaxSanitizedBlacklistReason))
+	scanned := 0
 	for _, r := range s {
+		scanned++
+		if scanned > MaxSanitizeScanRunes {
+			break
+		}
 		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || r == '\u2028' || r == '\u2029' {
 			continue
 		}

--- a/core/process/reasons.go
+++ b/core/process/reasons.go
@@ -1,0 +1,61 @@
+package process
+
+import (
+	"errors"
+	"unicode"
+)
+
+// Fixed BlacklistPeer reason identifiers. Callers must use these instead of
+// concatenating err.Error() into the reason — the antiflood handler forwards
+// the reason to its log stream, where attacker-controlled bytes would forge
+// or amplify log lines (CWE-117). See KLC-2357.
+const (
+	BlacklistReasonUnmarshalable         = "unmarshalable_payload"
+	BlacklistReasonDecompressFailed      = "decompress_failure"
+	BlacklistReasonFactoryCreateFailed   = "invalid_factory_create"
+	BlacklistReasonWrongVersion          = "invalid_version_or_chain"
+	BlacklistReasonInvalidConsensus      = "invalid_consensus_message"
+	BlacklistReasonInvalidHeartbeat      = "invalid_heartbeat_message"
+	BlacklistReasonInconsistentHeartbeat = "inconsistent_heartbeat_message"
+)
+
+// MaxSanitizedBlacklistReason caps the rune length of an err string forwarded
+// to a structured logger from a blacklist failure path, to deny length
+// amplification through the log shipper.
+const MaxSanitizedBlacklistReason = 256
+
+// SanitizeBlacklistReason strips control characters and Unicode "format" runes
+// from s and caps the result at MaxSanitizedBlacklistReason runes. The filter
+// removes:
+//   - C0 + DEL + C1 controls (via unicode.IsControl) — including ESC (which
+//     neuters ANSI CSI sequences) and U+0085 NEL;
+//   - Cf format chars (via unicode.Is(unicode.Cf, r)) — zero-width joiners,
+//     bidi controls (U+202A-U+202E / U+2066-U+2069, the Trojan-Source set),
+//     U+FEFF BOM;
+//   - U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR, which some log
+//     shippers treat as record separators.
+func SanitizeBlacklistReason(s string) string {
+	if s == "" {
+		return s
+	}
+	out := make([]rune, 0, min(len(s), MaxSanitizedBlacklistReason))
+	for _, r := range s {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) || r == '\u2028' || r == '\u2029' {
+			continue
+		}
+		out = append(out, r)
+		if len(out) == MaxSanitizedBlacklistReason {
+			break
+		}
+	}
+	return string(out)
+}
+
+// IsWrongVersionError reports whether err (or any wrapped err) indicates the
+// peer sent an intercepted message with a transaction version / chain ID this
+// node does not accept. The interceptors use this to decide whether to escalate
+// a CheckValidity failure to a BlacklistPeer call.
+func IsWrongVersionError(err error) bool {
+	return errors.Is(err, ErrInvalidTransactionVersion) ||
+		errors.Is(err, ErrInvalidChainID)
+}

--- a/core/process/reasons_test.go
+++ b/core/process/reasons_test.go
@@ -30,6 +30,12 @@ func TestSanitizeBlacklistReason(t *testing.T) {
 		{"keeps printable unicode", "héllo — wörld 日本語", "héllo — wörld 日本語"},
 		{"caps at MaxSanitizedBlacklistReason (ASCII)", strings.Repeat("a", process.MaxSanitizedBlacklistReason+1) + "\n", strings.Repeat("a", process.MaxSanitizedBlacklistReason)},
 		{"caps at MaxSanitizedBlacklistReason (multi-byte rune)", strings.Repeat("世", process.MaxSanitizedBlacklistReason+10), strings.Repeat("世", process.MaxSanitizedBlacklistReason)},
+		// Bounds scan when most/all runes are stripped: a long prefix of
+		// control chars must not force unbounded iteration just because the
+		// output cap never triggers. The trailing keepers are placed past
+		// MaxSanitizeScanRunes and must NOT appear in the output — proves the
+		// scan budget is enforced, not just the output cap.
+		{"bounds scan when input is dominated by stripped chars", strings.Repeat("\x00", process.MaxSanitizeScanRunes+1) + "keeper", ""},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/core/process/reasons_test.go
+++ b/core/process/reasons_test.go
@@ -1,0 +1,44 @@
+package process_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/klever-io/klever-go/core/process"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeBlacklistReason(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "hello world", "hello world"},
+		{"strips CR LF TAB", "a\rb\nc\td", "abcd"},
+		{"strips ANSI ESC (CSI is neutered)", "\x1b[31mred\x1b[0m", "[31mred[0m"},
+		{"strips DEL", "a\x7fb", "ab"},
+		{"strips C1 controls (NEL, raw CSI)", "a\u0085b\u009bc", "abc"},
+		{"strips U+2028 LINE SEPARATOR", "a\u2028b", "ab"},
+		{"strips U+2029 PARAGRAPH SEPARATOR", "a\u2029b", "ab"},
+		{"strips zero-width chars", "a\u200bb\u200cc\u200dd\ufeffe", "abcde"},
+		{"strips Trojan-Source bidi controls", "user\u202eadmin\u202cend", "useradminend"},
+		{"keeps printable unicode", "héllo — wörld 日本語", "héllo — wörld 日本語"},
+		{"caps at MaxSanitizedBlacklistReason (ASCII)", strings.Repeat("a", process.MaxSanitizedBlacklistReason+1) + "\n", strings.Repeat("a", process.MaxSanitizedBlacklistReason)},
+		{"caps at MaxSanitizedBlacklistReason (multi-byte rune)", strings.Repeat("世", process.MaxSanitizedBlacklistReason+10), strings.Repeat("世", process.MaxSanitizedBlacklistReason)},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := process.SanitizeBlacklistReason(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), process.MaxSanitizedBlacklistReason)
+			assert.False(t, strings.ContainsAny(got, "\r\n\t\x00\x1b\x7f\u0085\u009b\u2028\u2029\u200b\u202e"),
+				"sanitized must not contain any stripped char")
+		})
+	}
+}

--- a/data/retriever/resolvers/messageProcessor.go
+++ b/data/retriever/resolvers/messageProcessor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/data/retriever"
 	"github.com/klever-io/klever-go/network/p2p"
 	"github.com/klever-io/klever-go/tools/check"
@@ -44,9 +45,12 @@ func (mp *messageProcessor) parseReceivedMessage(message p2p.MessageP2P, fromCon
 	err := rd.UnmarshalWith(mp.marshalizer, message)
 	if err != nil {
 		//this situation is so severe that we need to black list the peers
-		reason := "unmarshalable data got on request topic " + mp.topic
-		mp.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-		mp.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+		log.Debug("messageProcessor: unmarshal failed on resolver topic",
+			"topic", mp.topic,
+			"originator", p2p.PeerIDToShortString(message.Peer()),
+			"err", process.SanitizeBlacklistReason(err.Error()))
+		mp.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonUnmarshalable, core.InvalidMessageBlacklistDuration)
+		mp.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonUnmarshalable, core.InvalidMessageBlacklistDuration)
 
 		return nil, err
 	}

--- a/node/heartbeat/process/monitor.go
+++ b/node/heartbeat/process/monitor.go
@@ -263,10 +263,11 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPe
 	if err != nil {
 		//this situation is so severe that we have to black list both the message originator and the connected peer
 		//that disseminated this message.
-
-		reason := "blacklisted due to invalid heartbeat message"
-		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+		log.Debug("Monitor: invalid heartbeat message",
+			"originator", p2p.PeerIDToShortString(message.Peer()),
+			"err", process.SanitizeBlacklistReason(err.Error()))
+		m.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonInvalidHeartbeat, core.InvalidMessageBlacklistDuration)
+		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonInvalidHeartbeat, core.InvalidMessageBlacklistDuration)
 
 		return err
 	}
@@ -274,9 +275,11 @@ func (m *Monitor) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedPe
 	if !bytes.Equal(hbRecv.Pid, message.Peer().Bytes()) {
 		//this situation is so severe that we have to black list both the message originator and the connected peer
 		//that disseminated this message.
-		reason := "blacklisted due to inconsistent heartbeat message"
-		m.antifloodHandler.BlacklistPeer(message.Peer(), reason, core.InvalidMessageBlacklistDuration)
-		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, reason, core.InvalidMessageBlacklistDuration)
+		log.Debug("Monitor: inconsistent heartbeat message",
+			"originator", p2p.PeerIDToShortString(message.Peer()),
+			"hbPid", p2p.PeerIDToShortString(core.PeerID(hbRecv.Pid)))
+		m.antifloodHandler.BlacklistPeer(message.Peer(), process.BlacklistReasonInconsistentHeartbeat, core.InvalidMessageBlacklistDuration)
+		m.antifloodHandler.BlacklistPeer(fromConnectedPeer, process.BlacklistReasonInconsistentHeartbeat, core.InvalidMessageBlacklistDuration)
 
 		return fmt.Errorf("%w heartbeat pid %s, message pid %s",
 			heartbeat.ErrHeartbeatPidMismatch,


### PR DESCRIPTION
## Summary

`BlacklistPeer(peer, reason, duration)` forwards `reason` verbatim to the antiflood log stream (`core/process/throttle/antiflood/p2pAntiflood.go:255`). Multiple call sites in the codebase passed `err.Error()` — bytes ultimately derived from network input — into that `reason` field through string concatenation.

This is a known anti-pattern (CWE-117 class). We have not demonstrated end-to-end exploitability — that would require confirming a specific marshalizer / factory implementation that actually surfaces attacker-controlled bytes through its `err.Error()`, which we did not audit individually. What this PR does is remove the primitive entirely so that attacker influence on log-stream bytes via this path is no longer possible. Defense in depth.

## What changed

- **New** `core/process/reasons.go` — shared `SanitizeBlacklistReason()`, `IsWrongVersionError()`, and 7 `BlacklistReason*` constants.
- **`core/consensus/slot/worker.go`** — the most direct case: `fmt.Sprintf("blacklisted due to invalid consensus message: %s", err.Error())` → `BlacklistReasonInvalidConsensus` + sanitized `log.Debug`.
- **`core/process/interceptors/multiDataInterceptor.go`** — 4 sites (unmarshal, decompress, factory.Create, wrong-version).
- **`core/process/interceptors/singleDataInterceptor.go`** — 2 sites (factory.Create, wrong-version).
- **`data/retriever/resolvers/messageProcessor.go`** — was topic-concat (topic isn't attacker-controlled, but standardizing for grep-ability).
- **`node/heartbeat/process/monitor.go`** — invalid + inconsistent heartbeat enumerators; observability `log.Debug` for parity.
- Duplicated wrong-version `errors.Is` predicate extracted into `process.IsWrongVersionError`.

`SanitizeBlacklistReason` is applied to the err that the structured logger receives as a separate field; the `reason` itself is always a fixed enumerator. The helper strips control characters (C0/DEL/C1), Cf format chars (zero-width joiners, bidi controls, BOM), and U+2028/U+2029 separators; caps output at 256 runes.

## Test plan

- [x] `go test -race ./core/process/... ./core/consensus/slot ./data/retriever/resolvers ./node/heartbeat/process` — all green
- [x] `go vet` + `gofmt -l` — clean on all touched files
- [x] `TestSanitizeBlacklistReason` covers C0/DEL/C1, ANSI ESC, U+2028/U+2029, zero-width, bidi controls, printable Unicode, multi-byte rune cap
- [x] `TestWorker_BlacklistReasonOnInvalidConsensusMessage_IsSanitized` drives a CRLF+ANSI+forged-line payload through the real `Worker.ProcessReceivedMessage` defer block
- [x] Interceptor security tests cover all four MultiData branches (incl. real `compress/gzip` decompression failure) and both SingleData branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->