### PR TITLE
[KLC-1927] Skip actions/cache on self-hosted runners to fix tar "Cannot open: File exists" errors

### DIFF
--- a/.github/actions/go-setup-action/action.yml
+++ b/.github/actions/go-setup-action/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Cache Go dependencies
       id: cache_vendor
-      if: inputs.cache-enabled == 'true'
+      if: inputs.cache-enabled == 'true' && runner.environment == 'github-hosted'
       uses: actions/cache@v4
       env:
         cache-name: go-cache-vendor
@@ -48,7 +48,6 @@ runs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
-        enableCrossOsArchive: true
 
     - name: Resolve package to module & Download dependencies
       if: ${{ steps.cache_vendor.outputs.cache-hit != 'true' }}

--- a/.github/actions/go-setup-action/action.yml
+++ b/.github/actions/go-setup-action/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Golang
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache: false
@@ -38,7 +38,7 @@ runs:
     - name: Cache Go dependencies
       id: cache_vendor
       if: inputs.cache-enabled == 'true' && runner.environment == 'github-hosted'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       env:
         cache-name: go-cache-vendor
       with:

--- a/.github/workflows/go-setup-lint.yaml
+++ b/.github/workflows/go-setup-lint.yaml
@@ -71,7 +71,7 @@ jobs:
           golangci-lint run --output.checkstyle.path=golangci-report.xml || true
 
       - name: Upload lint results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: lint-results
           path: golangci-report.xml

--- a/.github/workflows/pr-qa-sec.yaml
+++ b/.github/workflows/pr-qa-sec.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test-artifacts
           path: |
@@ -110,12 +110,12 @@ jobs:
           fetch-depth: 0
 
       - name: Download lint results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: lint-results
 
       - name: Download test results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: test-artifacts
 

--- a/.github/workflows/pr-qa-sec.yaml
+++ b/.github/workflows/pr-qa-sec.yaml
@@ -124,7 +124,7 @@ jobs:
           service-key: ${{ secrets.TWINGATE_SERVICE_ACCOUNT }}
 
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@v6
+        uses: sonarsource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
@@ -142,7 +142,7 @@ jobs:
         if: github.event_name != 'pull_request'
 
       - name: SonarQube Go detailed scan PR
