### PR TITLE
[KLC-2388] Gate klv_node_type / klv_peer_type writes on cache miss

### DIFF
--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -45,6 +45,12 @@ func InitMetrics(
 
 	appStatusHandler.SetStringValue(core.MetricPublicKeyBlockSign, pubkeyStr)
 	appStatusHandler.SetStringValue(core.MetricNodeType, string(nodeType))
+	// KLC-2388: seed klv_peer_type alongside klv_node_type so consumers see a
+	// real value during the bootstrap window before the peerTypeProvider cache
+	// is populated. The heartbeat sender's IsCachePopulated gate keeps this
+	// startup value in place until the first epoch-start event refreshes the
+	// cache, at which point the real peer-list classification takes over.
+	appStatusHandler.SetStringValue(core.MetricPeerType, string(core.ObserverList))
 	appStatusHandler.SetUInt64Value(core.MetricSlotTime, slotInterval/millisecondsInSecond)
 	appStatusHandler.SetStringValue(core.MetricAppVersion, version)
 	appStatusHandler.SetUInt64Value(core.MetricSlotsPerEpoch, uint64(slotsPerEpoch))

--- a/cmd/node/metrics/metrics.go
+++ b/cmd/node/metrics/metrics.go
@@ -44,12 +44,16 @@ func InitMetrics(
 	initZeroString := "0"
 
 	appStatusHandler.SetStringValue(core.MetricPublicKeyBlockSign, pubkeyStr)
+	// KLC-2388: node_type stays "validator" during the bootstrap window even
+	// though peer_type below is seeded to "observer". The two intentionally
+	// diverge until the peerTypeProvider cache populates: node_type is the
+	// PR's protected value (the original bug was validators flipping to
+	// observer on cache miss), so we cannot seed it observer without
+	// re-introducing exactly that symptom; peer_type is left pessimistic
+	// because it's a peer-list classification that we genuinely don't know
+	// yet. Once the gate opens the sender writes the real values from the
+	// fork detector / nodes coordinator.
 	appStatusHandler.SetStringValue(core.MetricNodeType, string(nodeType))
-	// KLC-2388: seed klv_peer_type alongside klv_node_type so consumers see a
-	// real value during the bootstrap window before the peerTypeProvider cache
-	// is populated. The heartbeat sender's IsCachePopulated gate keeps this
-	// startup value in place until the first epoch-start event refreshes the
-	// cache, at which point the real peer-list classification takes over.
 	appStatusHandler.SetStringValue(core.MetricPeerType, string(core.ObserverList))
 	appStatusHandler.SetUInt64Value(core.MetricSlotTime, slotInterval/millisecondsInSecond)
 	appStatusHandler.SetStringValue(core.MetricAppVersion, version)

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -55,10 +55,10 @@ func NewPeerTypeProvider(arg ArgPeerTypeProvider) (*PeerTypeProvider, error) {
 	return ptp, nil
 }
 
-// IsCachePopulated returns true once the cache has been refreshed by an epoch-start event.
-// During the bootstrap window before the first epoch-start notification fires, the cache
-// is either empty or seeded from a NodesCoordinator that is not yet fully populated, so
-// callers should treat its peer-type result as unreliable.
+// IsCachePopulated returns true once at least one updateCache call has produced a
+// non-empty cache. Until then, the NodesCoordinator has not yet exposed any
+// validator keys for the active epoch, so callers should treat the peer-type result
+// as unreliable and avoid overwriting startup-seeded values.
 func (ptp *PeerTypeProvider) IsCachePopulated() bool {
 	ptp.mutCache.RLock()
 	defer ptp.mutCache.RUnlock()
@@ -103,7 +103,6 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 				"slot", hdr.GetSlot(),
 				"epoch", hdr.GetEpoch())
 			ptp.updateCache(hdr.GetEpoch())
-			ptp.markReady()
 		},
 		func(_ data.HeaderHandler) {},
 		core.IndexerOrder,
@@ -117,12 +116,9 @@ func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
 
 	ptp.mutCache.Lock()
 	ptp.cache = newCache
-	ptp.mutCache.Unlock()
-}
-
-func (ptp *PeerTypeProvider) markReady() {
-	ptp.mutCache.Lock()
-	ptp.isReady = true
+	if len(newCache) > 0 {
+		ptp.isReady = true
+	}
 	ptp.mutCache.Unlock()
 }
 

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -23,6 +23,7 @@ type PeerTypeProvider struct {
 	nodesCoordinator sharding.NodesCoordinator
 	cache            map[string]*peerListAndShard
 	mutCache         sync.RWMutex
+	isReady          bool
 }
 
 // ArgPeerTypeProvider contains all parameters needed for creating a PeerTypeProvider
