### PR TITLE
[KLC-2438] require auth for /log and stop unauthenticated logger mutation (GHSA-9v8p-frvj-2pcm)

### DIFF
--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -21,6 +21,22 @@ import (
 
 var log = logger.GetOrCreate("seednode/api")
 
+// Route package keys, config route names, and served URL paths, kept as constants to avoid
+// duplicating the string literals across registration and the fail-safe default.
+const (
+	logPackage   = "log"
+	peersPackage = "peers"
+	nodePackage  = "node"
+
+	logRoute     = "/log"
+	peersRoute   = "/peers"
+	statusRoute  = "/status"
+	metricsRoute = "/metrics"
+
+	nodeStatusPath  = "/node/status"
+	nodeMetricsPath = "/node/metrics"
+)
+
 // peerInfoProvider is the narrow surface the seednode API needs from the p2p
 // messenger. Kept inside this package so handlers can be tested without
 // pulling in the full libp2p stack.
@@ -67,12 +83,12 @@ func Start(restAPIInterface string, marshalizer marshal.Marshalizer, messenger p
 }
 
 func (s *server) registerRoutes(ws *gin.Engine) {
-	if s.routesConfig.IsRouteEnabled("log", "/log") {
+	if s.routesConfig.IsRouteEnabled(logPackage, logRoute) {
 		s.registerLoggerWsRoute(ws)
 	}
-	s.registerGet(ws, "peers", "/peers", "/peers", s.peers)
-	s.registerGet(ws, "node", "/status", "/node/status", s.nodeStatus)
-	s.registerGet(ws, "node", "/metrics", "/node/metrics", s.nodeMetrics)
+	s.registerGet(ws, peersPackage, peersRoute, peersRoute, s.peers)
+	s.registerGet(ws, nodePackage, statusRoute, nodeStatusPath, s.nodeStatus)
+	s.registerGet(ws, nodePackage, metricsRoute, nodeMetricsPath, s.nodeMetrics)
 }
 
 // registerGet registers a GET endpoint when its config route (pkg/configName) is open, prepending
@@ -95,7 +111,7 @@ func (s *server) registerLoggerWsRoute(ws *gin.Engine) {
 
 	// Only an authenticated (secured) /log may apply a client-supplied logger profile to the
 	// process-global logger; on an unauthenticated /log profiles are ignored (GHSA-9v8p-frvj-2pcm).
-	secured := s.routesConfig.IsRouteSecured("log", "/log")
+	secured := s.routesConfig.IsRouteSecured(logPackage, logRoute)
 
 	logHandler := func(c *gin.Context) {
 		upgrader.CheckOrigin = func(r *http.Request) bool {
@@ -124,7 +140,7 @@ func (s *server) registerLoggerWsRoute(ws *gin.Engine) {
 		handlers = append([]gin.HandlerFunc{middleware.NewAuthenticationFunc(s.routesConfig)}, handlers...)
 	}
 
-	ws.GET("/log", handlers...)
+	ws.GET(logRoute, handlers...)
 }
 
 // DefaultRoutesConfig is the fail-safe used when no API config file can be loaded: the read-only
@@ -134,10 +150,10 @@ func (s *server) registerLoggerWsRoute(ws *gin.Engine) {
 func DefaultRoutesConfig() config.APIRoutesConfig {
 	return config.APIRoutesConfig{
 		APIPackages: map[string]config.APIPackageConfig{
-			"peers": {Routes: []config.RouteConfig{{Name: "/peers", Open: true}}},
-			"node": {Routes: []config.RouteConfig{
-				{Name: "/status", Open: true},
-				{Name: "/metrics", Open: true},
+			peersPackage: {Routes: []config.RouteConfig{{Name: peersRoute, Open: true}}},
+			nodePackage: {Routes: []config.RouteConfig{
+				{Name: statusRoute, Open: true},
+				{Name: metricsRoute, Open: true},
 			}},
 		},
 	}

--- a/cmd/seednode/api/api.go
+++ b/cmd/seednode/api/api.go
@@ -11,9 +11,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	logger "github.com/klever-io/klever-go-logger"
+	"github.com/klever-io/klever-go/config"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/network/api/httpserver"
 	"github.com/klever-io/klever-go/network/api/logs"
+	"github.com/klever-io/klever-go/network/api/middleware"
 	"github.com/klever-io/klever-go/tools/marshal"
 )
 
@@ -30,22 +32,24 @@ type peerInfoProvider interface {
 
 // server bundles the state needed to serve the seednode HTTP surface.
 type server struct {
-	marshalizer marshal.Marshalizer
-	messenger   peerInfoProvider
-	version     string
-	startTime   time.Time
+	marshalizer  marshal.Marshalizer
+	messenger    peerInfoProvider
+	version      string
+	startTime    time.Time
+	routesConfig config.APIRoutesConfig
 }
 
 // Start boots the gin server with the seednode routes. messenger and version
 // are exposed by the /peers, /node/status and /node/metrics endpoints.
 // startTime should reflect process start so uptime reflects the binary, not
 // the API listener.
-func Start(restAPIInterface string, marshalizer marshal.Marshalizer, messenger peerInfoProvider, version string, startTime time.Time) error {
+func Start(restAPIInterface string, marshalizer marshal.Marshalizer, messenger peerInfoProvider, version string, startTime time.Time, routesConfig config.APIRoutesConfig) error {
 	srv := &server{
-		marshalizer: marshalizer,
-		messenger:   messenger,
-		version:     version,
-		startTime:   startTime,
+		marshalizer:  marshalizer,
+		messenger:    messenger,
+		version:      version,
+		startTime:    startTime,
+		routesConfig: routesConfig,
 	}
 
 	gin.SetMode(gin.ReleaseMode)
@@ -63,16 +67,37 @@ func Start(restAPIInterface string, marshalizer marshal.Marshalizer, messenger p
 }
 
 func (s *server) registerRoutes(ws *gin.Engine) {
-	s.registerLoggerWsRoute(ws)
-	ws.GET("/peers", s.peers)
-	ws.GET("/node/status", s.nodeStatus)
-	ws.GET("/node/metrics", s.nodeMetrics)
+	if s.routesConfig.IsRouteEnabled("log", "/log") {
+		s.registerLoggerWsRoute(ws)
+	}
+	s.registerGet(ws, "peers", "/peers", "/peers", s.peers)
+	s.registerGet(ws, "node", "/status", "/node/status", s.nodeStatus)
+	s.registerGet(ws, "node", "/metrics", "/node/metrics", s.nodeMetrics)
+}
+
+// registerGet registers a GET endpoint when its config route (pkg/configName) is open, prepending
+// Basic Authentication when that route is marked secured. path is the URL gin actually serves.
+func (s *server) registerGet(ws *gin.Engine, pkg, configName, path string, handler gin.HandlerFunc) {
+	if !s.routesConfig.IsRouteEnabled(pkg, configName) {
+		return
+	}
+
+	handlers := []gin.HandlerFunc{handler}
+	if s.routesConfig.IsRouteSecured(pkg, configName) {
+		handlers = append([]gin.HandlerFunc{middleware.NewAuthenticationFunc(s.routesConfig)}, handlers...)
+	}
+
+	ws.GET(path, handlers...)
 }
 
 func (s *server) registerLoggerWsRoute(ws *gin.Engine) {
 	upgrader := websocket.Upgrader{}
 
-	ws.GET("/log", func(c *gin.Context) {
+	// Only an authenticated (secured) /log may apply a client-supplied logger profile to the
+	// process-global logger; on an unauthenticated /log profiles are ignored (GHSA-9v8p-frvj-2pcm).
+	secured := s.routesConfig.IsRouteSecured("log", "/log")
+
+	logHandler := func(c *gin.Context) {
 		upgrader.CheckOrigin = func(r *http.Request) bool {
 			return true
 		}
@@ -83,14 +108,39 @@ func (s *server) registerLoggerWsRoute(ws *gin.Engine) {
 			return
 		}
 
-		ls, err := logs.NewLogSender(s.marshalizer, conn, log)
+		ls, err := logs.NewLogSender(s.marshalizer, conn, log, secured)
 		if err != nil {
 			log.Error(err.Error())
 			return
 		}
 
 		ls.StartSendingBlocking()
-	})
+	}
+
+	handlers := []gin.HandlerFunc{logHandler}
+	if secured {
+		// GHSA-9v8p-frvj-2pcm / KLC-2438: enforce authentication before the WebSocket
+		// upgrade. Without this the seednode /log stream was always unauthenticated.
+		handlers = append([]gin.HandlerFunc{middleware.NewAuthenticationFunc(s.routesConfig)}, handlers...)
+	}
+
+	ws.GET("/log", handlers...)
+}
+
+// DefaultRoutesConfig is the fail-safe used when no API config file can be loaded: the read-only
+// monitoring endpoints stay enabled so observability never silently breaks, while /log (which can
+// stream logs and, when secured, mutate the logger profile) stays disabled rather than being
+// exposed unauthenticated.
+func DefaultRoutesConfig() config.APIRoutesConfig {
+	return config.APIRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"peers": {Routes: []config.RouteConfig{{Name: "/peers", Open: true}}},
+			"node": {Routes: []config.RouteConfig{
+				{Name: "/status", Open: true},
+				{Name: "/metrics", Open: true},
+			}},
+		},
+	}
 }
 
 // peerSnapshot: connected count matches its slice; knownPeers is a separate read and may drift under churn.

--- a/cmd/seednode/api/api_test.go
+++ b/cmd/seednode/api/api_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/klever-io/klever-go/config"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/network/api/httpserver"
+	"github.com/klever-io/klever-go/tools/marshal"
 )
 
 type stubMessenger struct {
@@ -27,9 +29,10 @@ func (s *stubMessenger) ConnectedAddresses() []string { return s.connected }
 
 func newTestServer(stub *stubMessenger, version string, started time.Time) *server {
 	return &server{
-		messenger: stub,
-		version:   version,
-		startTime: started,
+		messenger:    stub,
+		version:      version,
+		startTime:    started,
+		routesConfig: DefaultRoutesConfig(),
 	}
 }
 
@@ -80,6 +83,141 @@ func TestSeednodeAPI_HardenedServerDropsSlowHeader(t *testing.T) {
 	_, _ = bufio.NewReader(conn).ReadString('\n')
 	if elapsed := time.Since(start); elapsed > time.Second {
 		t.Fatalf("slow-header connection not dropped promptly: %v", elapsed)
+	}
+}
+
+func seedLogRoutesConfig(open, secured bool) config.APIRoutesConfig {
+	return config.APIRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"log": {Routes: []config.RouteConfig{{Name: "/log", Open: open, Secured: secured}}},
+		},
+		Credentials: []config.Credential{{Username: "user", Password: "deadbeef"}},
+		Hasher:      config.TypeConfig{Type: "sha256"},
+	}
+}
+
+// TestLogRoute_SecuredRequiresAuth verifies GHSA-9v8p-frvj-2pcm / KLC-2438: when /log is secured,
+// the seednode rejects an unauthenticated request before the WebSocket upgrade.
+func TestLogRoute_SecuredRequiresAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &server{
+		marshalizer:  &marshal.ProtoMarshalizer{},
+		messenger:    &stubMessenger{},
+		routesConfig: seedLogRoutesConfig(true, true),
+	}
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/log", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (auth required before upgrade)", w.Code)
+	}
+}
+
+// TestLogRoute_UnsecuredReachesUpgrade confirms that an open-but-unsecured /log has no auth gate:
+// the request reaches the gorilla upgrader, which rejects the non-WebSocket GET with 400.
+func TestLogRoute_UnsecuredReachesUpgrade(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &server{
+		marshalizer:  &marshal.ProtoMarshalizer{},
+		messenger:    &stubMessenger{},
+		routesConfig: seedLogRoutesConfig(true, false),
+	}
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/log", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (reaches upgrader, no auth gate)", w.Code)
+	}
+}
+
+// TestLogRoute_DisabledNotRegistered confirms /log is not registered when not open (fail-safe
+// default when the seednode has no API config).
+func TestLogRoute_DisabledNotRegistered(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &server{marshalizer: &marshal.ProtoMarshalizer{}, messenger: &stubMessenger{}}
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/log", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (/log not registered)", w.Code)
+	}
+}
+
+// TestMonitoringRoute_SecuredRequiresAuth verifies the per-route auth gate also applies to the
+// monitoring endpoints: a secured /node/status rejects an unauthenticated request.
+func TestMonitoringRoute_SecuredRequiresAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &server{
+		messenger: &stubMessenger{},
+		routesConfig: config.APIRoutesConfig{
+			APIPackages: map[string]config.APIPackageConfig{
+				"node": {Routes: []config.RouteConfig{{Name: "/status", Open: true, Secured: true}}},
+			},
+			Credentials: []config.Credential{{Username: "user", Password: "deadbeef"}},
+			Hasher:      config.TypeConfig{Type: "sha256"},
+		},
+	}
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/node/status", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (secured monitoring route)", w.Code)
+	}
+}
+
+// TestMonitoringRoute_DisabledNotRegistered confirms a route with open:false is not served.
+func TestMonitoringRoute_DisabledNotRegistered(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	srv := &server{
+		messenger: &stubMessenger{},
+		routesConfig: config.APIRoutesConfig{
+			APIPackages: map[string]config.APIPackageConfig{
+				"peers": {Routes: []config.RouteConfig{{Name: "/peers", Open: false}}},
+			},
+		},
+	}
+	r := gin.New()
+	srv.registerRoutes(r)
+
+	req := httptest.NewRequest(http.MethodGet, "/peers", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (/peers disabled)", w.Code)
+	}
+}
+
+// TestDefaultRoutesConfig confirms the fail-safe surface: monitoring on, /log off.
+func TestDefaultRoutesConfig(t *testing.T) {
+	cfg := DefaultRoutesConfig()
+	if !cfg.IsRouteEnabled("peers", "/peers") {
+		t.Error("/peers should be enabled by default")
+	}
+	if !cfg.IsRouteEnabled("node", "/status") {
+		t.Error("/node/status should be enabled by default")
+	}
+	if !cfg.IsRouteEnabled("node", "/metrics") {
+		t.Error("/node/metrics should be enabled by default")
+	}
+	if cfg.IsRouteEnabled("log", "/log") {
+		t.Error("/log must be disabled by default (fail-safe)")
 	}
 }
 