-        uses: sonarsource/sonarqube-scan-action@v6
+        uses: sonarsource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -36,7 +36,7 @@ jobs:
           make build-validator
           
       - name: Save artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: build
           path: |

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -77,13 +77,13 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.enabled }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         if: ${{ matrix.enabled }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=moby/buildkit:latest
@@ -91,7 +91,7 @@ jobs:
 
       - name: Login to Docker Hub
         if: ${{ matrix.enabled }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             bin/klevergo-node${{ matrix.extension }}
@@ -103,33 +103,33 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Configure GCP service account
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: '${{ secrets.GCP_CLOUD_RUN_SA }}'
 
       - name: Upload operator files to bucket
-        uses: 'google-github-actions/upload-cloud-storage@v2'
+        uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           path: 'bin/klevergo-operator${{ matrix.extension }}'
           destination: 'kleverchain-public/koperator/${{ matrix.name }}/${{ env.VERSION }}'
           predefinedAcl: 'publicRead'
 
       - name: Upload node files to bucket
-        uses: 'google-github-actions/upload-cloud-storage@v2'
+        uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           path: 'bin/klevergo-node${{ matrix.extension }}'
           destination: 'kleverchain-public/knode/${{ matrix.name }}/${{ env.VERSION }}'
           predefinedAcl: 'publicRead'
 
       - name: Upload benchmark files to bucket
-        uses: 'google-github-actions/upload-cloud-storage@v2'
+        uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           path: 'bin/klevergo-benchmark${{ matrix.extension }}'
           destination: 'kleverchain-public/kbenchmark/${{ matrix.name }}/${{ env.VERSION }}'
           predefinedAcl: 'publicRead'
 
       - name: Upload Klever Blockchain IDE operator files to bucket
-        uses: 'google-github-actions/upload-cloud-storage@v2'
+        uses: 'google-github-actions/upload-cloud-storage@v3'
         with:
           path: 'bin/${{ matrix.name }}'
           destination: 'kleverchain-public/koperator/${{ matrix.name }}/${{ env.VERSION }}'


### PR DESCRIPTION
## Problem

Workflows on the self-hosted `klever-pipe` runners flood the Actions UI with `/usr/bin/tar: Cannot open: File exists` annotations during cache restore (hundreds of thousands per run), masking real failures. The runners persist `~/go/pkg/mod` and `./vendor` between runs, so `actions/cache@v4` extracts its tarball over files that already exist and errors on every collision.

## Change

- Gate the `Cache Go dependencies` step to ephemeral GitHub-hosted runners only:
  `if: inputs.cache-enabled == 'true' && runner.environment == 'github-hosted'`.
  On self-hosted runners the step is skipped; the existing `cache-hit`-gated
  download/vendor steps regenerate from the persistent dirs.
- Remove the legacy `enableCrossOsArchive: true` flag.

## Why `runner.environment`

The root cause is self-hosted persistence, not the `klever-pipe` label specifically. Gating on `runner.environment` covers any self-hosted runner and fails safe (a missing value still skips the cache on self-hosted). Ephemeral `ubuntu`/`macos` jobs keep caching unchanged.

## Also: Node.js 24 runtime bumps

Node.js 20 is deprecated on GitHub Actions runners (forced to Node 24 from 2026-06-16, removed 2026-09-16). Bumped every action still on node20 to its latest Node 24 major. Inputs we use are unchanged across the bumps.

GitHub-owned:

| Action | From | To |
| --- | --- | --- |
| `actions/setup-go` | v5 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v5 | v7 |
| `actions/download-artifact` | v6 | v8 |

Third-party:

| Action | From | To |
| --- | --- | --- |
| `sonarsource/sonarqube-scan-action` | v6 | v8 |
| `softprops/action-gh-release` | v2 | v3 |
| `google-github-actions/auth` | v2 | v3 |
| `google-github-actions/upload-cloud-storage` | v2 | v3 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |

These majors require Actions Runner ≥ 2.327.1; `klever-pipe` is on 2.334.0. Already Node 24 and left as-is: `actions/checkout@v6`, `golangci/golangci-lint-action@v9`. Composite (unaffected): `sonarsource/sonarqube-quality-gate-action`, `twingate/github-action`.

Notable behavior changes verified safe for our usage: `sonarqube-scan-action@v8` enables scanner signature verification by default; `auth@v3` retains `credentials_json`; `upload-cloud-storage@v3` retains `predefinedAcl`/`parent`; `setup-buildx@v4` retains `driver-opts`.

## Notes for reviewers

`klever-pipe` is a multi-runner pool, so standalone creds-less jobs (`release-docker → build-multi-arch`, `push → validate-and-build`, `pr-qa-sec → test`) rely on each runner's persistent module dirs after the cache change. The common case is unaffected. If a new private `klever-io/*` module is added and a creds-less job lands on a runner that lacks it, pass `GIT_USER`/`GIT_PASS` to that job's `go-setup-action` step.

## Verification

- [ ] Trigger `release-docker.yaml` on `klever-pipe` → 0 `Cannot open: File exists` annotations
- [ ] Trigger `go-setup-lint.yaml` (PR / workflow_call) → 0 annotations
- [ ] No Node.js 20 deprecation warnings remain
- [ ] Go module / vendor resolution still succeeds (cache hit on ephemeral, cold rebuild on self-hosted)
- [ ] No CI duration regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates CI to skip the GitHub Actions cache restore on self-hosted runners and bumps several actions to Node.js 24–compatible majors.

### What changed
- .github/actions/go-setup-action/action.yml
  - "Cache Go dependencies" step now runs only when:
    if: inputs.cache-enabled == 'true' && runner.environment == 'github-hosted'
    (previously only checked inputs.cache-enabled).
  - actions/cache upgraded v4 → v5; removed enableCrossOsArchive: true.
  - actions/setup-go upgraded v5 → v6.
  - Resolve/download/vendor steps remain and run when cache miss.
- Workflows updated to newer action majors (no logic changes):
  - actions/upload-artifact v5 → v7 (go-setup-lint.yaml, push.yaml, pr-qa-sec.yaml)
  - actions/download-artifact v6 → v8 (pr-qa-sec.yaml)
  - sonarsource/sonarqube-scan-action v6 → v8
  - docker/setup-qemu-action, docker/setup-buildx-action, docker/login-action v3 → v4 (release-docker.yaml)
  - softprops/action-gh-release v2 → v3; google-github-actions/auth v2 → v3; google-github-actions/upload-cloud-storage v2 → v3 (release.yaml)
  - Other noted bumps to align with Node.js 24 and Actions Runner ≥ 2.327.1 (klever-pipe runs 2.334.0).

### Rationale
Self-hosted klever-pipe runners persist ~/go/pkg/mod and ./vendor between runs. actions/cache was extracting tarballs over existing files on those runners, producing many "/usr/bin/tar: Cannot open: File exists" annotations that hid real failures. Restricting the cache restore to GitHub-hosted runners avoids these noisy tar errors while preserving caching behavior on ephemeral hosted runners. On self-hosted runners, persistent directories continue to be used and the download/vendor steps regenerate dependencies when needed.

### Verification checklist (kept)
- release-docker.yaml on klever-pipe → 0 "Cannot open: File exists" annotations
- go-setup-lint.yaml → 0 such annotations
- No Node.js 20 deprecation warnings
- Go module/vendor resolution: cache hits on ephemeral runners; cold rebuilds on self-hosted
- No CI duration regression

### Impact on blockchain-critical components
- No changes to application source code touching consensus, transaction processing, state management, KVM, or networking.
- Build and packaging commands (make build-*, tar creation, upload to GCS) are unchanged; produced artifacts (including KVM/wasmer2 libs) and their packaging remain identical.
- No impact to node stability, runtime behavior, or on-disk data integrity.
- Cross-cutting: improves CI signal by removing spurious tar-related annotations; does not change production concurrency or error-handling logic.

### Reviewer notes
- klever-pipe is a multi-runner pool; some creds-less jobs rely on persisted module dirs. If a new private klever-io/* module is added and a creds-less job runs on a runner lacking it, pass GIT_USER/GIT_PASS to that job’s go-setup-action step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->