### PR TITLE
[KLC-2425] Makefile: reorganize sections and add pprof debugging targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 #   make all                    Run validator node (default log level)
 #   make debug                  Run node in debug mode
 #   make tests-unit             Run unit tests
-#   make profile                Run node with pprof on :8080 (see pprof-* targets)
+#   make profile                Run node with pprof on 127.0.0.1:8080 (see pprof-* targets)
 #   make docker-build           Build Debian Docker image (see docker/Makefile)
 #   make help                   List every available target
 #
@@ -105,7 +105,7 @@ GOBUILD=$(GOCMD) build $(GO_BUILD_FLAGS) -ldflags="$(ldflags) -extldflags '-Wl,-
 help: ## Show this help message
 	@echo "Klever Blockchain - Available Make Targets"
 	@echo ""
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:[^#]*##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 version: ## Print the build version string (git describe)
 	@echo $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,38 @@
 # K:::::::K    K:::::KL::::::::::::::::::::::LE::::::::::::::::::::E           V:::V           E::::::::::::::::::::ER::::::R     R:::::R
 # KKKKKKKKK    KKKKKKKLLLLLLLLLLLLLLLLLLLLLLLLEEEEEEEEEEEEEEEEEEEEEE            VVV            EEEEEEEEEEEEEEEEEEEEEERRRRRRRR     RRRRRRR
 
+###############################################################################
+# Usage                                                                       #
+###############################################################################
+#
+# Common workflows
+#   make build                  Build all binaries into ./bin/
+#   make all                    Run validator node (default log level)
+#   make debug                  Run node in debug mode
+#   make tests-unit             Run unit tests
+#   make profile                Run node with pprof on :8080 (see pprof-* targets)
+#   make docker-build           Build Debian Docker image (see docker/Makefile)
+#   make help                   List every available target
+#
+# Environment variables
+#   LOG=*:DEBUG                 Log level filter (default: *:INFO)
+#   VERBOSE=1                   Add -v to go test invocations
+#   RELEASE=1                   Strip DWARF + trim paths (CI / release builds)
+#   FOR_DEV=dev-                Prefix docker image tags with "dev-"
+#   FOR_TESTNET=-testnet        Suffix docker image tags with "-testnet"
+#   E2E_NODE_URL, E2E_PROXY_URL Used by tests-e2e
+#   NODE                        Used by connector (node URL)
+#   ARGS                        Forwarded to benchmark target
+#
+###############################################################################
+
+# Safer recipe execution: if a recipe fails, delete its target so the next
+# invocation doesn't treat a half-written file as up-to-date.
+.DELETE_ON_ERROR:
+
+###############################################################################
+# Configuration                                                               #
+###############################################################################
 
 # LOAD builder info
 ifndef VERSION
@@ -65,19 +97,26 @@ GOBUILD=$(GOCMD) build $(GO_BUILD_FLAGS) -ldflags="$(ldflags) -extldflags '-Wl,-
 
 .DEFAULT_GOAL := help
 
-############################
-###         HELP         ###
-############################
-.PHONY: help
+###############################################################################
+# Help                                                                        #
+###############################################################################
+
+.PHONY: help version
 help: ## Show this help message
 	@echo "Klever Blockchain - Available Make Targets"
 	@echo ""
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-############################
-###        Run node      ###
-############################
-.PHONY: all debug trace redundancy seednode
+version: ## Print the build version string (git describe)
+	@echo $(VERSION)
+
+###############################################################################
+# Run & Debug                                                                 #
+###############################################################################
+
+.PHONY: all debug trace redundancy seednode import-from-localdb runsc-trace
+.PHONY: profile pprof-goroutines pprof-heartbeat pprof-top
+
 all: ## Run validator node with default log level
 	$(GORUN) ./cmd/node --log-level="${LOG}" --use-log-view
 
@@ -96,19 +135,59 @@ seednode: ## Run seednode for network bootstrap
 import-from-localdb: ## Import blockchain data from local database
 	$(GORUN) ./cmd/node --log-level="${LOG}" --use-log-view --import-db=./db/local --import-db-no-sig-check
 
-############################
-###       Key Tools      ###
-############################
-.PHONY: newkey
+runsc-trace: ## Run node with smart-contract trace logging (wipes ./db first)
+	rm -rf db
+	$(GORUN) ./cmd/node --use-log-view --log-level=*:INFO,process/block:DEBUG,process/transaction:DEBUG,process/transaction.smartcontract:TRACE,process/smartcontract:DEBUG,vm/host:TRACE,vm/metering:DEBUG
+
+# --- pprof -------------------------------------------------------------------
+# Live runtime profiling. Start the node with `make profile`, then query the
+# pprof endpoint from another terminal.
+#
+# Typical workflow
+#   make profile               # terminal 1: start node with pprof on :8080
+#   make pprof-top             # terminal 2 (after ~20s bootstrap)
+#   make pprof-heartbeat       # focused heartbeat-monitor check
+#   go tool pprof http://127.0.0.1:8080/debug/pprof/heap   # interactive heap
+#
+# Reference: https://pkg.go.dev/net/http/pprof
+
+profile: ## Run node with pprof enabled on 127.0.0.1:8080/debug/pprof
+	$(GORUN) ./cmd/node --log-level="${LOG}" --use-log-view \
+		--profile-mode --rest-api-interface=127.0.0.1:8080
+
+pprof-goroutines: ## Dump all live goroutines from a running --profile-mode node
+	@curl -s "http://127.0.0.1:8080/debug/pprof/goroutine?debug=2"
+
+pprof-heartbeat: ## Show only the heartbeat monitor goroutine stack (with state header)
+	@curl -s "http://127.0.0.1:8080/debug/pprof/goroutine?debug=2" | \
+		grep -B 1 -A 4 "startValidatorProcessing.func1"
+
+pprof-top: ## Top 30 functions by live goroutine count (spot fan-out / leaks)
+	@curl -s "http://127.0.0.1:8080/debug/pprof/goroutine?debug=2" | \
+		awk '/^goroutine /{getline; sub(/\(.*/,""); print}' | \
+		sort | uniq -c | sort -rn | head -30
+
+###############################################################################
+# Tools                                                                       #
+###############################################################################
+
+.PHONY: newkey connector benchmark
+
 newkey: ## Generate new validator keys
 	$(GORUN) ./cmd/keygenerator
 
+connector: ## Run terminal UI connector against a node (NODE=<url>)
+	go run ./cmd/connector/main.go node --address="${NODE}" --log-level="${LOG}"
 
-############################
-###         BUILD        ###
-############################
+benchmark: ## Run full validator benchmark (ARGS=<args>)
+	$(GORUN) ./cmd/benchmark $(ARGS)
 
-.PHONY: build build-validator build-seednode build-operator build-keygenerator build-benchmark docker-build clean
+###############################################################################
+# Build                                                                       #
+###############################################################################
+
+.PHONY: build build-validator build-seednode build-operator build-keygenerator build-benchmark clean
+
 build: build-validator build-seednode build-operator build-keygenerator build-benchmark ## Build all binaries
 
 build-validator: ## Build validator node binary
@@ -134,21 +213,32 @@ clean: ## Remove build artifacts and caches
 	@go clean -cache
 	@echo "Clean complete"
 
-############################
-###    Docker Builds     ###
-############################
-# Docker-related targets are defined in docker/Makefile
-# This keeps the main Makefile focused on build and test targets
+###############################################################################
+# Docker                                                                      #
+###############################################################################
+# Docker-related targets are isolated in docker/Makefile (they have their own
+# registry / multi-arch builder model). Targets become available via include.
 
 include docker/Makefile
+
+###############################################################################
+# Code Generation & Docs                                                      #
+###############################################################################
+
+.PHONY: vm-generate-rs gen-doc
 
 vm-generate-rs: ## Generate VM hooks from Rust SDK
 	cd kvm/vmhost/vmhooks && go run generate/cmd/eiGenMain.go
 
-############################
-###    Test and Docs     ###
-############################
-.PHONY: prepare ensure-dependencies gen-doc
+gen-doc: ## Generate Swagger API documentation
+	swag init -d ./cmd/node,./network/api -o ./docs --parseInternal --parseDependency --instanceName="node"
+
+###############################################################################
+# Development Setup                                                           #
+###############################################################################
+
+.PHONY: prepare ensure-dependencies goimports
+
 prepare: ## Install development dependencies
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	go install github.com/swaggo/swag/cmd/swag@latest
@@ -170,18 +260,12 @@ goimports: ## Format Go code and organize imports
 		! -name 'gasCostWASM.go' \
 		! -path "./vendor/*")
 