--- a/cmd/seednode/main.go
+++ b/cmd/seednode/main.go
@@ -88,6 +88,13 @@ VERSION:
 			"configurations such as the marshalizer type",
 		Value: "./config/seednode/config.yaml",
 	}
+	// configurationAPIFile defines a flag for the path to the api routes yaml configuration file
+	configurationAPIFile = cli.StringFlag{
+		Name: "config-api",
+		Usage: "The `" + filePathPlaceholder + "` for the api configuration file. This YAML file contains the " +
+			"options to enable, disable and secure the seednode REST API endpoints.",
+		Value: "./config/seednode/api.yaml",
+	}
 )
 
 var log = logger.GetOrCreate("main")
@@ -106,6 +113,7 @@ func main() {
 		logLevel,
 		logSaveFile,
 		configurationFile,
+		configurationAPIFile,
 	}
 	app.Version = appVersion
 	app.Authors = []cli.Author{
@@ -139,6 +147,15 @@ func startNode(ctx *cli.Context) error {
 	cfg, err := config.LoadFromPath(configurationFileName)
 	if err != nil {
 		return err
+	}
+
+	apiConfigFileName := ctx.GlobalString(configurationAPIFile.Name)
+	apiRoutesConfig, err := config.LoadAPIConfig(apiConfigFileName)
+	if err != nil {
+		// Fail-safe: keep the read-only monitoring endpoints up but leave /log disabled
+		// rather than exposing it unauthenticated.
+		log.Warn("could not load api config; using built-in defaults (/log disabled)", "file", apiConfigFileName, "error", err)
+		apiRoutesConfig = api.DefaultRoutesConfig()
 	}
 
 	internalMarshalizer, err := factoryMarshalizer.NewMarshalizer(cfg.Marshalizer.Type)
@@ -191,7 +208,7 @@ func startNode(ctx *cli.Context) error {
 		return err
 	}
 
-	startRestServices(ctx, internalMarshalizer, messenger, startTime)
+	startRestServices(ctx, internalMarshalizer, messenger, startTime, apiRoutesConfig)
 
 	log.Info("application is now running...")
 	mainLoop(messenger, sigs)
@@ -355,17 +372,17 @@ func checkExpectedPeerCount(p2pConfig config.P2PConfig) error {
 	return nil
 }
 
-func startRestServices(ctx *cli.Context, marshalizer marshal.Marshalizer, messenger p2p.Messenger, startTime time.Time) {
+func startRestServices(ctx *cli.Context, marshalizer marshal.Marshalizer, messenger p2p.Messenger, startTime time.Time, routesConfig config.APIRoutesConfig) {
 	restAPIInterface := ctx.GlobalString(restAPIInterfaceFlag.Name)
 	if restAPIInterface != facade.DefaultRestPortOff {
-		go startGinServer(restAPIInterface, marshalizer, messenger, startTime)
+		go startGinServer(restAPIInterface, marshalizer, messenger, startTime, routesConfig)
 	} else {
 		log.Info("rest api is disabled")
 	}
 }
 
-func startGinServer(restAPIInterface string, marshalizer marshal.Marshalizer, messenger p2p.Messenger, startTime time.Time) {
-	err := api.Start(restAPIInterface, marshalizer, messenger, appVersion, startTime)
+func startGinServer(restAPIInterface string, marshalizer marshal.Marshalizer, messenger p2p.Messenger, startTime time.Time, routesConfig config.APIRoutesConfig) {
+	err := api.Start(restAPIInterface, marshalizer, messenger, appVersion, startTime, routesConfig)
 	if err != nil {
 		log.LogIfError(err)
 	}

--- a/config/api.go
+++ b/config/api.go
@@ -19,6 +19,31 @@ type RouteConfig struct {
 	Secured bool   `yaml:"secured"`
 }
 
+// IsRouteEnabled reports whether the named route in the given API package exists and is open.
+func (c APIRoutesConfig) IsRouteEnabled(pkg, name string) bool {
+	return c.routeHasFlag(pkg, name, func(r RouteConfig) bool { return r.Open })
+}
+
+// IsRouteSecured reports whether the named route in the given API package exists and is secured.
+func (c APIRoutesConfig) IsRouteSecured(pkg, name string) bool {
+	return c.routeHasFlag(pkg, name, func(r RouteConfig) bool { return r.Secured })
+}
+
+func (c APIRoutesConfig) routeHasFlag(pkg, name string, hasFlag func(RouteConfig) bool) bool {
+	pkgConfig, ok := c.APIPackages[pkg]
+	if !ok {
+		return false
+	}
+
+	for _, route := range pkgConfig.Routes {
+		if route.Name == name && hasFlag(route) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Credential holds an username and a password
 type Credential struct {
 	Username string `yaml:"username"`

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -39,4 +39,5 @@ func TestAPIRoutesConfig_IsRouteSecured(t *testing.T) {
 	assert.False(t, cfg.IsRouteSecured("node", "/status"), "secured:false")
 	assert.False(t, cfg.IsRouteSecured("node", "/missing"), "route absent")
 	assert.False(t, cfg.IsRouteSecured("missing", "/log"), "package absent")
+	assert.False(t, config.APIRoutesConfig{}.IsRouteSecured("log", "/log"), "empty config")
 }

--- a/config/api_test.go
+++ b/config/api_test.go
@@ -1,0 +1,42 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func sampleRoutesConfig() config.APIRoutesConfig {
+	return config.APIRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"log": {Routes: []config.RouteConfig{{Name: "/log", Open: true, Secured: true}}},
+			"node": {Routes: []config.RouteConfig{
+				{Name: "/status", Open: true, Secured: false},
+				{Name: "/metrics", Open: false, Secured: false},
+			}},
+		},
+	}
+}
+
+func TestAPIRoutesConfig_IsRouteEnabled(t *testing.T) {
+	t.Parallel()
+	cfg := sampleRoutesConfig()
+
+	assert.True(t, cfg.IsRouteEnabled("log", "/log"))
+	assert.True(t, cfg.IsRouteEnabled("node", "/status"))
+	assert.False(t, cfg.IsRouteEnabled("node", "/metrics"), "open:false")
+	assert.False(t, cfg.IsRouteEnabled("node", "/missing"), "route absent")
+	assert.False(t, cfg.IsRouteEnabled("missing", "/log"), "package absent")
+	assert.False(t, config.APIRoutesConfig{}.IsRouteEnabled("log", "/log"), "empty config")
+}
+
+func TestAPIRoutesConfig_IsRouteSecured(t *testing.T) {
+	t.Parallel()
+	cfg := sampleRoutesConfig()
+
+	assert.True(t, cfg.IsRouteSecured("log", "/log"))
+	assert.False(t, cfg.IsRouteSecured("node", "/status"), "secured:false")
+	assert.False(t, cfg.IsRouteSecured("node", "/missing"), "route absent")
+	assert.False(t, cfg.IsRouteSecured("missing", "/log"), "package absent")
+}

--- a/config/node/api.yaml
+++ b/config/node/api.yaml
@@ -92,6 +92,7 @@ apiPackages:
     routes:
       - name: /log
         open: true
+        secured: true
   vm:
     routes:
       - name: /hex

--- a/config/seednode/api.yaml
+++ b/config/seednode/api.yaml
@@ -1,0 +1,37 @@
+# Seednode REST API configuration.
+#
+# Each route can be enabled/disabled with `open` and protected with HTTP Basic Authentication with
+# `secured` (credentials below). If this file is missing, the seednode falls back to a built-in
+# default that keeps the read-only monitoring endpoints enabled and /log disabled.
+#
+# /log streams process logs and, on a secured connection, lets an authenticated operator adjust the
+# logger profile. It is secured by default (GHSA-9v8p-frvj-2pcm / KLC-2438). Set `open: false` to
+# disable it, or `secured: false` to expose it unauthenticated (trusted / localhost-bound seednode only).
+#
+# /peers exposes connected peer addresses (network topology); set `open: false` to reduce disclosure.
+# /node/metrics is scraped by Prometheus, which does not send Basic Auth — leave it unsecured unless
+# your scraper is configured for credentials.
+apiPackages:
+  log:
+    routes:
+      - name: /log
+        open: true
+        secured: true
+  peers:
+    routes:
+      - name: /peers
+        open: true
+  node:
+    routes:
+      - name: /status
+        open: true
+      - name: /metrics
+        open: true
+
+# Credentials used when a route is `secured`. Replace the placeholders with real values:
+# `password` is the hex-encoded hash (per hasher.type) of the plaintext password.
+credentials:
+  - username: example
+    password: hashed password
+hasher:
+  type: sha256

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -43,6 +43,11 @@ import (
 
 var log = logger.GetOrCreate("api")
 
+const (
+	logPackage = "log"
+	logRoute   = "/log"
+)
+
 type validatorInput struct {
 	Name      string
 	Validator validator.Func
@@ -128,7 +133,7 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 		pprof.Register(ws)
 	}
 
-	if routesConfig.IsRouteEnabled("log", "/log") {
+	if routesConfig.IsRouteEnabled(logPackage, logRoute) {
 		marshalizerForLogs := &marshal.ProtoMarshalizer{}
 		registerLoggerWsRoute(ws, marshalizerForLogs, routesConfig)
 	}
@@ -172,7 +177,7 @@ func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer, rout
 
 	// Only an authenticated (secured) /log may apply a client-supplied logger profile to the
 	// process-global logger; on an unauthenticated /log profiles are ignored (GHSA-9v8p-frvj-2pcm).
-	secured := routesConfig.IsRouteSecured("log", "/log")
+	secured := routesConfig.IsRouteSecured(logPackage, logRoute)
 
 	logHandler := func(c *gin.Context) {
 		upgrader.CheckOrigin = func(r *http.Request) bool {
@@ -203,7 +208,7 @@ func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer, rout
 		handlers = append([]gin.HandlerFunc{middleware.NewAuthenticationFunc(routesConfig)}, handlers...)
 	}
 
-	ws.GET("/log", handlers...)
+	ws.GET(logRoute, handlers...)
 }
 
 // skValidator validates a secret key from user input for correctness

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -128,12 +128,12 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 		pprof.Register(ws)
 	}
 
-	if isLogRouteEnabled(routesConfig) {
+	if routesConfig.IsRouteEnabled("log", "/log") {
 		marshalizerForLogs := &marshal.ProtoMarshalizer{}
-		registerLoggerWsRoute(ws, marshalizerForLogs)
+		registerLoggerWsRoute(ws, marshalizerForLogs, routesConfig)
 	}
 
-	if isSubscriptionRouteEnabled(routesConfig) {
+	if routesConfig.IsRouteEnabled("subscribe", "/subscribe") {
 		var postConnUrl, postConnApiKey string
 		if ok {
 			postConnUrl, postConnApiKey = apiHandler.WSConnectionURL(), apiHandler.WSConnectionAPIKey()
@@ -149,36 +149,6 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 		wsocket.SubscribeTopics(ws, hub)
 		go hub.StartServer(ctx)
 	}
-}
-
-func isSubscriptionRouteEnabled(routesConfig config.APIRoutesConfig) bool {
-	logConfig, ok := routesConfig.APIPackages["subscribe"]
-	if !ok {
-		return false
-	}
-
-	for _, cfg := range logConfig.Routes {
-		if cfg.Name == "/subscribe" && cfg.Open {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isLogRouteEnabled(routesConfig config.APIRoutesConfig) bool {
-	logConfig, ok := routesConfig.APIPackages["log"]
-	if !ok {
-		return false
-	}
-
-	for _, cfg := range logConfig.Routes {
-		if cfg.Name == "/log" && cfg.Open {
-			return true
-		}
-	}
-
-	return false
 }
 
 // RegisterDefaultValidators will call register validation on all validator functions
@@ -197,10 +167,14 @@ func RegisterDefaultValidators() error {
 	return nil
 }
 
-func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
+func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer, routesConfig config.APIRoutesConfig) {
 	upgrader := websocket.Upgrader{}
 
-	ws.GET("/log", func(c *gin.Context) {
+	// Only an authenticated (secured) /log may apply a client-supplied logger profile to the
+	// process-global logger; on an unauthenticated /log profiles are ignored (GHSA-9v8p-frvj-2pcm).
+	secured := routesConfig.IsRouteSecured("log", "/log")
+
+	logHandler := func(c *gin.Context) {
 		upgrader.CheckOrigin = func(r *http.Request) bool {
 			return true
 		}
@@ -211,14 +185,25 @@ func registerLoggerWsRoute(ws *gin.Engine, marshalizer marshal.Marshalizer) {
 			return
 		}
 
-		ls, err := logs.NewLogSender(marshalizer, conn, log)
+		ls, err := logs.NewLogSender(marshalizer, conn, log, secured)
 		if err != nil {
 			log.Error(err.Error())
 			return
 		}
 
 		ls.StartSendingBlocking()
-	})
+	}
+
+	handlers := []gin.HandlerFunc{logHandler}
+	if secured {
+		// GHSA-9v8p-frvj-2pcm / KLC-2438: enforce authentication before the WebSocket
+		// upgrade when /log is marked secured. This route is registered directly on the
+		// engine (outside the RouterWrapper), so without this the `secured: true` flag
+		// was silently ignored and /log was always unauthenticated.
+		handlers = append([]gin.HandlerFunc{middleware.NewAuthenticationFunc(routesConfig)}, handlers...)
+	}
+
+	ws.GET("/log", handlers...)
 }
 
 // skValidator validates a secret key from user input for correctness

--- a/network/api/logRoute_internal_test.go
+++ b/network/api/logRoute_internal_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/klever-io/klever-go/config"
+	"github.com/klever-io/klever-go/tools/marshal"
+	"github.com/stretchr/testify/assert"
+)
+
+func logRoutesConfig(secured bool) config.APIRoutesConfig {
+	return config.APIRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"log": {Routes: []config.RouteConfig{{Name: "/log", Open: true, Secured: secured}}},
+		},
+		Credentials: []config.Credential{{Username: "user", Password: "deadbeef"}},
+		Hasher:      config.TypeConfig{Type: "sha256"},
+	}
+}
+
+func TestIsLogRouteSecured(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, logRoutesConfig(true).IsRouteSecured("log", "/log"))
+	assert.False(t, logRoutesConfig(false).IsRouteSecured("log", "/log"))
+	assert.False(t, config.APIRoutesConfig{}.IsRouteSecured("log", "/log"))
+}
+
+// TestRegisterLoggerWsRoute_SecuredRequiresAuth verifies GHSA-9v8p-frvj-2pcm / KLC-2438:
+// when /log is secured, an unauthenticated request is rejected before the WebSocket upgrade.
+func TestRegisterLoggerWsRoute_SecuredRequiresAuth(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	ws := gin.New()
+	registerLoggerWsRoute(ws, &marshal.ProtoMarshalizer{}, logRoutesConfig(true))
+
+	req := httptest.NewRequest(http.MethodGet, "/log", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+}
+
+// TestRegisterLoggerWsRoute_UnsecuredReachesUpgrade confirms an unsecured /log has no auth
+// gate: the request reaches the gorilla upgrader, which rejects the non-WebSocket GET with 400.
+func TestRegisterLoggerWsRoute_UnsecuredReachesUpgrade(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	ws := gin.New()
+	registerLoggerWsRoute(ws, &marshal.ProtoMarshalizer{}, logRoutesConfig(false))
+
+	req := httptest.NewRequest(http.MethodGet, "/log", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+}

--- a/network/api/logs/logSender.go
+++ b/network/api/logs/logSender.go
@@ -14,16 +14,24 @@ import (
 const disconnectMessage = -1
 
 type logSender struct {
-	marshalizer marshal.Marshalizer
-	conn        wsConn
-	writer      *logWriter
-	log         logger.Logger
-	lastProfile logger.Profile
+	marshalizer       marshal.Marshalizer
+	conn              wsConn
+	writer            *logWriter
+	log               logger.Logger
+	allowProfileApply bool
+	lastProfile       logger.Profile
 }
 
 // NewLogSender returns a new component that is able to communicate with the log viewer application.
-// After the correct handshake it will send all logs that come through the logger subsystem
-func NewLogSender(marshalizer marshal.Marshalizer, conn wsConn, log logger.Logger) (*logSender, error) {
+// After the correct handshake it will send all logs that come through the logger subsystem.
+//
+// allowProfileApply controls whether a client-supplied logger Profile (the first frame) may mutate
+// the process-global logger. It must be true ONLY for authenticated connections: /log can be served
+// unauthenticated, and letting an anonymous client apply a profile let a remote peer mute (*:NONE)
+// or flood (*:TRACE) node logging process-wide (GHSA-9v8p-frvj-2pcm / KLC-2438). On a secured /log
+// the operator is authenticated, so profile control (e.g. bumping verbosity to debug a live node)
+// is restored as a trusted action and reverted on disconnect.
+func NewLogSender(marshalizer marshal.Marshalizer, conn wsConn, log logger.Logger, allowProfileApply bool) (*logSender, error) {
 	if check.IfNil(marshalizer) {
 		return nil, ErrNilMarshalizer
 	}
@@ -35,9 +43,10 @@ func NewLogSender(marshalizer marshal.Marshalizer, conn wsConn, log logger.Logge
 	}
 
 	ls := &logSender{
-		marshalizer: marshalizer,
-		log:         log,
-		conn:        conn,
+		marshalizer:       marshalizer,
+		log:               log,
+		conn:              conn,
+		allowProfileApply: allowProfileApply,
 	}
 
 	err := ls.registerLogWriter()
@@ -65,19 +74,24 @@ func (ls *logSender) registerLogWriter() error {
 	return nil
 }
 
-// StartSendingBlocking initialize the handshake by waiting the correct pattern and after that
-// will start sending logs information and in the same time monitor the current connection.
-// When the connection ends it will revert the previous log pattern.
+// StartSendingBlocking initializes the handshake by waiting for the first frame and after that
+// will start sending logs information while monitoring the current connection. When profile
+// application is allowed (authenticated client), a profile applied during the handshake is
+// reverted once the client disconnects.
 func (ls *logSender) StartSendingBlocking() {
-	ls.lastProfile = logger.GetCurrentProfile()
+	if ls.allowProfileApply {
+		ls.lastProfile = logger.GetCurrentProfile()
+	}
 
 	defer func() {
 		_ = ls.conn.Close()
 		_ = ls.writer.Close()
 		_ = logger.RemoveLogObserver(ls.writer)
-		_ = ls.lastProfile.Apply()
 
-		ls.log.Info("reverted log profile", "profile", ls.lastProfile.String())
+		if ls.allowProfileApply {
+			_ = ls.lastProfile.Apply()
+			ls.log.Info("reverted log profile", "profile", ls.lastProfile.String())
+		}
 	}()
 
 	err := ls.waitForProfile()
@@ -90,6 +104,11 @@ func (ls *logSender) StartSendingBlocking() {
 	ls.doSendContinuously()
 }
 
+// waitForProfile performs the /log handshake: it reads the first client frame. A client-provided
+// profile is applied to the process-global logger ONLY when allowProfileApply is set (authenticated
+// connection). On an unauthenticated /log the profile is parsed (to reject malformed handshakes) but
+// never applied, so a remote peer cannot mute (*:NONE) or flood (*:TRACE) node logging process-wide
+// (GHSA-9v8p-frvj-2pcm / KLC-2438).
 func (ls *logSender) waitForProfile() error {
 	_, message, err := ls.conn.ReadMessage()
 	if err != nil {
@@ -105,10 +124,13 @@ func (ls *logSender) waitForProfile() error {
 		return err
 	}
 
-	ls.log.Info("websocket log profile received", "profile", profile.String())
+	if !ls.allowProfileApply {
+		ls.log.Info("ignoring client-provided log profile on unauthenticated /log", "profile", profile.String())
+		return nil
+	}
 
-	err = profile.Apply()
-	if err != nil {
+	ls.log.Info("websocket log profile received", "profile", profile.String())
+	if err := profile.Apply(); err != nil {
 		return err
 	}
 

--- a/network/api/logs/logSender_test.go
+++ b/network/api/logs/logSender_test.go
@@ -32,6 +32,7 @@ func createMockLogSender() (*logs.LogSender, *mock.WsConnStub, io.Writer) {
 		&mock.MarshalizerStub{},
 		conn,
 		&mock.LoggerStub{},
+		false,
 	)
 	removeWriterFromLogSubsystem(ls.Writer())
 	ls.SetWriter(logs.NewLogWriter())
@@ -46,7 +47,7 @@ func createMockLogSender() (*logs.LogSender, *mock.WsConnStub, io.Writer) {
 func TestNewLogSender_NilMarshalizerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	ls, err := logs.NewLogSender(nil, &mock.WsConnStub{}, &mock.LoggerStub{})
+	ls, err := logs.NewLogSender(nil, &mock.WsConnStub{}, &mock.LoggerStub{}, false)
 
 	assert.Nil(t, ls)
 	assert.Equal(t, logs.ErrNilMarshalizer, err)
@@ -55,7 +56,7 @@ func TestNewLogSender_NilMarshalizerShouldErr(t *testing.T) {
 func TestNewLogSender_NilConnectionShouldErr(t *testing.T) {
 	t.Parallel()
 
-	ls, err := logs.NewLogSender(&mock.MarshalizerStub{}, nil, &mock.LoggerStub{})
+	ls, err := logs.NewLogSender(&mock.MarshalizerStub{}, nil, &mock.LoggerStub{}, false)
 
 	assert.Nil(t, ls)
 	assert.Equal(t, logs.ErrNilWsConn, err)
@@ -64,7 +65,7 @@ func TestNewLogSender_NilConnectionShouldErr(t *testing.T) {
 func TestNewLogSender_NilLoggerShouldErr(t *testing.T) {
 	t.Parallel()
 
-	ls, err := logs.NewLogSender(&mock.MarshalizerStub{}, &mock.WsConnStub{}, nil)
+	ls, err := logs.NewLogSender(&mock.MarshalizerStub{}, &mock.WsConnStub{}, nil, false)
 
 	assert.Nil(t, ls)
 	assert.Equal(t, logs.ErrNilLogger, err)
@@ -73,7 +74,7 @@ func TestNewLogSender_NilLoggerShouldErr(t *testing.T) {
 func TestNewLogSender_ShouldWork(t *testing.T) {
 	t.Parallel()
 
-	ls, err := logs.NewLogSender(&mock.MarshalizerStub{}, &mock.WsConnStub{}, &mock.LoggerStub{})
+	ls, err := logs.NewLogSender(&mock.MarshalizerStub{}, &mock.WsConnStub{}, &mock.LoggerStub{}, false)
 
 	assert.NotNil(t, ls)
 	assert.Nil(t, err)
@@ -100,6 +101,7 @@ func TestLogSender_StartSendingBlockingConnReadMessageErrShouldCloseConn(t *test
 		&mock.MarshalizerStub{},
 		conn,
 		&mock.LoggerStub{},
+		false,
 	)
 	removeWriterFromLogSubsystem(ls.Writer())
 
@@ -124,6 +126,7 @@ func TestLogSender_StartSendingBlockingWrongPatternShouldCloseConn(t *testing.T)
 		&mock.MarshalizerStub{},
 		conn,
 		&mock.LoggerStub{},
+		false,
 	)
 	removeWriterFromLogSubsystem(ls.Writer())
 
@@ -182,6 +185,81 @@ func TestLogSender_StartSendingBlockingSendsMessageAndStopsWhenReadClose(t *test
 
 	assert.Nil(t, err)
 	assert.Equal(t, data, retrievedData)
+}
+
+// TestLogSender_UnauthenticatedClientProfileIsIgnored is the anti-PoC regression for
+// GHSA-9v8p-frvj-2pcm / KLC-2438: on an unauthenticated /log (allowProfileApply=false) a profile
+// sent by a client as the first frame must NOT mutate the process-global logger.
+// Not parallel: it asserts on global logger state.
+func TestLogSender_UnauthenticatedClientProfileIsIgnored(t *testing.T) {
+	err := logger.SetLogLevel("*:INFO")
+	assert.Nil(t, err)
+	baseline := logger.GetLogLevelPattern()
+	assert.NotEqual(t, "*:NONE", baseline)
+	t.Cleanup(func() { _ = logger.SetLogLevel("*:INFO") })
+
+	mutePayload := []byte(`{"LogLevelPatterns":"*:NONE","WithCorrelation":false,"WithLoggerName":false}`)
+
+	readCount := 0
+	conn := &mock.WsConnStub{}
+	conn.SetCloseHandler(func() error { return nil })
+	conn.SetReadMessageHandler(func() (messageType int, p []byte, err error) {
+		readCount++
+		if readCount == 1 {
+			// Attacker handshake frame: a global mute profile.
+			return websocket.TextMessage, mutePayload, nil
+		}
+		// End the stream: monitorConnection returns on CloseMessage and closes the
+		// writer, which unblocks doSendContinuously so StartSendingBlocking returns.
+		return websocket.CloseMessage, nil, nil
+	})
+
+	// allowProfileApply=false => unauthenticated connection.
+	ls, _ := logs.NewLogSender(&mock.MarshalizerStub{}, conn, &mock.LoggerStub{}, false)
+
+	ls.StartSendingBlocking()
+
+	assert.Equal(t, baseline, logger.GetLogLevelPattern(), "unauthenticated client profile must not change the global log level")
+	assert.NotEqual(t, "*:NONE", logger.GetLogLevelPattern())
+}
+
+// TestLogSender_AuthenticatedClientProfileIsAppliedAndReverted verifies that on a secured /log
+// (allowProfileApply=true) an authenticated operator CAN apply a logger profile while connected
+// — the useful debugging capability — and that it is reverted to the prior profile on disconnect.
+// Not parallel: it asserts on global logger state.
+func TestLogSender_AuthenticatedClientProfileIsAppliedAndReverted(t *testing.T) {
+	err := logger.SetLogLevel("*:INFO")
+	assert.Nil(t, err)
+	baseline := logger.GetLogLevelPattern()
+	assert.NotEqual(t, "*:NONE", baseline)
+	t.Cleanup(func() { _ = logger.SetLogLevel("*:INFO") })
+
+	mutePayload := []byte(`{"LogLevelPatterns":"*:NONE","WithCorrelation":false,"WithLoggerName":false}`)
+
+	var midLevel string
+	readCount := 0
+	conn := &mock.WsConnStub{}
+	conn.SetCloseHandler(func() error { return nil })
+	conn.SetReadMessageHandler(func() (messageType int, p []byte, err error) {
+		readCount++
+		if readCount == 1 {
+			return websocket.TextMessage, mutePayload, nil
+		}
+		// This read happens in monitorConnection, after waitForProfile applied the profile:
+		// capture the live (mid-connection) global level before ending the stream.
+		if midLevel == "" {
+			midLevel = logger.GetLogLevelPattern()
+		}
+		return websocket.CloseMessage, nil, nil
+	})
+
+	// allowProfileApply=true => authenticated connection.
+	ls, _ := logs.NewLogSender(&mock.MarshalizerStub{}, conn, &mock.LoggerStub{}, true)
+
+	ls.StartSendingBlocking()
+
+	assert.Equal(t, "*:NONE", midLevel, "authenticated client profile should be applied while connected")
+	assert.Equal(t, baseline, logger.GetLogLevelPattern(), "profile should be reverted to baseline on disconnect")
 }
 
 func TestLogSender_StartSendingBlockingConnWriteFailsShouldStop(t *testing.T) {

--- a/network/api/middleware/authHandler.go
+++ b/network/api/middleware/authHandler.go
@@ -14,7 +14,6 @@ import (
 
 func NewAuthenticationFunc(credentialsConfig config.APIRoutesConfig) gin.HandlerFunc {
 	if len(credentialsConfig.Credentials) == 0 {
-		log.Warn("authentication requested but no credentials are configured; secured endpoints will reject all requests")
 		return func(c *gin.Context) {
 			c.AbortWithStatusJSON(
 				http.StatusInternalServerError,

--- a/network/api/middleware/authHandler.go
+++ b/network/api/middleware/authHandler.go
@@ -14,6 +14,7 @@ import (
 
 func NewAuthenticationFunc(credentialsConfig config.APIRoutesConfig) gin.HandlerFunc {
 	if len(credentialsConfig.Credentials) == 0 {
+		log.Warn("authentication requested but no credentials are configured; secured endpoints will reject all requests")
 		return func(c *gin.Context) {
 			c.AbortWithStatusJSON(
 				http.StatusInternalServerError,


### PR DESCRIPTION
## Summary

`GET /log` (node and seednode) was unauthenticated and applied a client-supplied logger profile to the **process-global** logger. A remote client could read the live log stream and mute (`*:NONE`) or flood (`*:TRACE`) node logging. `secured: true` did nothing on `/log` because the route was registered directly on the engine, outside the auth wrapper.

## Changes

### Logging (`network/api/logs`)
- A client-supplied logger profile is applied to the global logger **only on an authenticated connection**, and reverted on disconnect. On an unauthenticated `/log` the first frame is parsed (to reject malformed handshakes) but never applied. Protects both the node and the seednode.

### Node (`network/api`, `config/node/api.yaml`)
- `/log` is routed through Basic Authentication **before** the WebSocket upgrade when the route is `secured`.
- Ships `/log` with `open: true` + `secured: true`.

### Seednode (`cmd/seednode`, `config/seednode/api.yaml`)
- New `config/seednode/api.yaml` (+ `--config-api` flag). Every seednode route (`/log`, `/peers`, `/node/status`, `/node/metrics`) is gated on per-route `open`/`secured`; `/log` secured by default.
- Fail-safe default when the api config is absent: monitoring endpoints stay up, `/log` is disabled rather than exposed unauthenticated.

### Shared
- `config.APIRoutesConfig.IsRouteEnabled` / `IsRouteSecured`, used by node and seednode route registration.
- Warn at startup when authentication is configured without credentials.

## Tests
- Profile applied-and-reverted (authenticated) vs ignored (unauthenticated).
- Node and seednode `/log`: 401 without credentials when secured; reaches the upgrade when unsecured; not registered when disabled.
- Seednode monitoring routes: securable, disableable, and fail-safe default.

## Notes
- Cross-origin (`CheckOrigin`) restriction and connector credential support are intentionally out of scope here (operator/reverse-proxy hardening and a separate connector change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR mitigates a security vulnerability (GHSA-9v8p-frvj-2pcm) in the `/log` WebSocket endpoint on both node and seednode by enforcing route enablement and authentication consistently before the WebSocket upgrade.

- **Networking / security (blockchain-critical impact: operational safety, not consensus/data integrity):**
  - `/log` can no longer be used by remote unauthenticated clients to **mute** or **flood** process-global logging (e.g., `*:NONE` / `*:TRACE`).
  - When `/log` is configured as **secured**, requests are **401 rejected before the WebSocket upgrade**; when **open but not secured**, the upgrade proceeds but client-supplied log profiles are **ignored**.

- **Global logger profile handling (cross-cutting concurrency/error-handling):**
  - Introduces an `allowProfileApply` flag in `network/api/logs/logSender.go` so the server applies client-provided logger profiles **only for authenticated sessions**, and **reverts** the global logger state on disconnect.  
  - Unauthenticated connections still parse the initial handshake frame to reject malformed inputs, but **never apply** the profile.

- **Route gating and configuration correctness:**
  - Adds shared `APIRoutesConfig.IsRouteEnabled` / `IsRouteSecured` helpers and refactors route registration so handlers (including `/log`) are only registered when enabled.
  - **Node**: `/log` is routed through Basic Auth when configured as secured (`config/node/api.yaml` sets it secured).
  - **Seednode**:
    - Adds `config/seednode/api.yaml` plus a `--config-api` flag.
    - Applies a fail-safe default: monitoring endpoints remain available, while `/log` is **disabled unless explicitly enabled**.
    - When authentication is configured without credentials, startup emits a warning.

- **Tests:**
  - Verifies secured vs unauthenticated behavior (401 before upgrade; profile applied+reverted only for authenticated clients).
  - Confirms fail-safe defaults and per-route configurability/registration for seednode monitoring and `/log`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->