### PR TITLE
[KLC-2423] heartbeat: stop Monitor and sender goroutines on shutdown

### DIFF
--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -1001,6 +1001,7 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		nodeMetricsCloser,
 		clockMetricsCloser,
 		currentNode.GetPeerHonestyHandler(),
+		currentNode.GetHeartbeatHandler(),
 	}
 
 	log.Trace("creating klever node facade")

--- a/node/heartbeat/componentHandler/heartbeatHandler.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler.go
@@ -57,6 +57,7 @@ type HeartbeatHandler struct {
 	arg              ArgHeartbeat
 	peerTypeProvider *peer.PeerTypeProvider
 	cancelFunc       func()
+	senderDone       chan struct{}
 }
 
 // NewHeartbeatHandler will create a heartbeat handler containing both a monitor and a sender
@@ -184,6 +185,7 @@ func (hbh *HeartbeatHandler) create() error {
 		return err
 	}
 
+	hbh.senderDone = make(chan struct{})
 	go hbh.startSendingHeartbeats(ctx)
 
 	return nil
@@ -204,6 +206,7 @@ func (hbh *HeartbeatHandler) getLatestValidators() ([]*state.ValidatorInfo, map[
 }
 
 func (hbh *HeartbeatHandler) startSendingHeartbeats(ctx context.Context) {
+	defer close(hbh.senderDone)
 	// #nosec G404: required for randomness
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	cfg := hbh.arg.HeartbeatConfig
@@ -263,11 +266,18 @@ func (hbh *HeartbeatHandler) Sender() *process.Sender {
 	return hbh.sender
 }
 
-// Close will close the endless running go routine
+// Close stops the heartbeat sender and monitor background goroutines and waits
+// for both to exit. Idempotent: each step (cancelFunc, channel receive on closed
+// channel, monitor.Close) is safe to repeat.
 func (hbh *HeartbeatHandler) Close() error {
 	hbh.cancelFunc()
 	log.Debug("calling close on heartbeat system")
 
+	<-hbh.senderDone
+
+	if hbh.monitor != nil {
+		return hbh.monitor.Close()
+	}
 	return nil
 }
 

--- a/node/heartbeat/componentHandler/heartbeatHandler_close_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_close_test.go
@@ -1,0 +1,119 @@
+package componentHandler
+
+import (
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type strBuf struct{ b *strings.Builder }
+
+func (w *strBuf) Write(p []byte) (int, error) { w.b.Write(p); return len(p), nil }
+
+func countHeartbeatGoroutines(t *testing.T, marker string) int {
+	t.Helper()
+	var buf strings.Builder
+	require.NoError(t, pprof.Lookup("goroutine").WriteTo(&strBuf{&buf}, 1))
+	return strings.Count(buf.String(), marker)
+}
+
+// Verifies the full production shutdown path:
+// HeartbeatHandler.Close() -> monitor.Close() -> stops background goroutine cleanly.
+func TestHeartbeatHandler_CloseStopsMonitorGoroutine(t *testing.T) {
+	// No t.Parallel: depends on global goroutine count.
+
+	arg := createMockArgument()
+	hbh, err := NewHeartbeatHandler(arg)
+	assert.Nil(t, err)
+	require.NotNil(t, hbh.Monitor())
+
+	// Let the monitor goroutine actually start and park in its select.
+	time.Sleep(100 * time.Millisecond)
+	runtime.Gosched()
+
+	monGoroutinesBefore := countHeartbeatGoroutines(t, "startValidatorProcessing")
+	t.Logf("monitor goroutines BEFORE close: %d", monGoroutinesBefore)
+	require.GreaterOrEqual(t, monGoroutinesBefore, 1,
+		"expected at least one monitor goroutine after construction")
+
+	// Call Close with a watchdog so we fail loudly if Wait() blocks forever.
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- hbh.Close() }()
+
+	select {
+	case err := <-closeDone:
+		assert.Nil(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("hbh.Close did not return within 5s — monitor.Close() blocked on wg.Wait")
+	}
+
+	// Allow scheduler to reflect the exit in pprof.
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	runtime.Gosched()
+
+	monGoroutinesAfter := countHeartbeatGoroutines(t, "startValidatorProcessing")
+	t.Logf("monitor goroutines AFTER close: %d", monGoroutinesAfter)
+
+	assert.Equal(t, 0, monGoroutinesAfter,
+		"monitor goroutine should be gone after HeartbeatHandler.Close")
+}
+
+// Locks in that HeartbeatHandler.Close() is idempotent. The implementation has no
+// explicit guard — it relies on cancelFunc, <-senderDone (closed channel), and
+// monitor.Close (sync.Once) all being safe to repeat. Regressions in any of those
+// would surface here as a panic.
+func TestHeartbeatHandler_CloseIsIdempotent(t *testing.T) {
+	arg := createMockArgument()
+	hbh, err := NewHeartbeatHandler(arg)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, hbh.Close())
+		require.NoError(t, hbh.Close())
+		require.NoError(t, hbh.Close())
+	})
+}
+
+// Locks in safety under concurrent shutdown — e.g. signal handler and closer
+// loop racing to Close the same handler.
+func TestHeartbeatHandler_ConcurrentClose(t *testing.T) {
+	arg := createMockArgument()
+	hbh, err := NewHeartbeatHandler(arg)
+	require.NoError(t, err)
+
+	const concurrency = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- hbh.Close()
+		}()
+	}
+	close(start)
+
+	doneAll := make(chan struct{})
+	go func() { wg.Wait(); close(doneAll) }()
+
+	select {
+	case <-doneAll:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent HeartbeatHandler.Close did not converge within 5s")
+	}
+
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/node/heartbeat/componentHandler/heartbeatHandler_close_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_close_test.go
@@ -33,13 +33,11 @@ func TestHeartbeatHandler_CloseStopsMonitorGoroutine(t *testing.T) {
 	assert.Nil(t, err)
 	require.NotNil(t, hbh.Monitor())
 
-	// Let the monitor goroutine actually start and park in its select.
-	time.Sleep(100 * time.Millisecond)
-	runtime.Gosched()
-
-	monGoroutinesBefore := countHeartbeatGoroutines(t, "startValidatorProcessing")
-	t.Logf("monitor goroutines BEFORE close: %d", monGoroutinesBefore)
-	require.GreaterOrEqual(t, monGoroutinesBefore, 1,
+	// Wait until the monitor goroutine is visible in pprof.
+	require.Eventually(t, func() bool {
+		runtime.Gosched()
+		return countHeartbeatGoroutines(t, "startValidatorProcessing") >= 1
+	}, 2*time.Second, 10*time.Millisecond,
 		"expected at least one monitor goroutine after construction")
 
 	// Call Close with a watchdog so we fail loudly if Wait() blocks forever.
@@ -53,15 +51,12 @@ func TestHeartbeatHandler_CloseStopsMonitorGoroutine(t *testing.T) {
 		t.Fatal("hbh.Close did not return within 5s — monitor.Close() blocked on wg.Wait")
 	}
 
-	// Allow scheduler to reflect the exit in pprof.
-	time.Sleep(100 * time.Millisecond)
-	runtime.GC()
-	runtime.Gosched()
-
-	monGoroutinesAfter := countHeartbeatGoroutines(t, "startValidatorProcessing")
-	t.Logf("monitor goroutines AFTER close: %d", monGoroutinesAfter)
-
-	assert.Equal(t, 0, monGoroutinesAfter,
+	// Wait until pprof reflects the goroutine exit.
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		runtime.Gosched()
+		return countHeartbeatGoroutines(t, "startValidatorProcessing") == 0
+	}, 2*time.Second, 10*time.Millisecond,
 		"monitor goroutine should be gone after HeartbeatHandler.Close")
 }
 