-gen-doc: ## Generate Swagger API documentation
-	swag init -d ./cmd/node,./network/api -o ./docs --parseInternal --parseDependency --instanceName="node"
+###############################################################################
+# Tests                                                                       #
+###############################################################################
 
-runsc-trace:
-	rm -rf db
-	$(GORUN) ./cmd/node --use-log-view --log-level=*:INFO,process/block:DEBUG,process/transaction:DEBUG,process/transaction.smartcontract:TRACE,process/smartcontract:DEBUG,vm/host:TRACE,vm/metering:DEBUG
+.PHONY: tests tests-unit tests-integration tests-kvm tests-e2e
 
-############################
-###  Integration Tests   ###
-############################
-
-.PHONY: tests tests-unit tests-integration tests-kvm tests-e2e benchmark
 tests: tests-unit tests-integration tests-kvm tests-e2e ## Run all tests
 
 tests-unit: ## Run unit tests
@@ -200,9 +284,3 @@ tests-e2e: ## Run end-to-end tests
 	if [ ! -d klever-go-e2e ]; then git clone git@github.com:klever-io/klever-go-e2e.git; fi
 	cd klever-go-e2e && go mod tidy && make build && cd ..
 	klever-go-e2e/bin/klever-go-e2e --node="${E2E_NODE_URL}" --proxy="${E2E_PROXY_URL}"
