### PR TITLE
[KLC-2447] release: replace retired macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-15-intel]
         include:
           - os: ubuntu-latest
             name: linux
             extension: .tar.gz
-          - os: macos-13
+          - os: macos-15-intel
             name: darwin
             extension: .tar.gz
           - os: macos-latest


### PR DESCRIPTION
## What
Replaces the retired `macos-13` runner in `.github/workflows/release.yaml` with the native Intel replacement `macos-15-intel`.

## Why
`macos-13` was GitHub's last Intel (x86_64) hosted macOS runner and was [retired in Dec 2025](https://github.com/actions/runner-images/issues/13046). In the v1.7.18 release run the `macos-13` build hung ~2h and was manually canceled — the Intel macOS artifact wasn't produced.

`macos-15-intel` is GitHub's official x86_64 replacement (supported until macOS 15 retires, ~Fall 2027), so the amd64 macOS build is preserved as a **native** build — no cross-compile toolchain or prebuilt-on-arm dylib needed.

## Changes
- `macos-13` → `macos-15-intel` for the `darwin` (amd64) build slot
- `macos-latest` (arm64) and `ubuntu-latest` unchanged

## Notes
- Downstream steps key off `matrix.name` (`darwin` / `darwin-arm64`), which is unchanged, so tarball/dylib selection and GCS upload paths are identical.
- Verified the committed `kvm/wasmer2/libvmexeccapi.dylib` is x86_64 Mach-O.
- `actionlint` may flag `macos-15-intel` as an unknown label — false positive from a stale bundled label list; the label is valid per [GitHub's changelog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/).

## Follow-up
Validate with a `workflow_dispatch` run or an `rc` tag to confirm all assets (linux, darwin amd64, darwin-arm64) build and upload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Infrastructure Update: macOS CI Runner Migration

**Impact on blockchain components and node operations: None**

This PR adds the GitHub Actions release workflow configuration with an updated macOS build matrix that uses `macos-15-intel` for native x86_64 Intel macOS builds. This replaces the deprecated `macos-13` runner that was retired in December 2025 and previously caused build timeouts during the v1.7.18 release.

The workflow matrix now includes:
- `ubuntu-latest` (Linux x86_64)
- `macos-latest` (ARM64)
- `macos-15-intel` (Intel x86_64, native replacement for macos-13)

The workflow produces platform-specific artifacts including the native x86_64 `libvmexeccapi.dylib` library for the Intel macOS build without cross-compilation. This is purely a CI/CD infrastructure change with no impact on consensus, transaction processing, state management, KVM integration, networking, or node stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->