### PR TITLE
[KLC-2424] blockchain: atomic Set/Get current header+hash primitive

### DIFF
--- a/common/mock/blockChainMock.go
+++ b/common/mock/blockChainMock.go
@@ -6,22 +6,24 @@ import (
 
 // BlockChainMock is a mock implementation of the blockchain interface
 type BlockChainMock struct {
-	GetGenesisHeaderCalled          func() data.HeaderHandler
-	SetGenesisHeaderCalled          func(handler data.HeaderHandler) error
-	GetGenesisHeaderHashCalled      func() []byte
-	SetGenesisHeaderHashCalled      func([]byte)
-	GetCurrentBlockHeaderCalled     func() data.HeaderHandler
-	SetCurrentBlockHeaderCalled     func(data.HeaderHandler) error
-	GetCurrentBlockHeaderHashCalled func() []byte
-	SetCurrentBlockHeaderHashCalled func([]byte)
-	GetCurrentBlockRootHashCalled   func() []byte
-	GetLocalHeightCalled            func() int64
-	SetLocalHeightCalled            func(int64)
-	GetNetworkHeightCalled          func() int64
-	SetNetworkHeightCalled          func(int64)
-	HasBadBlockCalled               func([]byte) bool
-	PutBadBlockCalled               func([]byte)
-	CreateNewHeaderCalled           func() data.HeaderHandler
+	GetGenesisHeaderCalled             func() data.HeaderHandler
+	SetGenesisHeaderCalled             func(handler data.HeaderHandler) error
+	GetGenesisHeaderHashCalled         func() []byte
+	SetGenesisHeaderHashCalled         func([]byte)
+	GetCurrentBlockHeaderCalled        func() data.HeaderHandler
+	SetCurrentBlockHeaderCalled        func(data.HeaderHandler) error
+	GetCurrentBlockHeaderHashCalled    func() []byte
+	SetCurrentBlockHeaderHashCalled    func([]byte)
+	SetCurrentBlockHeaderAndHashCalled func(data.HeaderHandler, []byte) error
+	GetCurrentBlockHeaderAndHashCalled func() (data.HeaderHandler, []byte)
+	GetCurrentBlockRootHashCalled      func() []byte
+	GetLocalHeightCalled               func() int64
+	SetLocalHeightCalled               func(int64)
+	GetNetworkHeightCalled             func() int64
+	SetNetworkHeightCalled             func(int64)
+	HasBadBlockCalled                  func([]byte) bool
+	PutBadBlockCalled                  func([]byte)
+	CreateNewHeaderCalled              func() data.HeaderHandler
 }
 
 // GetGenesisHeader returns the genesis block header pointer
@@ -84,6 +86,22 @@ func (bc *BlockChainMock) SetCurrentBlockHeaderHash(hash []byte) {
 	if bc.SetCurrentBlockHeaderHashCalled != nil {
 		bc.SetCurrentBlockHeaderHashCalled(hash)
 	}
+}
+
+// SetCurrentBlockHeaderAndHash atomically sets the current block header and its hash
+func (bc *BlockChainMock) SetCurrentBlockHeaderAndHash(header data.HeaderHandler, hash []byte) error {
+	if bc.SetCurrentBlockHeaderAndHashCalled != nil {
+		return bc.SetCurrentBlockHeaderAndHashCalled(header, hash)
+	}
+	return nil
+}
+
+// GetCurrentBlockHeaderAndHash atomically returns the current block header and its hash
+func (bc *BlockChainMock) GetCurrentBlockHeaderAndHash() (data.HeaderHandler, []byte) {
+	if bc.GetCurrentBlockHeaderAndHashCalled != nil {
+		return bc.GetCurrentBlockHeaderAndHashCalled()
+	}
+	return nil, nil
 }
 
 // GetCurrentBlockRootHash returns the current block root hash

--- a/common/mock/blockChainStub.go
+++ b/common/mock/blockChainStub.go
@@ -6,15 +6,17 @@ import (
 
 // BlockChainStub is a mock implementation of the blockchain interface
 type BlockChainStub struct {
-	GetGenesisHeaderCalled          func() data.HeaderHandler
-	SetGenesisHeaderCalled          func(handler data.HeaderHandler) error
-	GetGenesisHeaderHashCalled      func() []byte
-	SetGenesisHeaderHashCalled      func([]byte)
-	GetCurrentBlockHeaderCalled     func() data.HeaderHandler
-	SetCurrentBlockHeaderCalled     func(data.HeaderHandler) error
-	GetCurrentBlockHeaderHashCalled func() []byte
-	SetCurrentBlockHeaderHashCalled func([]byte)
-	CreateNewHeaderCalled           func() data.HeaderHandler
+	GetGenesisHeaderCalled             func() data.HeaderHandler
+	SetGenesisHeaderCalled             func(handler data.HeaderHandler) error
+	GetGenesisHeaderHashCalled         func() []byte
+	SetGenesisHeaderHashCalled         func([]byte)
+	GetCurrentBlockHeaderCalled        func() data.HeaderHandler
+	SetCurrentBlockHeaderCalled        func(data.HeaderHandler) error
+	GetCurrentBlockHeaderHashCalled    func() []byte
+	SetCurrentBlockHeaderHashCalled    func([]byte)
+	SetCurrentBlockHeaderAndHashCalled func(data.HeaderHandler, []byte) error
+	GetCurrentBlockHeaderAndHashCalled func() (data.HeaderHandler, []byte)
+	CreateNewHeaderCalled              func() data.HeaderHandler
 }
 
 // GetGenesisHeader returns the genesis block header pointer
@@ -77,6 +79,22 @@ func (bcs *BlockChainStub) SetCurrentBlockHeaderHash(hash []byte) {
 	if bcs.SetCurrentBlockHeaderHashCalled != nil {
 		bcs.SetCurrentBlockHeaderHashCalled(hash)
 	}
+}
+
+// SetCurrentBlockHeaderAndHash atomically sets the current block header and its hash
+func (bcs *BlockChainStub) SetCurrentBlockHeaderAndHash(header data.HeaderHandler, hash []byte) error {
+	if bcs.SetCurrentBlockHeaderAndHashCalled != nil {
+		return bcs.SetCurrentBlockHeaderAndHashCalled(header, hash)
+	}
+	return nil
+}
+
+// GetCurrentBlockHeaderAndHash atomically returns the current block header and its hash
+func (bcs *BlockChainStub) GetCurrentBlockHeaderAndHash() (data.HeaderHandler, []byte) {
+	if bcs.GetCurrentBlockHeaderAndHashCalled != nil {
+		return bcs.GetCurrentBlockHeaderAndHashCalled()
+	}
+	return nil, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/core/process/block/block.go
+++ b/core/process/block/block.go
@@ -673,12 +673,12 @@ func (mp *metaProcessor) CommitBlock(
 	lastMetaBlock := mp.blockChain.GetCurrentBlockHeader()
 	mp.updateState(lastMetaBlock)
 
-	// set blockchain header info
-	err = mp.blockChain.SetCurrentBlockHeader(header)
+	// set blockchain header info atomically so readers cannot observe a
+	// mismatched (header, hash) pair between the two updates
+	err = mp.blockChain.SetCurrentBlockHeaderAndHash(header, headerHash)
 	if err != nil {
 		return err
 	}
-	mp.blockChain.SetCurrentBlockHeaderHash(headerHash)
 
 	mp.tpsBenchmark.Update(lastMetaBlock)
 

--- a/core/process/sync/baseSync.go
+++ b/core/process/sync/baseSync.go
@@ -886,12 +886,10 @@ func (boot *baseBootstrap) restoreState(
 		"nonce", currHeader.GetNonce(),
 		"hash", currHeaderHash)
 
-	err := boot.chainHandler.SetCurrentBlockHeader(currHeader)
+	err := boot.chainHandler.SetCurrentBlockHeaderAndHash(currHeader, currHeaderHash)
 	if err != nil {
-		log.Debug("SetCurrentBlockHeader", "error", err.Error())
+		log.Debug("SetCurrentBlockHeaderAndHash", "error", err.Error())
 	}
-
-	boot.chainHandler.SetCurrentBlockHeaderHash(currHeaderHash)
 
 	err = boot.blockProcessor.RevertStateToBlock(currHeader)
 	if err != nil {
@@ -903,15 +901,7 @@ func (boot *baseBootstrap) setCurrentBlockInfo(
 	headerHash []byte,
 	header data.HeaderHandler,
 ) error {
-
-	err := boot.chainHandler.SetCurrentBlockHeader(header)
-	if err != nil {
-		return err
-	}
-
-	boot.chainHandler.SetCurrentBlockHeaderHash(headerHash)
-
-	return nil
+	return boot.chainHandler.SetCurrentBlockHeaderAndHash(header, headerHash)
 }
 
 func (boot *baseBootstrap) init() {

--- a/core/process/sync/baseSync.go
+++ b/core/process/sync/baseSync.go
@@ -888,12 +888,13 @@ func (boot *baseBootstrap) restoreState(
 
 	err := boot.chainHandler.SetCurrentBlockHeaderAndHash(currHeader, currHeaderHash)
 	if err != nil {
-		log.Debug("SetCurrentBlockHeaderAndHash", "error", err.Error())
+		// recovery path after a failed rollback — surface double-failures so ops can react
+		log.Warn("restoreState: SetCurrentBlockHeaderAndHash", "error", err.Error())
 	}
 
 	err = boot.blockProcessor.RevertStateToBlock(currHeader)
 	if err != nil {
-		log.Debug("RevertState", "error", err.Error())
+		log.Warn("restoreState: RevertStateToBlock", "error", err.Error())
 	}
 }
 

--- a/core/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/core/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -391,7 +391,7 @@ func (st *storageBootstrapper) restoreBlockChainToGenesis() {
 
 	err = st.blkc.SetCurrentBlockHeaderAndHash(nil, nil)
 	if err != nil {
-		log.Debug("cannot set current block header", "error", err.Error())
+		log.Debug("cannot set current block header and hash", "error", err.Error())
 	}
 }
 

--- a/core/process/sync/storageBootstrap/baseStorageBootstrapper.go
+++ b/core/process/sync/storageBootstrap/baseStorageBootstrapper.go
@@ -379,14 +379,7 @@ func (st *storageBootstrapper) cleanupStorage(headerInfo *bootstrapStorage.Boots
 }
 
 func (st *storageBootstrapper) applyBlock(header data.HeaderHandler, headerHash []byte) error {
-	err := st.blkc.SetCurrentBlockHeader(header)
-	if err != nil {
-		return err
-	}
-
-	st.blkc.SetCurrentBlockHeaderHash(headerHash)
-
-	return nil
+	return st.blkc.SetCurrentBlockHeaderAndHash(header, headerHash)
 }
 
 func (st *storageBootstrapper) restoreBlockChainToGenesis() {
@@ -396,12 +389,10 @@ func (st *storageBootstrapper) restoreBlockChainToGenesis() {
 		log.Debug("cannot recreate trie for genesis header with nonce", "nonce", genesisHeader.GetNonce())
 	}
 
-	err = st.blkc.SetCurrentBlockHeader(nil)
+	err = st.blkc.SetCurrentBlockHeaderAndHash(nil, nil)
 	if err != nil {
 		log.Debug("cannot set current block header", "error", err.Error())
 	}
-
-	st.blkc.SetCurrentBlockHeaderHash(nil)
 }
 
 func checkBaseStorageBootstrapperArguments(args ArgsBaseStorageBootstrapper) error {

--- a/core/process/sync/storageBootstrap/baseStorageBootstrapper_test.go
+++ b/core/process/sync/storageBootstrap/baseStorageBootstrapper_test.go
@@ -176,8 +176,9 @@ func TestStorageBootstrapper_LoadAndApplyBlocks(t *testing.T) {
 		var headerCalled []byte
 
 		sb := newValidStorageBootstrapper(bootstrapData)
-		sb.blkc.(*mock.BlockChainMock).SetCurrentBlockHeaderHashCalled = func(hash []byte) {
+		sb.blkc.(*mock.BlockChainMock).SetCurrentBlockHeaderAndHashCalled = func(_ data.HeaderHandler, hash []byte) error {
 			headerCalled = hash
+			return nil
 		}
 
 		result, err := sb.loadAndApplyBlocks(98)
@@ -268,16 +269,14 @@ func TestStorageBootstrapper_HandleBlockLoadingError(t *testing.T) {
 		sb.blkc.(*mock.BlockChainMock).GetGenesisHeaderCalled = func() data.HeaderHandler {
 			return &block.Block{}
 		}
-		sb.blkc.(*mock.BlockChainMock).SetCurrentBlockHeaderCalled = func(header data.HeaderHandler) error {
+		sb.blkc.(*mock.BlockChainMock).SetCurrentBlockHeaderAndHashCalled = func(header data.HeaderHandler, hash []byte) error {
 			if header == nil {
 				headerCleared = true
 			}
-			return nil
-		}
-		sb.blkc.(*mock.BlockChainMock).SetCurrentBlockHeaderHashCalled = func(hash []byte) {
 			if hash == nil {
 				headerHashCleared = true
 			}
+			return nil
 		}
 
 		testErr := errors.New("test error")

--- a/data/blockchain/blockchain.go
+++ b/data/blockchain/blockchain.go
@@ -69,7 +69,7 @@ func (bc *blockChain) prepareCurrentBlockHeader(header data.HeaderHandler) (data
 		return nil, common.ErrInvalidHeaderType
 	}
 
-	log.Trace("SetCurrentBlockHeader", "nonce", h.Header.Nonce)
+	log.Trace("setCurrentBlockHeader", "nonce", h.Header.Nonce)
 
 	bc.appStatusHandler.SetUInt64Value(core.MetricSynchronizedSlot, h.Header.Slot)
 	bc.appStatusHandler.SetUInt64Value(core.MetricNonce, h.Header.Nonce)

--- a/data/blockchain/blockchain.go
+++ b/data/blockchain/blockchain.go
@@ -160,15 +160,19 @@ func (bc *blockChain) GetCurrentBlockHeaderHash() []byte {
 // calling GetCurrentBlockHeader and GetCurrentBlockHeaderHash separately when
 // the (header, hash) pair must be consistent — those two calls take separate
 // RLocks and can observe an update interleaved between them.
+//
+// The returned hash is a defensive copy so callers cannot mutate the
+// backing array and corrupt the atomic snapshot.
 func (bc *blockChain) GetCurrentBlockHeaderAndHash() (data.HeaderHandler, []byte) {
 	bc.mut.RLock()
 	defer bc.mut.RUnlock()
 
+	hashCopy := append([]byte(nil), bc.currentBlockHeaderHash...)
 	if check.IfNil(bc.currentBlockHeader) {
-		return nil, bc.currentBlockHeaderHash
+		return nil, hashCopy
 	}
 
-	return bc.currentBlockHeader.Clone(), bc.currentBlockHeaderHash
+	return bc.currentBlockHeader.Clone(), hashCopy
 }
 
 // SetCurrentBlockHeaderHash returns the current block header hash
@@ -181,15 +185,20 @@ func (bc *blockChain) SetCurrentBlockHeaderHash(hash []byte) {
 // SetCurrentBlockHeaderAndHash atomically sets the current block header and its hash
 // under a single mutex acquisition, preventing concurrent readers from observing a
 // mismatched (header, hash) pair between the two updates.
+//
+// The hash bytes are defensively copied so subsequent caller-side mutation of the
+// input slice cannot corrupt the stored snapshot.
 func (bc *blockChain) SetCurrentBlockHeaderAndHash(header data.HeaderHandler, hash []byte) error {
 	clone, err := bc.prepareCurrentBlockHeader(header)
 	if err != nil {
 		return err
 	}
 
+	hashCopy := append([]byte(nil), hash...)
+
 	bc.mut.Lock()
 	bc.currentBlockHeader = clone
-	bc.currentBlockHeaderHash = hash
+	bc.currentBlockHeaderHash = hashCopy
 	bc.mut.Unlock()
 
 	return nil

--- a/data/blockchain/blockchain.go
+++ b/data/blockchain/blockchain.go
@@ -56,19 +56,17 @@ func (bc *blockChain) SetGenesisHeader(genesisBlock data.HeaderHandler) error {
 	return nil
 }
 
-// SetCurrentBlockHeader sets current block header pointer
-func (bc *blockChain) SetCurrentBlockHeader(header data.HeaderHandler) error {
+// prepareCurrentBlockHeader validates the header, updates status metrics, and returns
+// a clone ready to be stored. Returns (nil, nil) when header is the nil interface.
+// Callers must assign the returned value under the appropriate mutex.
+func (bc *blockChain) prepareCurrentBlockHeader(header data.HeaderHandler) (data.HeaderHandler, error) {
 	if check.IfNil(header) {
-		bc.mut.Lock()
-		bc.currentBlockHeader = nil
-		bc.mut.Unlock()
-
-		return nil
+		return nil, nil
 	}
 
 	h, ok := header.(*block.Block)
 	if !ok {
-		return common.ErrInvalidHeaderType
+		return nil, common.ErrInvalidHeaderType
 	}
 
 	log.Trace("SetCurrentBlockHeader", "nonce", h.Header.Nonce)
@@ -76,8 +74,18 @@ func (bc *blockChain) SetCurrentBlockHeader(header data.HeaderHandler) error {
 	bc.appStatusHandler.SetUInt64Value(core.MetricSynchronizedSlot, h.Header.Slot)
 	bc.appStatusHandler.SetUInt64Value(core.MetricNonce, h.Header.Nonce)
 
+	return h.Clone(), nil
+}
+
+// SetCurrentBlockHeader sets current block header pointer
+func (bc *blockChain) SetCurrentBlockHeader(header data.HeaderHandler) error {
+	clone, err := bc.prepareCurrentBlockHeader(header)
+	if err != nil {
+		return err
+	}
+
 	bc.mut.Lock()
-	bc.currentBlockHeader = h.Clone()
+	bc.currentBlockHeader = clone
 	bc.mut.Unlock()
 
 	return nil
@@ -147,11 +155,44 @@ func (bc *blockChain) GetCurrentBlockHeaderHash() []byte {
 	return bc.currentBlockHeaderHash
 }
 
+// GetCurrentBlockHeaderAndHash atomically returns the current block header and
+// its hash under a single read lock acquisition. Use this in preference to
+// calling GetCurrentBlockHeader and GetCurrentBlockHeaderHash separately when
+// the (header, hash) pair must be consistent — those two calls take separate
+// RLocks and can observe an update interleaved between them.
+func (bc *blockChain) GetCurrentBlockHeaderAndHash() (data.HeaderHandler, []byte) {
+	bc.mut.RLock()
+	defer bc.mut.RUnlock()
+
+	if check.IfNil(bc.currentBlockHeader) {
+		return nil, bc.currentBlockHeaderHash
+	}
+
+	return bc.currentBlockHeader.Clone(), bc.currentBlockHeaderHash
+}
+
 // SetCurrentBlockHeaderHash returns the current block header hash
 func (bc *blockChain) SetCurrentBlockHeaderHash(hash []byte) {
 	bc.mut.Lock()
 	bc.currentBlockHeaderHash = hash
 	bc.mut.Unlock()
+}
+
+// SetCurrentBlockHeaderAndHash atomically sets the current block header and its hash
+// under a single mutex acquisition, preventing concurrent readers from observing a
+// mismatched (header, hash) pair between the two updates.
+func (bc *blockChain) SetCurrentBlockHeaderAndHash(header data.HeaderHandler, hash []byte) error {
+	clone, err := bc.prepareCurrentBlockHeader(header)
+	if err != nil {
+		return err
+	}
+
+	bc.mut.Lock()
+	bc.currentBlockHeader = clone
+	bc.currentBlockHeaderHash = hash
+	bc.mut.Unlock()
+
+	return nil
 }
 
 // GetCurrentBlockRootHash returns the current committed block root hash. The returned byte slice is a new copy

--- a/data/blockchain/blockchain_test.go
+++ b/data/blockchain/blockchain_test.go
@@ -2,6 +2,7 @@ package blockchain_test
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -205,17 +206,17 @@ func TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs(t *testing.T) {
 			default:
 			}
 			h, hash := bc.GetCurrentBlockHeaderAndHash()
-			if h == nil {
-				continue
-			}
-			want, ok := pairs[h.GetNonce()]
-			if !ok || want != string(hash) {
-				select {
-				case mismatch <- fmt.Sprintf("nonce=%d hash=%q", h.GetNonce(), string(hash)):
-				default:
+			if h != nil {
+				want, ok := pairs[h.GetNonce()]
+				if !ok || want != string(hash) {
+					select {
+					case mismatch <- fmt.Sprintf("nonce=%d hash=%q", h.GetNonce(), string(hash)):
+					default:
+					}
+					return
 				}
-				return
 			}
+			runtime.Gosched()
 		}
 	}()
 
@@ -229,6 +230,7 @@ func TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs(t *testing.T) {
 			}
 			_ = bc.SetCurrentBlockHeaderAndHash(hdrB, hashB)
 			_ = bc.SetCurrentBlockHeaderAndHash(hdrA, hashA)
+			runtime.Gosched()
 		}
 	}()
 
@@ -278,6 +280,7 @@ func TestBlockChain_SetCurrentBlockHeaderAndHashRaceClean(t *testing.T) {
 			}
 			_ = bc.GetCurrentBlockHeader()
 			_ = bc.GetCurrentBlockHeaderHash()
+			runtime.Gosched()
 		}
 	}()
 
@@ -291,6 +294,7 @@ func TestBlockChain_SetCurrentBlockHeaderAndHashRaceClean(t *testing.T) {
 			}
 			_ = bc.SetCurrentBlockHeaderAndHash(hdrB, hashB)
 			_ = bc.SetCurrentBlockHeaderAndHash(hdrA, hashA)
+			runtime.Gosched()
 		}
 	}()
 

--- a/data/blockchain/blockchain_test.go
+++ b/data/blockchain/blockchain_test.go
@@ -1,7 +1,9 @@
 package blockchain_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/common/mock"
@@ -111,6 +113,191 @@ func TestBlockChain_SettersWithInvalidBlock(t *testing.T) {
 
 	err = bc.SetGenesisHeader(&mock.HeaderHandlerStub{})
 	assert.Equal(t, common.ErrInvalidHeaderType, err)
+}
+
+func TestBlockChain_SetCurrentBlockHeaderAndHashShouldWork(t *testing.T) {
+	t.Parallel()
+
+	bc := blockchain.NewBlockChain()
+
+	hdr := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce: 7,
+		},
+	}
+	hash := []byte("matching-hash")
+
+	err := bc.SetCurrentBlockHeaderAndHash(hdr, hash)
+	assert.Nil(t, err)
+
+	assert.Equal(t, hdr.Clone(), bc.GetCurrentBlockHeader())
+	assert.Equal(t, hash, bc.GetCurrentBlockHeaderHash())
+}
+
+func TestBlockChain_SetCurrentBlockHeaderAndHashNilHeader(t *testing.T) {
+	t.Parallel()
+
+	bc := blockchain.NewBlockChain()
+
+	hdr := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce: 3,
+		},
+	}
+	require.NoError(t, bc.SetCurrentBlockHeader(hdr))
+	bc.SetCurrentBlockHeaderHash([]byte("old"))
+
+	err := bc.SetCurrentBlockHeaderAndHash(nil, []byte("new"))
+	assert.Nil(t, err)
+
+	assert.Nil(t, bc.GetCurrentBlockHeader())
+	assert.Equal(t, []byte("new"), bc.GetCurrentBlockHeaderHash())
+}
+
+func TestBlockChain_SetCurrentBlockHeaderAndHashInvalidHeaderType(t *testing.T) {
+	t.Parallel()
+
+	bc := blockchain.NewBlockChain()
+
+	hdr := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce: 1,
+		},
+	}
+	hash := []byte("preserved")
+	require.NoError(t, bc.SetCurrentBlockHeader(hdr))
+	bc.SetCurrentBlockHeaderHash(hash)
+
+	err := bc.SetCurrentBlockHeaderAndHash(&mock.HeaderHandlerStub{}, []byte("ignored"))
+	assert.Equal(t, common.ErrInvalidHeaderType, err)
+
+	assert.Equal(t, hdr.Clone(), bc.GetCurrentBlockHeader())
+	assert.Equal(t, hash, bc.GetCurrentBlockHeaderHash())
+}
+
+func TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs(t *testing.T) {
+	t.Parallel()
+
+	bc := blockchain.NewBlockChain()
+
+	hdrA := &block.Block{Header: &block.BlockHeader{Nonce: 10}}
+	hashA := []byte("hash-10")
+	hdrB := &block.Block{Header: &block.BlockHeader{Nonce: 9}}
+	hashB := []byte("hash-9")
+
+	// The pair (nonce, hash) must always be one of these two valid combinations.
+	pairs := map[uint64]string{
+		10: "hash-10",
+		9:  "hash-9",
+	}
+	require.NoError(t, bc.SetCurrentBlockHeaderAndHash(hdrA, hashA))
+
+	stop := make(chan struct{})
+	mismatch := make(chan string, 1)
+	done := make(chan struct{}, 2)
+
+	go func() {
+		defer func() { done <- struct{}{} }()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h, hash := bc.GetCurrentBlockHeaderAndHash()
+			if h == nil {
+				continue
+			}
+			want, ok := pairs[h.GetNonce()]
+			if !ok || want != string(hash) {
+				select {
+				case mismatch <- fmt.Sprintf("nonce=%d hash=%q", h.GetNonce(), string(hash)):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer func() { done <- struct{}{} }()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = bc.SetCurrentBlockHeaderAndHash(hdrB, hashB)
+			_ = bc.SetCurrentBlockHeaderAndHash(hdrA, hashA)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	<-done
+	<-done
+
+	select {
+	case m := <-mismatch:
+		t.Fatalf("observed mismatched (header, hash) pair via paired-read getter: %s", m)
+	default:
+	}
+}
+
+func TestBlockChain_GetCurrentBlockHeaderAndHashEmpty(t *testing.T) {
+	t.Parallel()
+
+	bc := blockchain.NewBlockChain()
+
+	h, hash := bc.GetCurrentBlockHeaderAndHash()
+	assert.Nil(t, h)
+	assert.Nil(t, hash)
+}
+
+func TestBlockChain_SetCurrentBlockHeaderAndHashRaceClean(t *testing.T) {
+	t.Parallel()
+
+	bc := blockchain.NewBlockChain()
+
+	hdrA := &block.Block{Header: &block.BlockHeader{Nonce: 10}}
+	hashA := []byte("hash-10")
+	hdrB := &block.Block{Header: &block.BlockHeader{Nonce: 9}}
+	hashB := []byte("hash-9")
+	require.NoError(t, bc.SetCurrentBlockHeaderAndHash(hdrA, hashA))
+
+	stop := make(chan struct{})
+	done := make(chan struct{}, 2)
+
+	go func() {
+		defer func() { done <- struct{}{} }()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = bc.GetCurrentBlockHeader()
+			_ = bc.GetCurrentBlockHeaderHash()
+		}
+	}()
+
+	go func() {
+		defer func() { done <- struct{}{} }()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = bc.SetCurrentBlockHeaderAndHash(hdrB, hashB)
+			_ = bc.SetCurrentBlockHeaderAndHash(hdrA, hashA)
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	<-done
+	<-done
 }
 
 func TestBlockChain_GetCurrentBlockRootHash(t *testing.T) {

--- a/data/blockchain/blockchain_test.go
+++ b/data/blockchain/blockchain_test.go
@@ -195,6 +195,7 @@ func TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs(t *testing.T) {
 
 	stop := make(chan struct{})
 	mismatch := make(chan string, 1)
+	writeErr := make(chan error, 1)
 	done := make(chan struct{}, 2)
 
 	go func() {
@@ -222,14 +223,23 @@ func TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs(t *testing.T) {
 
 	go func() {
 		defer func() { done <- struct{}{} }()
+		recordErr := func(err error) {
+			if err == nil {
+				return
+			}
+			select {
+			case writeErr <- err:
+			default:
+			}
+		}
 		for {
 			select {
 			case <-stop:
 				return
 			default:
 			}
-			_ = bc.SetCurrentBlockHeaderAndHash(hdrB, hashB)
-			_ = bc.SetCurrentBlockHeaderAndHash(hdrA, hashA)
+			recordErr(bc.SetCurrentBlockHeaderAndHash(hdrB, hashB))
+			recordErr(bc.SetCurrentBlockHeaderAndHash(hdrA, hashA))
 			runtime.Gosched()
 		}
 	}()
@@ -242,6 +252,11 @@ func TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs(t *testing.T) {
 	select {
 	case m := <-mismatch:
 		t.Fatalf("observed mismatched (header, hash) pair via paired-read getter: %s", m)
+	default:
+	}
+	select {
+	case err := <-writeErr:
+		t.Fatalf("writer goroutine reported error: %v", err)
 	default:
 	}
 }
@@ -268,6 +283,7 @@ func TestBlockChain_SetCurrentBlockHeaderAndHashRaceClean(t *testing.T) {
 	require.NoError(t, bc.SetCurrentBlockHeaderAndHash(hdrA, hashA))
 
 	stop := make(chan struct{})
+	writeErr := make(chan error, 1)
 	done := make(chan struct{}, 2)
 
 	go func() {
@@ -286,14 +302,23 @@ func TestBlockChain_SetCurrentBlockHeaderAndHashRaceClean(t *testing.T) {
 
 	go func() {
 		defer func() { done <- struct{}{} }()
+		recordErr := func(err error) {
+			if err == nil {
+				return
+			}
+			select {
+			case writeErr <- err:
+			default:
+			}
+		}
 		for {
 			select {
 			case <-stop:
 				return
 			default:
 			}
-			_ = bc.SetCurrentBlockHeaderAndHash(hdrB, hashB)
-			_ = bc.SetCurrentBlockHeaderAndHash(hdrA, hashA)
+			recordErr(bc.SetCurrentBlockHeaderAndHash(hdrB, hashB))
+			recordErr(bc.SetCurrentBlockHeaderAndHash(hdrA, hashA))
 			runtime.Gosched()
 		}
 	}()
@@ -302,6 +327,12 @@ func TestBlockChain_SetCurrentBlockHeaderAndHashRaceClean(t *testing.T) {
 	close(stop)
 	<-done
 	<-done
+
+	select {
+	case err := <-writeErr:
+		t.Fatalf("writer goroutine reported error: %v", err)
+	default:
+	}
 }
 
 func TestBlockChain_GetCurrentBlockRootHash(t *testing.T) {

--- a/data/interface.go
+++ b/data/interface.go
@@ -101,6 +101,8 @@ type ChainHandler interface {
 	SetCurrentBlockHeader(bh HeaderHandler) error
 	GetCurrentBlockHeaderHash() []byte
 	SetCurrentBlockHeaderHash(hash []byte)
+	SetCurrentBlockHeaderAndHash(bh HeaderHandler, hash []byte) error
+	GetCurrentBlockHeaderAndHash() (HeaderHandler, []byte)
 	GetCurrentBlockRootHash() []byte
 	CreateNewHeader() HeaderHandler
 	IsInterfaceNil() bool

--- a/integrationTest/processorNode/processorNode.go
+++ b/integrationTest/processorNode/processorNode.go
@@ -1483,12 +1483,19 @@ func (n *ProcessorNode) RevertOneBlock(nonce uint64) error {
 		return err
 	}
 
-	prevHash, err := tools.CalculateHash(n.InternalMarshalizer, n.Hasher, prevHeader.GetBlockHeader())
-	if err != nil {
-		return err
+	// Mirror production rollBackOneBlock: when reverting block 1 (back to
+	// genesis), clear the current pair instead of pointing at the genesis
+	// block. See core/process/sync/baseSync.go rollBackOneBlock.
+	if nonce <= 1 {
+		err = n.Blkc.SetCurrentBlockHeaderAndHash(nil, nil)
+	} else {
+		var prevHash []byte
+		prevHash, err = tools.CalculateHash(n.InternalMarshalizer, n.Hasher, prevHeader.GetBlockHeader())
+		if err != nil {
+			return err
+		}
+		err = n.Blkc.SetCurrentBlockHeaderAndHash(prevHeader, prevHash)
 	}
-
-	err = n.Blkc.SetCurrentBlockHeaderAndHash(prevHeader, prevHash)
 	if err != nil {
 		return err
 	}

--- a/integrationTest/processorNode/processorNode.go
+++ b/integrationTest/processorNode/processorNode.go
@@ -1465,28 +1465,33 @@ func (n *ProcessorNode) ConnectTo(connectable Connectable) error {
 }
 
 func (n *ProcessorNode) GetCurrentBlockHeaderAndHash() (data.HeaderHandler, []byte) {
-	return n.Blkc.GetCurrentBlockHeader(), n.Blkc.GetCurrentBlockHeaderHash()
+	return n.Blkc.GetCurrentBlockHeaderAndHash()
 }
 
+// RevertOneBlock mirrors the production rollBackOneBlock flow in baseBootstrap:
+// atomically swap the current header/hash to the previous block, revert state,
+// restore the current block's body to pools, then clean caches and storage so
+// the rolled-back block does not snap back via fork detector or nonce->hash storage.
 func (n *ProcessorNode) RevertOneBlock(nonce uint64) error {
-	// get current block
 	currHeader, err := n.GetBlock(nonce)
 	if err != nil {
 		return err
 	}
 
-	// get last block
 	prevHeader, err := n.GetBlock(nonce - 1)
 	if err != nil {
 		return err
 	}
 
-	err = n.Blkc.SetCurrentBlockHeader(prevHeader)
+	prevHash, err := tools.CalculateHash(n.InternalMarshalizer, n.Hasher, prevHeader.GetBlockHeader())
 	if err != nil {
 		return err
 	}
 
-	n.Blkc.SetCurrentBlockHeaderHash(prevHeader.GetParentHash())
+	err = n.Blkc.SetCurrentBlockHeaderAndHash(prevHeader, prevHash)
+	if err != nil {
+		return err
+	}
 
 	err = n.BlockProcessor.RevertStateToBlock(prevHeader)
 	if err != nil {
@@ -1500,7 +1505,40 @@ func (n *ProcessorNode) RevertOneBlock(nonce uint64) error {
 		return err
 	}
 
+	n.cleanCachesAndStorageOnRollback(currHeader)
 	return nil
+}
+
+// cleanCachesAndStorageOnRollback mirrors baseBootstrap.cleanCachesAndStorageOnRollback:
+// removes the rolled-back header from the data pool, the fork detector, and the
+// nonce->hash storage unit. Returns silently on any per-step failure (mirroring
+// production, which logs at Debug and ignores errors here).
+func (n *ProcessorNode) cleanCachesAndStorageOnRollback(header data.HeaderHandler) {
+	hash := n.removeHeaderFromPools(header)
+	n.ForkDetector.RemoveHeader(header.GetNonce(), hash)
+	nonceBytes := n.Uint64ByteSliceConverter.ToByteSlice(header.GetNonce())
+	storer := n.Store.GetStorer(retriever.HdrNonceHashDataUnit)
+	if storer != nil {
+		_ = storer.Remove(nonceBytes)
+	}
+}
+
+// removeHeaderFromPools mirrors baseBootstrap.removeHeaderFromPools: compute the
+// block's own header hash and evict it from the data pool. Returns nil on any
+// failure (matching production), with a Debug-level log to preserve symmetry.
+func (n *ProcessorNode) removeHeaderFromPools(hdr data.HeaderHandler) []byte {
+	blk, ok := hdr.(*block.Block)
+	if !ok {
+		log.Debug("removeHeaderFromPools: type assertion to *block.Block failed")
+		return nil
+	}
+	hash, err := tools.CalculateHash(n.InternalMarshalizer, n.Hasher, blk.Header)
+	if err != nil {
+		log.Debug("removeHeaderFromPools: CalculateHash failed", "error", err.Error())
+		return nil
+	}
+	n.DataPool.Headers().RemoveHeaderByHash(hash)
+	return hash
 }
 
 // SyncNode tries to process and commit a block already stored in data pool with provided nonce


### PR DESCRIPTION
## Summary

Adds `SetCurrentBlockHeaderAndHash` and `GetCurrentBlockHeaderAndHash` to `ChainHandler` so the `(header, hash)` pair is updated and read under a single lock acquisition. Without this, readers (chronology, sync, bootstrap) could observe the new header paired with the old hash between two separate Set calls — surfaced by `TestConsensus_RevertBlockAndTransactions` as flakiness.

Test scaffolding `RevertOneBlock` is realigned with production `rollBackOneBlock`:
- Passes the block's own hash (was the grand-parent hash via `prevHeader.GetParentHash()`)
- Adds the `cleanCachesAndStorageOnRollback` equivalent (fork detector / nonce→hash store / data pool eviction). Without these, the corrected hash lets the chain snap back through storage on the next slot.

Production call sites refactored to the atomic primitive: `CommitBlock`, `restoreState`, `setCurrentBlockInfo`, `applyBlock`, `restoreBlockChainToGenesis`.

## Atomicity proof

`TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs` asserts no mismatched `(nonce, hash)` pair is ever observed via the paired-read getter under concurrent writers. Verified to fail deterministically (5/5) against the old two-lock pattern with the exact bug signature (`nonce=9 hash="hash-10"` — new header paired with old hash).

## Test plan

- [x] `go test -race ./data/blockchain/...`
- [x] `go test -race ./core/process/block/...`
- [x] `go test -race ./core/process/sync/...`
- [x] `go test -race ./integrationTest/consensus/ -run TestConsensus_RevertBlockAndTransactions -count=50`
- [x] Full `go test -race ./integrationTest/consensus/ -count=10`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds atomic SetCurrentBlockHeaderAndHash / GetCurrentBlockHeaderAndHash operations and migrates call sites and tests to use them to eliminate a real race where readers could observe a new header paired with an old hash.

What changed
- New ChainHandler API: SetCurrentBlockHeaderAndHash(bh HeaderHandler, hash []byte) error and GetCurrentBlockHeaderAndHash() (HeaderHandler, []byte).
- Implemented atomic setter/getter in data/blockchain/blockchain.go (reads and writes header+hash under one mutex, with defensive copies and header cloning).
- Replaced the previous two-call pattern with the atomic API at production sites: CommitBlock, restoreState, applyBlock, setCurrentBlockInfo, restoreBlockChainToGenesis, restoreBlockChainToGenesis (bootstrapping), restoreState in baseSync, and related code.
- Updated integration test harness (ProcessorNode.RevertOneBlock) to perform a production-like rollback: compute previous hash correctly, call SetCurrentBlockHeaderAndHash(prevHeader, prevHash), and perform post-rollback cache/storage cleanup (fork detector, nonce→hash store, data-pool eviction).
- Extended mocks/stubs (BlockChainMock / BlockChainStub) to expose callbacks for the combined API.
- Added unit and race tests including deterministic TestBlockChain_GetCurrentBlockHeaderAndHashAtomicPairs and other concurrency-focused tests; tests capture writer-side errors and use runtime.Gosched() to reduce spin under -race.

Affected blockchain-critical components
- Consensus: CommitBlock now updates header+hash atomically, preventing consensus observers from seeing inconsistent header/hash state.
- Transaction processing & state management: bootstrap/restore and rollback flows use atomic updates; RevertOneBlock now mirrors production rollback semantics and clears caches/storage to avoid chain "snapping back" through storage.
- KVM / smart contracts: visibility of current header+hash to VMs and hooks is now consistent across concurrent readers.
- Networking / integration: ProcessorNode and integration tests updated to use atomic APIs, removing a source of test/network flakiness.

Stability and data integrity impact
- Improves data integrity by ensuring readers always observe consistent (header, hash) pairs; eliminates deterministic race that caused test failures.
- Rollback correctness improved by aligning test scaffolding with production rollback and adding cache/storage cleanup to avoid stale state reappearance.
- No on-disk format changes; behavior changes are concurrency-safety and API-extension only.

Concurrency and error handling
- Single mutex acquisition prevents interleaving between header and hash updates.
- prepareCurrentBlockHeader preserves existing validation/cloning and ErrInvalidHeaderType semantics.
- Call sites now propagate errors from the combined setter directly (e.g., CommitBlock returns on setter error), avoiding partial/observable updates.
- Tests exercise atomicity under -race and have been adjusted to report writer-side failures deterministically.

Cross-cutting notes for reviewers
- ChainHandler interface extended — update any external implementations/mocks; build will fail until mocks/stubs are updated (this PR updates them).
- Audit for callers that intentionally relied on separate SetCurrentBlockHeader / SetCurrentBlockHeaderHash ordering (rare); semantics preserved but callers were migrated where consistency matters.
- No persisted storage or data-format migration required.
- Marked consensus-critical: reviewer attention on concurrency correctness, error propagation paths, and the rollback cleanup behavior is recommended.

Summary judgment
- Fixes a concurrency bug that could expose inconsistent header/hash reads, hardens rollback behavior, and improves test determinism with minimal functional surface changes; overall positive impact on node stability and data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->