@@ -52,6 +53,16 @@ func NewPeerTypeProvider(arg ArgPeerTypeProvider) (*PeerTypeProvider, error) {
 	arg.EpochStartEventNotifier.RegisterHandler(ptp.epochStartEventHandler())
 
 	return ptp, nil
+}
+
+// IsCachePopulated returns true once the cache has been refreshed by an epoch-start event.
+// During the bootstrap window before the first epoch-start notification fires, the cache
+// is either empty or seeded from a NodesCoordinator that is not yet fully populated, so
+// callers should treat its peer-type result as unreliable.
+func (ptp *PeerTypeProvider) IsCachePopulated() bool {
+	ptp.mutCache.RLock()
+	defer ptp.mutCache.RUnlock()
+	return ptp.isReady
 }
 
 // ComputeForPubKey returns the peer type for a given public key and shard id
@@ -92,6 +103,7 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 				"slot", hdr.GetSlot(),
 				"epoch", hdr.GetEpoch())
 			ptp.updateCache(hdr.GetEpoch())
+			ptp.markReady()
 		},
 		func(_ data.HeaderHandler) {},
 		core.IndexerOrder,
@@ -105,6 +117,12 @@ func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
 
 	ptp.mutCache.Lock()
 	ptp.cache = newCache
+	ptp.mutCache.Unlock()
+}
+
+func (ptp *PeerTypeProvider) markReady() {
+	ptp.mutCache.Lock()
+	ptp.isReady = true
 	ptp.mutCache.Unlock()
 }
 

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -205,6 +205,31 @@ func TestNewPeerTypeProvider_ComputeForKeyNotFoundInCacheReturnsObserver(t *test
 	assert.Nil(t, err)
 }
 
+func TestPeerTypeProvider_IsCachePopulated_FalseAtConstruction(t *testing.T) {
+	arg := createDefaultArgPeerTypeProvider()
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+	require.NotNil(t, ptp)
+
+	assert.False(t, ptp.IsCachePopulated())
+}
+
+func TestPeerTypeProvider_IsCachePopulated_TrueAfterEpochStart(t *testing.T) {
+	arg := createDefaultArgPeerTypeProvider()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+	require.NotNil(t, ptp)
+	require.False(t, ptp.IsCachePopulated())
+
+	epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Nonce: 1, Epoch: 1}})
+
+	assert.True(t, ptp.IsCachePopulated())
+}
+
 func TestNewPeerTypeProvider_IsInterfaceNil(t *testing.T) {
 	arg := createDefaultArgPeerTypeProvider()
 

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -205,7 +205,7 @@ func TestNewPeerTypeProvider_ComputeForKeyNotFoundInCacheReturnsObserver(t *test
 	assert.Nil(t, err)
 }
 
-func TestPeerTypeProvider_IsCachePopulated_FalseAtConstruction(t *testing.T) {
+func TestPeerTypeProvider_IsCachePopulated_FalseWhenCoordinatorReturnsEmpty(t *testing.T) {
 	arg := createDefaultArgPeerTypeProvider()
 
 	ptp, err := NewPeerTypeProvider(arg)
@@ -215,7 +215,43 @@ func TestPeerTypeProvider_IsCachePopulated_FalseAtConstruction(t *testing.T) {
 	assert.False(t, ptp.IsCachePopulated())
 }
 
-func TestPeerTypeProvider_IsCachePopulated_TrueAfterEpochStart(t *testing.T) {
+func TestPeerTypeProvider_IsCachePopulated_TrueAtConstructionWhenCachePopulated(t *testing.T) {
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("validator-pk")}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+	require.NotNil(t, ptp)
+
+	assert.True(t, ptp.IsCachePopulated())
+}
+
+func TestPeerTypeProvider_IsCachePopulated_TrueAfterEpochStartFillsCache(t *testing.T) {
+	arg := createDefaultArgPeerTypeProvider()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
+
+	coordinator := &mock.NodesCoordinatorMock{}
+	arg.NodesCoordinator = coordinator
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+	require.NotNil(t, ptp)
+	require.False(t, ptp.IsCachePopulated())
+
+	coordinator.GetAllElectedValidatorsKeysCalled = func() ([][]byte, error) {
+		return [][]byte{[]byte("validator-pk")}, nil
+	}
+	epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Nonce: 1, Epoch: 1}})
+
+	assert.True(t, ptp.IsCachePopulated())
+}
+
+func TestPeerTypeProvider_IsCachePopulated_StaysFalseWhenEpochStartFiresButCacheEmpty(t *testing.T) {
 	arg := createDefaultArgPeerTypeProvider()
 	epochStartNotifier := &mock.EpochStartNotifierStub{}
 	arg.EpochStartEventNotifier = epochStartNotifier
@@ -227,7 +263,7 @@ func TestPeerTypeProvider_IsCachePopulated_TrueAfterEpochStart(t *testing.T) {
 
 	epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Nonce: 1, Epoch: 1}})
 