-
-connector: ## Run terminal UI connector
-	go run ./cmd/connector/main.go node --address="${NODE}" --log-level="${LOG}"
-
-benchmark: ## Run full validator benchmark
-	$(GORUN) ./cmd/benchmark $(ARGS)


### PR DESCRIPTION
## Summary

- Reorganize the root `Makefile` with consistent section banners and consolidate misplaced targets (`runsc-trace`, `vm-generate-rs`, `connector`, `benchmark`) into logical sections
- Add four pprof debugging targets (`profile`, `pprof-goroutines`, `pprof-heartbeat`, `pprof-top`) grouped under **Run & Debug** — recipes verbatim from the Jira issue, pre-tested against a live `--profile-mode` node
- Improve developer experience: top-level usage / env-vars docstring, `version` target, `.DELETE_ON_ERROR`, help regex fix so `tests-e2e` is no longer hidden

## Decision: keep monolithic (ADR)

Evaluated splitting into a `make/` directory with `build.mk`, `run.mk`, `test.mk`, etc. **Decided to keep a single file** and instead clean up structure. Rationale:

- All non-Docker sections share core variables (`$(GORUN)`, `$(GOBUILD)`, `$(ENV_FLAG)`); splitting would require either duplication or careful include ordering
- Single file means trivial grep/search and no file-jump friction
- The existing `docker/Makefile` split remains justified by its own conceptual model (registry, builders, multi-arch); other sections don't have that isolation
- The issue itself cautions: _"Do not split for the sake of splitting"_

## Section layout

```
Usage (new)
Configuration
Help            -> + version target
Run & Debug     -> + profile, pprof-goroutines, pprof-heartbeat, pprof-top
                   + runsc-trace moved here (was orphaned)
Tools           -> + connector, benchmark moved here (were stranded)
Build
Docker          -> include docker/Makefile (unchanged)
Code Generation & Docs  -> vm-generate-rs moved here, plus gen-doc
Development Setup       -> prepare, ensure-dependencies, goimports
Tests
```

## pprof usage

```bash
make profile             # terminal 1 — start node with pprof on :8080
make pprof-top           # terminal 2 (after ~20s bootstrap)
make pprof-heartbeat     # focused heartbeat-monitor check
go tool pprof http://127.0.0.1:8080/debug/pprof/heap   # interactive heap
```

## Other improvements

- **Usage docstring at top** — common workflows and every relevant env var (`LOG`, `VERBOSE`, `RELEASE`, `FOR_DEV`, `FOR_TESTNET`, `E2E_NODE_URL`, `NODE`, `ARGS`) in one place
- **`.DELETE_ON_ERROR`** — GNU Make best practice; ensures a failed recipe doesn't leave a half-written target on disk
- **`version` target** — `make version` prints the `git describe` build string (useful in CI)
- **Help regex fix** — `[a-zA-Z_-]+` → `[a-zA-Z0-9_-]+` so target names containing digits (e.g. `tests-e2e`) now appear in `make help`
- **Missing help text** — `runsc-trace` had no `## …` annotation; added one
- **Wider help column** — `%-20s` → `%-25s` to fit longer target names like `docker-build-alpine-validator`

## Acceptance criteria

- [x] Decision documented (kept monolithic with clearer sections + rationale above)
- [x] All existing targets continue to work
- [x] `make help` lists every target (including previously-hidden `tests-e2e`)
- [x] New pprof targets added and verified against a live `--profile-mode` node
- [x] `make pprof-heartbeat` against a running node prints the monitor goroutine stack with `[select]` state header

## Test plan

- [x] `make help` lists all targets — including `pprof-*` and `tests-e2e`
- [x] `make version` prints the git describe string
- [x] `make build` builds all 5 binaries into `./bin/` (validator, seednode, operator, keygenerator, benchmark)
- [x] `make clean` removes `./bin/` and clears caches
- [x] `make profile` starts the node with pprof on `127.0.0.1:8080`
- [x] After ~20s bootstrap: `make pprof-top` shows top 30 goroutine functions
- [x] `make pprof-heartbeat` against running node prints the heartbeat monitor stack with `[select]` state header
- [x] `make docker-build` still works (docker/Makefile include unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR does not affect any blockchain-critical components or node stability. It is purely a build and developer tooling reorganization that:

- Reorganizes the Makefile with consistent section banners for improved maintainability
- Adds pprof debugging targets (`profile`, `pprof-goroutines`, `pprof-heartbeat`, `pprof-top`) for profiling node performance in development/testing scenarios
- Adds a `version` target for build information and a `runsc-trace` target for debugging with trace-level logging
- Improves the `help` target with better regex handling and target documentation
- Implements `.DELETE_ON_ERROR` for safer artifact cleanup on recipe failures
- Consolidates related targets (Tools, Code Generation & Docs, Tests) into logical groupings
- Clarifies that pprof binds to localhost-only (127.0.0.1:8080) rather than all interfaces
- Replaces non-portable awk regex patterns for consistent behavior across awk implementations

The changes are confined to the developer build system and do not modify consensus logic, transaction processing, state management, networking, KVM, or any other blockchain-critical components. No impact on node stability or data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->