--- a/node/heartbeat/process/monitor.go
+++ b/node/heartbeat/process/monitor.go
@@ -551,6 +551,10 @@ func (m *Monitor) startValidatorProcessing() {
 		ticker := time.NewTicker(refreshInterval)
 		defer ticker.Stop()
 
+		// Initial refresh on startup so metrics/state are persisted immediately,
+		// matching the pre-ticker behavior.
+		m.refreshHeartbeatMessageInfo()
+
 		for {
 			select {
 			case <-m.stopCh:

--- a/node/heartbeat/process/monitor.go
+++ b/node/heartbeat/process/monitor.go
@@ -60,6 +60,9 @@ type Monitor struct {
 	validatorPubkeyConverter           core.PubkeyConverter
 	heartbeatRefreshIntervalInSec      uint32
 	hideInactiveValidatorIntervalInSec uint32
+	stopCh                             chan struct{}
+	wg                                 sync.WaitGroup
+	closeOnce                          sync.Once
 }
 
 // NewMonitor returns a new monitor instance
@@ -110,6 +113,7 @@ func NewMonitor(arg ArgHeartbeatMonitor) (*Monitor, error) {
 		heartbeatRefreshIntervalInSec:      arg.HeartbeatRefreshIntervalInSec,
 		hideInactiveValidatorIntervalInSec: arg.HideInactiveValidatorIntervalInSec,
 		doubleSignerPeers:                  make(map[string]process.TimeCacher),
+		stopCh:                             make(chan struct{}),
 	}
 
 	err := mon.storer.UpdateGenesisTime(arg.GenesisTime)
@@ -540,14 +544,32 @@ func (m *Monitor) convertFromExportedStruct(hbDTO *data.HeartbeatDTO, maxDuratio
 
 // startValidatorProcessing will start the updating of the information about the nodes
 func (m *Monitor) startValidatorProcessing() {
+	m.wg.Add(1)
 	go func() {
+		defer m.wg.Done()
 		refreshInterval := time.Duration(m.heartbeatRefreshIntervalInSec) * time.Second
+		ticker := time.NewTicker(refreshInterval)
+		defer ticker.Stop()
 
 		for {
-			m.refreshHeartbeatMessageInfo()
-			time.Sleep(refreshInterval)
+			select {
+			case <-m.stopCh:
+				return
+			case <-ticker.C:
+				m.refreshHeartbeatMessageInfo()
+			}
 		}
 	}()
+}
+
+// Close will stop the background processing goroutine and wait for it to exit.
+// Safe to call multiple times; subsequent calls are no-ops.
+func (m *Monitor) Close() error {
+	m.closeOnce.Do(func() {
+		close(m.stopCh)
+	})
+	m.wg.Wait()
+	return nil
 }
 
 func (m *Monitor) refreshHeartbeatMessageInfo() {

--- a/node/heartbeat/process/monitorEdgeCases_test.go
+++ b/node/heartbeat/process/monitorEdgeCases_test.go
@@ -69,6 +69,7 @@ func TestMonitor_ObserverGapValidatorOffline(t *testing.T) {
 
 	genesisTime := timer.Now()
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	time.Sleep(sleepDuration)
 	timer.SetSeconds(tenSeconds)
 	mon1.RefreshHeartbeatMessageInfo()
@@ -82,6 +83,7 @@ func TestMonitor_ObserverGapValidatorOffline(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 
 	time.Sleep(sleepDuration)
 	timer.SetSeconds(hundredFiftySeconds)
@@ -108,6 +110,7 @@ func TestMonitor_ObserverGapValidatorOnline(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	mon1.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 
 	mon1.RefreshHeartbeatMessageInfo()
@@ -127,6 +130,7 @@ func TestMonitor_ObserverGapValidatorOnline(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon2.RefreshHeartbeatMessageInfo()
 	heartBeats = mon2.GetHeartbeats()
@@ -158,6 +162,7 @@ func TestMonitor_ObserverGapValidatorActiveUnitlMaxPeriodEnds(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	mon1.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon1.RefreshHeartbeatMessageInfo()
 	heartBeats := mon1.GetHeartbeats()
@@ -198,6 +203,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline1(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	mon1.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 
 	mon1.RefreshHeartbeatMessageInfo()
@@ -217,6 +223,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline1(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 	time.Sleep(20 * time.Millisecond)
 	mon2.RefreshHeartbeatMessageInfo()
 	heartBeats = mon2.GetHeartbeats()
@@ -251,6 +258,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline2(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	mon1.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 
 	mon1.RefreshHeartbeatMessageInfo()
@@ -273,6 +281,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline2(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon2.RefreshHeartbeatMessageInfo()
@@ -304,6 +313,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline3(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	mon1.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 
 	mon1.RefreshHeartbeatMessageInfo()
@@ -324,6 +334,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline3(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon2.RefreshHeartbeatMessageInfo()
 	heartBeats = mon2.GetHeartbeats()
@@ -357,6 +368,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline4(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	time.Sleep(20 * time.Millisecond)
 	mon1.RefreshHeartbeatMessageInfo()
 	heartBeats := mon1.GetHeartbeats()
@@ -376,6 +388,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline4(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon2.RefreshHeartbeatMessageInfo()
 	heartBeats = mon2.GetHeartbeats()
@@ -407,6 +420,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline5(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	heartBeats := mon1.GetHeartbeats()
 	verifyHeartBeat(t, heartBeats[0], false, 0, 0)
 
@@ -424,6 +438,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline5(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon2.RefreshHeartbeatMessageInfo()
 	heartBeats = mon2.GetHeartbeats()
@@ -459,6 +474,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline6(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	time.Sleep(20 * time.Millisecond)
 	mon1.RefreshHeartbeatMessageInfo()
 	heartBeats := mon1.GetHeartbeats()
@@ -476,6 +492,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline6(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 	mon2.RefreshHeartbeatMessageInfo()
 	heartBeats = mon2.GetHeartbeats()
 	verifyHeartBeat(t, heartBeats[0], false, 0, 100)
@@ -506,6 +523,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline7(t *testing.T) {
 	genesisTime := timer.Now()
 
 	mon1 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon1.Close()
 	mon1.RefreshHeartbeatMessageInfo()
 	mon1.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	heartBeats := mon1.GetHeartbeats()
@@ -524,6 +542,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline7(t *testing.T) {
 
 	timer.SetSeconds(hundredSeconds)
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+	defer mon2.Close()
 	mon2.RefreshHeartbeatMessageInfo()
 	heartBeats = mon2.GetHeartbeats()
 	verifyHeartBeat(t, heartBeats[0], true, 100, 0)

--- a/node/heartbeat/process/monitorEdgeCases_test.go
+++ b/node/heartbeat/process/monitorEdgeCases_test.go
@@ -82,6 +82,7 @@ func TestMonitor_ObserverGapValidatorOffline(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], false, 0, 20)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 
@@ -129,6 +130,7 @@ func TestMonitor_ObserverGapValidatorOnline(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -222,6 +224,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline1(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	time.Sleep(20 * time.Millisecond)
@@ -280,6 +283,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline2(t *testing.T) {
 	time.Sleep(sleepDuration)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 
@@ -333,6 +337,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline3(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -387,6 +392,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline4(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 10, 10)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -437,6 +443,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline5(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 10, 10)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -491,6 +498,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline6(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], false, 0, 20)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.RefreshHeartbeatMessageInfo()
@@ -541,6 +549,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline7(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
+	mon1.Close() // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.RefreshHeartbeatMessageInfo()

--- a/node/heartbeat/process/monitorEdgeCases_test.go
+++ b/node/heartbeat/process/monitorEdgeCases_test.go
@@ -82,7 +82,7 @@ func TestMonitor_ObserverGapValidatorOffline(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], false, 0, 20)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 
@@ -130,7 +130,7 @@ func TestMonitor_ObserverGapValidatorOnline(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -224,7 +224,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline1(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	time.Sleep(20 * time.Millisecond)
@@ -283,7 +283,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline2(t *testing.T) {
 	time.Sleep(sleepDuration)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 
@@ -337,7 +337,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline3(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -392,7 +392,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline4(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 10, 10)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -443,7 +443,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline5(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 10, 10)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.AddHeartbeatMessageToMap(&data.Heartbeat{Pubkey: []byte(pkValidator)})
@@ -498,7 +498,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline6(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], false, 0, 20)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.RefreshHeartbeatMessageInfo()
@@ -549,7 +549,7 @@ func TestMonitor_ObserverGapValidatorPartlyOnline7(t *testing.T) {
 	verifyHeartBeat(t, heartBeats[0], true, 20, 0)
 
 	timer.SetSeconds(hundredSeconds)
-	mon1.Close() // explicit shutdown before mon2 — models a node restart
+	assert.NoError(t, mon1.Close()) // explicit shutdown before mon2 — models a node restart
 	mon2 := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 	defer mon2.Close()
 	mon2.RefreshHeartbeatMessageInfo()

--- a/node/heartbeat/process/monitor_close_test.go
+++ b/node/heartbeat/process/monitor_close_test.go
@@ -1,0 +1,206 @@
+package process_test
+
+import (
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/klever-io/klever-go/node/heartbeat/mock"
+	"github.com/klever-io/klever-go/node/heartbeat/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// countMonitorGoroutines counts how many goroutines are currently parked
+// inside startValidatorProcessing (identified by the function name in their stack).
+func countMonitorGoroutines(t *testing.T) int {
+	t.Helper()
+	var buf strings.Builder
+	if err := pprof.Lookup("goroutine").WriteTo(&logWriter{&buf}, 1); err != nil {
+		t.Fatalf("pprof dump failed: %v", err)
+	}
+	return strings.Count(buf.String(), "startValidatorProcessing")
+}
+
+type logWriter struct{ b *strings.Builder }
+
+func (w *logWriter) Write(p []byte) (int, error) {
+	w.b.Write(p)
+	return len(p), nil
+}
+
+func TestMonitor_CloseStopsGoroutine(t *testing.T) {
+	// No t.Parallel: depends on global goroutine count.
+
+	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	before := countMonitorGoroutines(t)
+	t.Logf("monitor goroutines BEFORE create: %d", before)
+
+	mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+
+	// Give the goroutine a moment to actually start and park in select
+	time.Sleep(50 * time.Millisecond)
+	runtime.Gosched()
+
+	afterCreate := countMonitorGoroutines(t)
+	t.Logf("monitor goroutines AFTER create: %d", afterCreate)
+
+	if afterCreate <= before {
+		t.Fatalf("expected new startValidatorProcessing goroutine to appear, before=%d after=%d", before, afterCreate)
+	}
+
+	// Now call Close and verify the goroutine actually exits
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- mon.Close() }()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return within 5s — goroutine leak / Wait blocked forever")
+	}
+
+	// Give scheduler a tick to reflect the goroutine exit in pprof
+	time.Sleep(50 * time.Millisecond)
+	runtime.Gosched()
+
+	afterClose := countMonitorGoroutines(t)
+	t.Logf("monitor goroutines AFTER close: %d", afterClose)
+
+	if afterClose != before {
+		// Dump goroutines to show what's still around
+		var dump strings.Builder
+		_ = pprof.Lookup("goroutine").WriteTo(&logWriter{&dump}, 1)
+		t.Fatalf("goroutine did not exit on Close: before=%d, afterClose=%d\n%s",
+			before, afterClose, dump.String())
+	}
+}
+
+func TestMonitor_CloseDoesNotHangOnFreshMonitor(t *testing.T) {
+	// Verify that Close on a freshly-created Monitor (before any ticker fire)
+	// returns promptly and does not block on wg.Wait().
+	t.Parallel()
+
+	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+
+	done := make(chan struct{})
+	go func() {
+		_ = mon.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — Close completed
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close hung even before any ticker fire")
+	}
+}
+
+func TestMonitor_CloseIsIdempotent(t *testing.T) {
+	// Verify that calling Close() multiple times does NOT panic
+	// (close-of-closed-channel) and returns nil on every call.
+	t.Parallel()
+
+	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, mon.Close())
+		require.NoError(t, mon.Close())
+		require.NoError(t, mon.Close())
+	}, "Close must be idempotent and not panic on repeated calls")
+}
+
+func TestMonitor_ConcurrentClose(t *testing.T) {
+	// Fire many goroutines all racing to Close the same Monitor.
+	// Validates the sync.Once guard works correctly under contention.
+	t.Parallel()
+
+	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+
+	const concurrency = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- mon.Close()
+		}()
+	}
+
+	close(start)
+
+	doneAll := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneAll)
+	}()
+
+	select {
+	case <-doneAll:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Close did not converge within 5s")
+	}
+
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err, "Close must return nil for every concurrent caller")
+	}
+}
+
+func TestMonitor_NoGoroutineLeakAcrossManyCreates(t *testing.T) {
+	// Create and Close 50 monitors; verify no accumulation of startValidatorProcessing goroutines.
+	// No t.Parallel: depends on global goroutine count.
+
+	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	before := countMonitorGoroutines(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = mon.Close()
+		}()
+	}
+	wg.Wait()
+
+	// Allow scheduler to clean up
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	runtime.Gosched()
+
+	after := countMonitorGoroutines(t)
+	t.Logf("monitor goroutines: before=%d after=%d", before, after)
+
+	if after > before {
+		t.Fatalf("goroutine leak detected: %d extra goroutines after 50 create/close cycles", after-before)
+	}
+}

--- a/node/heartbeat/process/monitor_close_test.go
+++ b/node/heartbeat/process/monitor_close_test.go
@@ -34,7 +34,8 @@ func (w *logWriter) Write(p []byte) (int, error) {
 func TestMonitor_CloseStopsGoroutine(t *testing.T) {
 	// No t.Parallel: depends on global goroutine count.
 
-	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	storer, err := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	require.NoError(t, err)
 	timer := mock.NewTimerMock()
 	genesisTime := timer.Now()
 
@@ -43,44 +44,32 @@ func TestMonitor_CloseStopsGoroutine(t *testing.T) {
 
 	mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 
-	// Give the goroutine a moment to actually start and park in select
-	time.Sleep(50 * time.Millisecond)
-	runtime.Gosched()
+	// Wait until the new goroutine is visible in pprof.
+	require.Eventually(t, func() bool {
+		runtime.Gosched()
+		return countMonitorGoroutines(t) > before
+	}, 2*time.Second, 10*time.Millisecond,
+		"expected new startValidatorProcessing goroutine to appear")
 
-	afterCreate := countMonitorGoroutines(t)
-	t.Logf("monitor goroutines AFTER create: %d", afterCreate)
-
-	if afterCreate <= before {
-		t.Fatalf("expected new startValidatorProcessing goroutine to appear, before=%d after=%d", before, afterCreate)
-	}
-
-	// Now call Close and verify the goroutine actually exits
+	// Now call Close and verify the goroutine actually exits.
 	closeDone := make(chan error, 1)
 	go func() { closeDone <- mon.Close() }()
 
 	select {
 	case err := <-closeDone:
-		if err != nil {
-			t.Fatalf("Close returned error: %v", err)
-		}
+		require.NoError(t, err, "Close returned error")
 	case <-time.After(5 * time.Second):
 		t.Fatal("Close did not return within 5s — goroutine leak / Wait blocked forever")
 	}
 
-	// Give scheduler a tick to reflect the goroutine exit in pprof
-	time.Sleep(50 * time.Millisecond)
-	runtime.Gosched()
-
-	afterClose := countMonitorGoroutines(t)
-	t.Logf("monitor goroutines AFTER close: %d", afterClose)
-
-	if afterClose != before {
-		// Dump goroutines to show what's still around
-		var dump strings.Builder
-		_ = pprof.Lookup("goroutine").WriteTo(&logWriter{&dump}, 1)
-		t.Fatalf("goroutine did not exit on Close: before=%d, afterClose=%d\n%s",
-			before, afterClose, dump.String())
-	}
+	// Wait until pprof reflects the goroutine exit. Use non-increase rather than
+	// strict equality to tolerate other tests' goroutines on the global count.
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		runtime.Gosched()
+		return countMonitorGoroutines(t) <= before
+	}, 2*time.Second, 10*time.Millisecond,
+		"goroutine did not exit on Close")
 }
 
 func TestMonitor_CloseDoesNotHangOnFreshMonitor(t *testing.T) {
@@ -88,21 +77,19 @@ func TestMonitor_CloseDoesNotHangOnFreshMonitor(t *testing.T) {
 	// returns promptly and does not block on wg.Wait().
 	t.Parallel()
 
-	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	storer, err := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	require.NoError(t, err)
 	timer := mock.NewTimerMock()
 	genesisTime := timer.Now()
 
 	mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 
-	done := make(chan struct{})
-	go func() {
-		_ = mon.Close()
-		close(done)
-	}()
+	closeErr := make(chan error, 1)
+	go func() { closeErr <- mon.Close() }()
 
 	select {
-	case <-done:
-		// Good — Close completed
+	case err := <-closeErr:
+		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("Close hung even before any ticker fire")
 	}
@@ -113,7 +100,8 @@ func TestMonitor_CloseIsIdempotent(t *testing.T) {
 	// (close-of-closed-channel) and returns nil on every call.
 	t.Parallel()
 
-	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	storer, err := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	require.NoError(t, err)
 	timer := mock.NewTimerMock()
 	genesisTime := timer.Now()
 
@@ -131,7 +119,8 @@ func TestMonitor_ConcurrentClose(t *testing.T) {
 	// Validates the sync.Once guard works correctly under contention.
 	t.Parallel()
 
-	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	storer, err := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	require.NoError(t, err)
 	timer := mock.NewTimerMock()
 	genesisTime := timer.Now()
 
@@ -175,32 +164,35 @@ func TestMonitor_NoGoroutineLeakAcrossManyCreates(t *testing.T) {
 	// Create and Close 50 monitors; verify no accumulation of startValidatorProcessing goroutines.
 	// No t.Parallel: depends on global goroutine count.
 
-	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	storer, err := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
+	require.NoError(t, err)
 	timer := mock.NewTimerMock()
 	genesisTime := timer.Now()
 
 	before := countMonitorGoroutines(t)
 
+	const cycles = 50
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
+	closeErrs := make(chan error, cycles)
+	for i := 0; i < cycles; i++ {
 		mon := createMonitor(storer, genesisTime, unresponsiveDuration, timer)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = mon.Close()
+			closeErrs <- mon.Close()
 		}()
 	}
 	wg.Wait()
-
-	// Allow scheduler to clean up
-	time.Sleep(100 * time.Millisecond)
-	runtime.GC()
-	runtime.Gosched()
-
-	after := countMonitorGoroutines(t)
-	t.Logf("monitor goroutines: before=%d after=%d", before, after)
-
-	if after > before {
-		t.Fatalf("goroutine leak detected: %d extra goroutines after 50 create/close cycles", after-before)
+	close(closeErrs)
+	for err := range closeErrs {
+		require.NoError(t, err)
 	}
+
+	// Wait until the global count drops back to baseline (non-increase).
+	require.Eventually(t, func() bool {
+		runtime.GC()
+		runtime.Gosched()
+		return countMonitorGoroutines(t) <= before
+	}, 2*time.Second, 10*time.Millisecond,
+		"goroutine leak detected after %d create/close cycles", cycles)
 }

--- a/node/heartbeat/process/monitor_test.go
+++ b/node/heartbeat/process/monitor_test.go
@@ -196,6 +196,7 @@ func TestNewMonitor_OkValsShouldCreatePubkeyMap(t *testing.T) {
 	mon, err := process.NewMonitor(arg)
 
 	assert.Nil(t, err)
+	defer mon.Close()
 	assert.False(t, check.IfNil(mon))
 
 	hbStatus := mon.GetHeartbeats()

--- a/node/interface.go
+++ b/node/interface.go
@@ -76,6 +76,7 @@ type Accumulator interface {
 type HeartbeatHandler interface {
 	Monitor() *process.Monitor
 	Sender() *process.Sender
+	Close() error
 	IsInterfaceNil() bool
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -227,6 +227,12 @@ func (n *Node) GetPeerHonestyHandler() consensus.PeerHonestyHandler {
 	return n.peerHonestyHandler
 }
 
+// GetHeartbeatHandler returns the heartbeat handler attached to this node.
+// Returned for shutdown wiring so the caller can Close it on process exit.
+func (n *Node) GetHeartbeatHandler() HeartbeatHandler {
+	return n.heartbeatHandler
+}
+
 // CreateStores instantiate cachers for Transactions and Headers
 func (n *Node) CreateStores() error {
 	if n.dataPool == nil {


### PR DESCRIPTION
## Summary

`process.Monitor` started an unbounded background goroutine in `startValidatorProcessing` with no stop path. When two monitors share a `HeartbeatDbStorer` (the node-restart shape used by `TestMonitor_ObserverGapValidatorPartlyOnline5`), the first monitor's goroutine could fire after the test advanced the mock clock but before the second monitor loaded state, writing stale "inactive" calculations into shared storage and corrupting the second monitor's view.

The fix gives both the monitor refresh loop and the heartbeat sender loop a proper shutdown handshake, then wires both into the existing background-closer slice in `cmd/node/startup.go`.

## Changes

**`node/heartbeat/process/monitor.go`**
- Add `stopCh chan struct{}`, `wg sync.WaitGroup`, `closeOnce sync.Once` fields
- Replace `time.Sleep` ticker loop with `time.NewTicker` + `select` on `stopCh`
- Add `Close() error` guarded by `sync.Once` so repeated calls are safe

**`node/heartbeat/componentHandler/heartbeatHandler.go`**
- Add `senderDone chan struct{}`; `defer close(hbh.senderDone)` inside `startSendingHeartbeats`
- `Close()` cancels the context, waits on `<-senderDone`, then calls `monitor.Close()`
- Idempotency is implicit: `cancelFunc` is idempotent, receive on a closed channel returns immediately, `monitor.Close()` is guarded by its own `sync.Once`

**`node/interface.go` / `node/node.go`**
- Add `Close() error` to the `HeartbeatHandler` interface
- Expose `Node.GetHeartbeatHandler()` so the startup closer slice can reach it

**`cmd/node/startup.go`**
- Append `currentNode.GetHeartbeatHandler()` to the `backgroundClosers` slice so the closer loop drains heartbeat goroutines before tearing down dependent components

**Tests**
- Add `defer mon.Close()` to all `createMonitor(...)` and `NewMonitor(arg)` sites in the existing test suites
- New `monitor_close_test.go`: goroutine-leak detection (pprof-based), idempotency, concurrent `Close`, no-leak-across-many-creates
- New `heartbeatHandler_close_test.go`: full production shutdown path drains the monitor goroutine; idempotent and concurrent `Close` on the handler

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./node/heartbeat/... ./cmd/node ./node` clean
- [x] `go test -race ./node/...` — all packages pass
- [x] `TestMonitor_ObserverGapValidatorPartlyOnline5` — 100× with `-race`, no failures
- [x] `TestMonitor_CloseIsIdempotent`, `TestMonitor_ConcurrentClose` — 100× with `-race`
- [x] `TestHeartbeatHandler_CloseStopsMonitorGoroutine`, `TestHeartbeatHandler_CloseIsIdempotent`, `TestHeartbeatHandler_ConcurrentClose` — 50× with `-race`
- [x] `go build -race ./cmd/node` — node binary builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Node Stability & Resource Management

This PR fixes a goroutine leak in the heartbeat monitoring subsystem that could cause resource leaks and stale "inactive" writes when multiple monitors share a HeartbeatDbStorer. The root cause was an unbounded monitor background goroutine started by process.Monitor with no stop path; it is now drained during shutdown to avoid stale writes and shared-storage corruption.

## Concurrency & Lifecycle Management Changes

- Monitor shutdown:
  - Monitor now includes stopCh, sync.WaitGroup, and sync.Once.
  - startValidatorProcessing now performs an immediate refresh and runs a ticker-driven loop with a select on stopCh instead of a sleep loop.
  - Added Monitor.Close() which is idempotent and waits for the background goroutine to exit.
- HeartbeatHandler sender shutdown:
  - Added senderDone channel; startSendingHeartbeats defers close(senderDone).
  - HeartbeatHandler.Close() cancels the handler context, waits for senderDone, then calls monitor.Close().
- Shutdown wiring:
  - HeartbeatHandler interface now includes Close() error.
  - Node exposes GetHeartbeatHandler().
  - Node startup appends the heartbeat handler to backgroundClosers so heartbeat components are closed/drained during global shutdown.

## Testing

- Added unit tests that detect goroutine leaks via runtime/pprof, assert Close() idempotency, verify concurrent Close() safety, and stress repeated create/close cycles.
- Updated existing tests to defer mon.Close() and to explicitly Close() previous monitors before creating replacements.
- Reported passing: build, vet, race tests and targeted stress runs.

## Impact on blockchain-critical components

- No changes to consensus, transaction processing, state management, the KVM, or networking logic. Changes are limited to heartbeat/monitor lifecycle and concurrency handling.
- Improves node stability and data integrity by eliminating goroutine leaks and preventing stale heartbeat writes that could corrupt shared heartbeat storage. No changes to core protocols or functional behavior.

## Cross-cutting concerns

- Improves concurrency safety via explicit shutdown handshakes and idempotent Close() implementations.
- Ensures deterministic shutdown ordering for heartbeat components, avoiding races during node teardown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->