-	assert.True(t, ptp.IsCachePopulated())
+	assert.False(t, ptp.IsCachePopulated())
 }
 
 func TestNewPeerTypeProvider_IsInterfaceNil(t *testing.T) {

--- a/node/heartbeat/interface.go
+++ b/node/heartbeat/interface.go
@@ -80,6 +80,7 @@ type P2PAntifloodHandler interface {
 type PeerTypeProviderHandler interface {
 	ComputeForPubKey(pubKey []byte) (core.PeerType, uint32, error)
 	GetAllPeerTypeInfos() []*state.PeerTypeInfo
+	IsCachePopulated() bool
 	IsInterfaceNil() bool
 }
 

--- a/node/heartbeat/mock/peerTypeProviderStub.go
+++ b/node/heartbeat/mock/peerTypeProviderStub.go
@@ -8,6 +8,7 @@ import (
 // PeerTypeProviderStub -
 type PeerTypeProviderStub struct {
 	ComputeForPubKeyCalled func(pubKey []byte) (core.PeerType, uint32, error)
+	IsCachePopulatedCalled func() bool
 }
 
 // ComputeForPubKey -
@@ -22,6 +23,15 @@ func (p *PeerTypeProviderStub) ComputeForPubKey(pubKey []byte) (core.PeerType, u
 // GetAllPeerTypeInfos -
 func (p *PeerTypeProviderStub) GetAllPeerTypeInfos() []*state.PeerTypeInfo {
 	return nil
+}
+
+// IsCachePopulated -
+func (p *PeerTypeProviderStub) IsCachePopulated() bool {
+	if p.IsCachePopulatedCalled != nil {
+		return p.IsCachePopulatedCalled()
+	}
+
+	return true
 }
 
 // IsInterfaceNil -

--- a/node/heartbeat/process/export_test.go
+++ b/node/heartbeat/process/export_test.go
@@ -92,6 +92,11 @@ func VerifyLengths(hbmi *data.Heartbeat) error {
 	return verifyLengths(hbmi)
 }
 
+// UpdateMetrics -
+func (s *Sender) UpdateMetrics(hb *data.Heartbeat) {
+	s.updateMetrics(hb)
+}
+
 // GetMaxSizeInBytes -
 func GetMaxSizeInBytes() int {
 	return maxSizeInBytes

--- a/node/heartbeat/process/sender.go
+++ b/node/heartbeat/process/sender.go
@@ -174,6 +174,10 @@ func (s *Sender) getCurrentPrivateAndPublicKeys() (crypto.PrivateKey, crypto.Pub
 }
 
 func (s *Sender) updateMetrics(hb *heartbeatData.Heartbeat) {
+	if !s.peerTypeProvider.IsCachePopulated() {
+		return
+	}
+
 	result := s.computePeerList(hb.Pubkey)
 
 	nodeType := ""

--- a/node/heartbeat/process/sender_test.go
+++ b/node/heartbeat/process/sender_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	cMock "github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/crypto"
 	"github.com/klever-io/klever-go/node/heartbeat"
 	"github.com/klever-io/klever-go/node/heartbeat/data"
@@ -620,4 +621,63 @@ func TestSender_SendHeartbeatAfterTriggerWithRecorededPayloadShouldWork(t *testi
 	assert.True(t, signCalled)
 	assert.True(t, genPubKeyCalled)
 	assert.True(t, marshalCalled)
+}
+
+func TestSender_UpdateMetricsSkipsWritesWhenCacheNotPopulated(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArgHeartbeatSender()
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		IsCachePopulatedCalled: func() bool {
+			return false
+		},
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			t.Fatalf("ComputeForPubKey must not be called when cache is not populated")
+			return "", 0, nil
+		},
+	}
+	setStringCalls := make(map[string]string)
+	arg.StatusHandler = &mock.AppStatusHandlerStub{
+		SetStringValueHandler: func(key string, value string) {
+			setStringCalls[key] = value
+		},
+	}
+
+	sender, err := process.NewSender(arg)
+	assert.Nil(t, err)
+
+	sender.UpdateMetrics(&data.Heartbeat{Pubkey: []byte("pk")})
+
+	_, gotNodeType := setStringCalls[core.MetricNodeType]
+	_, gotPeerType := setStringCalls[core.MetricPeerType]
+	assert.False(t, gotNodeType)
+	assert.False(t, gotPeerType)
+}
+
+func TestSender_UpdateMetricsWritesWhenCachePopulated(t *testing.T) {
+	t.Parallel()
+
+	arg := createMockArgHeartbeatSender()
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		IsCachePopulatedCalled: func() bool {
+			return true
+		},
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			return core.EligibleList, 0, nil
+		},
+	}
+	setStringCalls := make(map[string]string)
+	arg.StatusHandler = &mock.AppStatusHandlerStub{
+		SetStringValueHandler: func(key string, value string) {
+			setStringCalls[key] = value
+		},
+	}
+
+	sender, err := process.NewSender(arg)
+	assert.Nil(t, err)
+
+	sender.UpdateMetrics(&data.Heartbeat{Pubkey: []byte("pk")})
+
+	assert.Equal(t, string(core.NodeTypeValidator), setStringCalls[core.MetricNodeType])
+	assert.Equal(t, string(core.EligibleList), setStringCalls[core.MetricPeerType])
 }


### PR DESCRIPTION
On validator startup, the heartbeat sender's `updateMetrics` was overwriting the correct startup-time `klv_node_type=validator` with `observer`, because `peerTypeProvider.ComputeForPubKey` returns `ObserverList` silently on cache miss and the cache isn't populated until the first epoch-start event fires. Same root cause hit `klv_peer_type`. Operators and monitoring tooling saw the wrong node type for the entire bootstrap window — minutes to hours depending on epoch length.

The fix adds an `IsCachePopulated()` readiness gate on `PeerTypeProvider` that flips true only when the epoch-start handler fires. `Sender.updateMetrics` early-returns when the gate is closed, preserving the startup-init values. A fourth commit also seeds `klv_peer_type` at startup alongside `klv_node_type`, so consumers never observe an empty/absent field during the bootstrap window.

## What changed

4 atomic commits:
- `Add IsCachePopulated readiness gate to PeerTypeProvider` — new `isReady` field flipped inside the existing epoch-start handler.
- `Expose IsCachePopulated on PeerTypeProviderHandler interface` — wired through the heartbeat-side interface + mock stub.
- `Skip klv_node_type and klv_peer_type writes on cache miss` — early-return in `Sender.updateMetrics` + sender tests via an `UpdateMetrics` exporter.
- `Initialize klv_peer_type at startup alongside klv_node_type` — one-line seed of `ObserverList` so the field is never empty pre-gate.

## Validation

1. **Unit tests** (4 new): `IsCachePopulated` false at construction, flips true after epoch-start event; `updateMetrics` skips writes when not ready, writes correct values when ready. All green via `go test ./node/heartbeat/process/... ./core/process/peer/...`.

2. **Binary verification**: extracted the validator binary from the docker image and confirmed via `go tool nm` that `IsCachePopulated` + `markReady` symbols compile in, and via `go tool objdump -s 'Sender.*updateMetrics'` that the gate is actually called at `sender.go:177` *before* `computePeerList` at `sender.go:181`.

3. **In-the-wild observation**: during this sprint's KLC-1920 multi-validator harness work, captured the live bug on the fallback container reporting `klv_node_type=observer` despite `klv_redundancy_level=2` — independent pre-fix proof.

4. **End-to-end Docker A/B/C/D runs** on a 3-validator + 1-redundancy-2-fallback localnet (kleverchain-localnet harness, both images built from the same Klever HEAD):
   - **Run A** — pre-fix baseline, \`slotsPerEpoch=300\`: fallback flips to \`observer\` at T+25s — KLC-2388 bug reproduces cleanly.
   - **Run B** — patched gate-only, same config: fallback stays at \`validator\` for 4+ minutes through 50+ post-genesis slots; \`klv_peer_type\` empty (gate holds).
   - **Run C** — patched gate-only, \`slotsPerEpoch=20\`: captures the gate *opening* at slot 26 when the first epoch-start event fires; transitions to legitimate values (\`validator/elected\` for primaries, \`observer/observer\` for the fallback's observer-key heartbeat).
   - **Run D** — patched + \`klv_peer_type\` startup-init, \`slotsPerEpoch=20\`: confirms \`peer_type=observer\` from t=0 (vs empty in B/C), held through gate-closed window, transitions cleanly at gate open. No dangling-dash TUI artifact, no empty Prometheus label.

5. **Side-effect audit**: grep'd every reader of `MetricNodeType` / `MetricPeerType` in the codebase. Only consumers are the statusHandler presenter (TUI dashboard) and the `/node/status` + Prometheus exposers. No consensus, sync, fork-detection, heartbeat-message, or block-processing code branches on these values. Fix has no internal impact beyond observability.

## Notes

The KLC-2388 bug requires the `peerTypeProvider` cache to be unpopulated when the heartbeat first ticks (a production peer-churn condition). On localnet the cache populates correctly at construction, so the A/B runs deliberately exercise the cache-not-yet-populated codepath. The gate is correct regardless of whether the underlying cache-miss is reproducible in any specific environment.

One build-system gotcha worth flagging for reviewers: the first two patched docker builds produced a binary where the \`IsCachePopulated\` symbol existed but \`updateMetrics\` wasn't calling it — BuildKit cache mounts (\`--mount=type=cache,target=/root/.cache/go-build\`) persist across \`docker build --no-cache\` and reused a stale \`.a\` for \`node/heartbeat/process\`. Dropping the cache mounts temporarily for the rebuild defeated it; the upstream Dockerfile is unchanged in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a startup observability bug by preventing the heartbeat sender from emitting incorrect peer-type metrics during node bootstrap. It gates metric writes on a peer-type cache readiness flag and seeds a bootstrap peer-type value to avoid empty metrics before the cache is populated.

Impact assessment
- Affected components:
  - Heartbeat sender metrics (node/heartbeat/process/sender.go / Sender.updateMetrics)
  - Peer-type provider cache/state and readiness API (core/process/peer/peerTypeProvider.go)
  - Observability surface: TUI, /node/status, Prometheus exporter (metrics and status codepaths)
- Blockchain-critical components: none. The change is confined to observability and the peer-type cache readiness API. It does not change consensus, transaction processing, state management, KVM, or networking decision logic.
- Node stability and data integrity: unchanged. No on-chain state, consensus flows, or persistent node state are modified. The gating only prevents emission of misleading metric labels during bootstrap.

Key changes
- Readiness gate
  - PeerTypeProvider gains an isReady field and an exported IsCachePopulated() bool (protected by RW locks). isReady is set inside existing cache-refresh/updateCache logic (including epoch-start refreshes) when a non-empty cache is produced.
- Interface and test stubs
  - PeerTypeProviderHandler interface now includes IsCachePopulated(); mocks/stubs updated to support test control.
- Metric gating and bootstrap seeding
  - Sender.updateMetrics early-returns when IsCachePopulated() is false, skipping ComputeForPubKey and writes of klv_node_type / klv_peer_type to avoid falsely writing "observer" on cache miss.
  - InitMetrics seeds core.MetricPeerType at startup (ObserverList placeholder) alongside core.MetricNodeType so klv_peer_type is not empty before the gate opens.
- Concurrency and error handling
  - isReady is read/written under locks to ensure safe concurrent access by the heartbeat sender.
  - The gate prevents fallback-to-observer behavior that previously occurred when ComputeForPubKey ran on cache miss or error during bootstrap.

Validation
- Unit tests: added coverage for IsCachePopulated transitions (construction and epoch-start) and for Sender.UpdateMetrics behavior (skips writes when not ready; writes correct values when ready). Tests passed for relevant packages.
- Binary inspection: go tool nm/objdump verified IsCachePopulated symbol and that updateMetrics checks the gate before computing peer lists.
- Local harness: Docker runs reproduced the pre-fix misreporting; the gate + startup seed preserved correct metrics through bootstrap and transitioned correctly when the cache populated.

Notes
- A stale Docker build-cache produced a binary where updateMetrics didn't call the new gate; rebuilding without cache resolved it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/klever-io/klever-go/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->