### PR TITLE
[KLC-2469] Validate kdaFeesPool fee ratios

### DIFF
--- a/common/mock/forkControllerStub.go
+++ b/common/mock/forkControllerStub.go
@@ -16,6 +16,7 @@ type ForkControllerStub struct {
 	EpochRewardsV2Value          bool
 	FixAuditChangesV2Value       bool
 	FixMarketBuyOverflowValue    bool
+	FixAuditChangesV3Value       bool
 	EpochConfirmedCalled         bool
 	LastConfirmedEpoch           uint32
 }
@@ -54,6 +55,8 @@ func (s *ForkControllerStub) SetFork(forkName string, value bool) *ForkControlle
 		s.FixAuditChangesV2Value = value
 	case "FixMarketBuyOverflow":
 		s.FixMarketBuyOverflowValue = value
+	case "FixAuditChangesV3":
+		s.FixAuditChangesV3Value = value
 	}
 
 	return s
@@ -73,6 +76,7 @@ func (s *ForkControllerStub) SetAll(value bool) {
 	s.EpochRewardsV2Value = value
 	s.FixAuditChangesV2Value = value
 	s.FixMarketBuyOverflowValue = value
+	s.FixAuditChangesV3Value = value
 	s.LastConfirmedEpoch = 0
 }
 
@@ -90,6 +94,7 @@ func (s *ForkControllerStub) SetByConfig(config config.EnableEpochs) {
 	s.EpochRewardsV2Value = config.EpochRewardsV2 == 0
 	s.FixAuditChangesV2Value = config.FixAuditChangesV2 == 0
 	s.FixMarketBuyOverflowValue = config.FixMarketBuyOverflow == 0
+	s.FixAuditChangesV3Value = config.FixAuditChangesV3 == 0
 	s.LastConfirmedEpoch = 0
 }
 
@@ -151,6 +156,11 @@ func (s *ForkControllerStub) FixAuditChangesV2() bool {
 // FixMarketBuyOverflow returns the stubbed value
 func (s *ForkControllerStub) FixMarketBuyOverflow() bool {
 	return s.FixMarketBuyOverflowValue
+}
+
+// FixAuditChangesV3 returns the stubbed value
+func (s *ForkControllerStub) FixAuditChangesV3() bool {
+	return s.FixAuditChangesV3Value
 }
 
 // EpochConfirmed records that the method was called and stores the epoch

--- a/config/enableEpochs.go
+++ b/config/enableEpochs.go
@@ -27,6 +27,7 @@ type EnableEpochs struct {
 	EpochRewardsV2          uint32 `yaml:"epochRewardsV2"`
 	FixAuditChangesV2       uint32 `yaml:"fixAuditChangesV2"`
 	FixMarketBuyOverflow    uint32 `yaml:"fixMarketBuyOverflow"`
+	FixAuditChangesV3       uint32 `yaml:"fixAuditChangesV3"`
 }
 
 // GasScheduleByEpochs represents a gas schedule toml entry that will be applied from the provided epoch

--- a/config/node/enableEpochs.yaml
+++ b/config/node/enableEpochs.yaml
@@ -29,6 +29,8 @@ enableEpochs:
   # royalties (GHSA-p7gw-2pcp-5pf8), and SFT add-quantity circulation
   # overflow (GHSA-mrpp-v6pg-p54x).
   fixMarketBuyOverflow: 0
+  # Audit Changes V3 (reject non-positive kdaFeesPool fee ratios + range-check swap price)
+  fixAuditChangesV3: 0
 
 gasSchedule:
   gasScheduleByEpochs:

--- a/core/fork/forks.go
+++ b/core/fork/forks.go
@@ -25,6 +25,7 @@ type forkController struct {
 	flagEpochRewardsV2               atomic.Flag
 	flagFixAuditChangesV2            atomic.Flag
 	flagFixMarketBuyOverflow         atomic.Flag
+	flagFixAuditChangesV3            atomic.Flag
 }
 
 func NewForkController(cfg config.EnableEpochs, epochNotifier process.EpochNotifier) (*forkController, error) {
@@ -88,6 +89,10 @@ func (f *forkController) FixMarketBuyOverflow() bool {
 	return f.flagFixMarketBuyOverflow.IsSet()
 }
 
+func (f *forkController) FixAuditChangesV3() bool {
+	return f.flagFixAuditChangesV3.IsSet()
+}
+
 // EpochConfirmed is called whenever a new epoch is confirmed
 func (f *forkController) EpochConfirmed(epoch uint32) {
 	f.flagClaimKFIEnabled.Toggle(epoch >= f.enableEpochs.ClaimKFI)
@@ -125,6 +130,8 @@ func (f *forkController) EpochConfirmed(epoch uint32) {
 
 	f.flagFixMarketBuyOverflow.Toggle(epoch >= f.enableEpochs.FixMarketBuyOverflow)
 	log.Debug("forkController: FixMarketBuyOverflow", "enabled", f.flagFixMarketBuyOverflow.IsSet())
+	f.flagFixAuditChangesV3.Toggle(epoch >= f.enableEpochs.FixAuditChangesV3)
+	log.Debug("forkController: FixAuditChangesV3", "enabled", f.flagFixAuditChangesV3.IsSet())
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/core/fork/forks_test.go
+++ b/core/fork/forks_test.go
@@ -1,0 +1,86 @@
+package fork
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/common"
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/config"
+	"github.com/klever-io/klever-go/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewForkController(t *testing.T) {
+	t.Run("nil epoch notifier returns error", func(t *testing.T) {
+		fc, err := NewForkController(config.EnableEpochs{}, nil)
+		require.Nil(t, fc)
+		require.Equal(t, common.ErrNilEpochNotifier, err)
+	})
+
+	t.Run("valid notifier registers the handler", func(t *testing.T) {
+		registered := false
+		notifier := &mock.EpochNotifierStub{
+			RegisterNotifyHandlerCalled: func(handler core.EpochSubscriberHandler) {
+				registered = true
+			},
+		}
+
+		fc, err := NewForkController(config.EnableEpochs{}, notifier)
+		require.NoError(t, err)
+		require.NotNil(t, fc)
+		require.True(t, registered)
+		require.False(t, fc.IsInterfaceNil())
+	})
+}
+
+func TestForkController_FlagsToggleAtConfiguredEpoch(t *testing.T) {
+	cfg := config.EnableEpochs{
+		ClaimKFI:                1,
+		ProcessorFlowITOPrice:   2,
+		FixStakingBuckets:       3,
+		KdaFpr:                  4,
+		BigBucketsCompute:       5,
+		FPRComputeAndKdaFeeFlow: 6,
+		FixDelegationSameEpoch:  7,
+		SmartContracts:          8,
+		FixAuditChanges:         9,
+		EpochRewardsV2:          10,
+		FixAuditChangesV2:       11,
+		FixAuditChangesV3:       12,
+	}
+	fc := &forkController{enableEpochs: cfg}
+
+	flags := []struct {
+		name  string
+		epoch uint32
+		get   func() bool
+	}{
+		{"ClaimKFI", cfg.ClaimKFI, fc.ClaimKFI},
+		{"ProcessorFlowITOPrice", cfg.ProcessorFlowITOPrice, fc.ProcessorFlowITOPrice},
+		{"FixStakingBuckets", cfg.FixStakingBuckets, fc.FixStakingBuckets},
+		{"KdaFpr", cfg.KdaFpr, fc.KdaFpr},
+		{"BigBucketsCompute", cfg.BigBucketsCompute, fc.BigBucketsCompute},
+		{"FPRComputeAndKdaFeeFlow", cfg.FPRComputeAndKdaFeeFlow, fc.FPRComputeAndKdaFeeFlow},
+		{"FixDelegationSameEpoch", cfg.FixDelegationSameEpoch, fc.FixDelegationSameEpoch},
+		{"EnableSmartContracts", cfg.SmartContracts, fc.EnableSmartContracts},
+		{"FixAuditChanges", cfg.FixAuditChanges, fc.FixAuditChanges},
+		{"EpochRewardsV2", cfg.EpochRewardsV2, fc.EpochRewardsV2},
+		{"FixAuditChangesV2", cfg.FixAuditChangesV2, fc.FixAuditChangesV2},
+		{"FixAuditChangesV3", cfg.FixAuditChangesV3, fc.FixAuditChangesV3},
+	}
+
+	maxEpoch := uint32(0)
+	for _, f := range flags {
+		if f.epoch > maxEpoch {
+			maxEpoch = f.epoch
+		}
+	}
+
+	for epoch := uint32(0); epoch <= maxEpoch; epoch++ {
+		fc.EpochConfirmed(epoch)
+		for _, f := range flags {
+			require.Equal(t, epoch >= f.epoch, f.get(),
+				"flag %s (activation epoch %d) is wired wrong: unexpected state at confirmed epoch %d", f.name, f.epoch, epoch)
+		}
+	}
+}

--- a/core/interface.go
+++ b/core/interface.go
@@ -81,6 +81,7 @@ type ForkController interface {
 	EpochRewardsV2() bool
 	FixAuditChangesV2() bool
 	FixMarketBuyOverflow() bool
+	FixAuditChangesV3() bool
 	IsInterfaceNil() bool
 }
 

--- a/core/kapp/kdaFeesPool/actions.go
+++ b/core/kapp/kdaFeesPool/actions.go
@@ -63,11 +63,7 @@ func (v *kdaFeesPoolKApp) UpdatePool(poolID []byte, assetOwner []byte, sender []
 		return transaction.Transaction_ParameterInvalid, common.ErrAssetPoolInvalidAddress
 	}
 
-	invalidRatio := info.FRatioKLV == 0 || info.FRatioKDA == 0
-	if v.forkController.FixAuditChangesV3() {
-		invalidRatio = info.FRatioKLV <= 0 || info.FRatioKDA <= 0
-	}
-	if invalidRatio {
+	if v.invalidFeeRatio(info) {
 		ctx.Receipts().AddError(ctx.ContractID(), common.ErrFieldInvalidAmount, common.ErrAssetPoolInvalidAmount.Error())
 		return transaction.Transaction_ParameterInvalid, common.ErrAssetPoolInvalidAmount
 	}
@@ -96,6 +92,14 @@ func (v *kdaFeesPoolKApp) UpdatePool(poolID []byte, assetOwner []byte, sender []
 	))
 
 	return transaction.Transaction_Ok, nil
+}
+
+func (v *kdaFeesPoolKApp) invalidFeeRatio(info *transaction.KDAPoolInfo) bool {
+	if v.forkController.FixAuditChangesV3() {
+		return info.FRatioKLV <= 0 || info.FRatioKDA <= 0
+	}
+
+	return info.FRatioKLV == 0 || info.FRatioKDA == 0
 }
 
 // ChangePoolOwner -

--- a/core/kapp/kdaFeesPool/actions.go
+++ b/core/kapp/kdaFeesPool/actions.go
@@ -524,6 +524,10 @@ func (v *kdaFeesPoolKApp) compute(app state.KAppAccountHandler, klvFee int64, in
 		return nil, 0, common.ErrAssetPoolNotActive
 	}
 
+	if v.forkController.FixAuditChangesV3() && (pool.FRatioKLV <= 0 || pool.FRatioKDA <= 0) {
+		return nil, 0, common.ErrAssetPoolInvalidAmount
+	}
+
 	// TODO: implement automated exchange based on balance with spread
 	// compute amount fixed ratio
 	// FRatioKDA:FRatioKLV

--- a/core/kapp/kdaFeesPool/actions.go
+++ b/core/kapp/kdaFeesPool/actions.go
@@ -63,7 +63,11 @@ func (v *kdaFeesPoolKApp) UpdatePool(poolID []byte, assetOwner []byte, sender []
 		return transaction.Transaction_ParameterInvalid, common.ErrAssetPoolInvalidAddress
 	}
 
-	if info.FRatioKLV == 0 || info.FRatioKDA == 0 {
+	invalidRatio := info.FRatioKLV == 0 || info.FRatioKDA == 0
+	if v.forkController.FixAuditChangesV3() {
+		invalidRatio = info.FRatioKLV <= 0 || info.FRatioKDA <= 0
+	}
+	if invalidRatio {
 		ctx.Receipts().AddError(ctx.ContractID(), common.ErrFieldInvalidAmount, common.ErrAssetPoolInvalidAmount.Error())
 		return transaction.Transaction_ParameterInvalid, common.ErrAssetPoolInvalidAmount
 	}
@@ -525,6 +529,10 @@ func (v *kdaFeesPoolKApp) compute(app state.KAppAccountHandler, klvFee int64, in
 	fv := big.NewInt(klvFee)
 	fv = fv.Mul(fv, big.NewInt(pool.FRatioKDA))
 	fv = fv.Quo(fv, big.NewInt(pool.FRatioKLV))
+
+	if v.forkController.FixAuditChangesV3() && !fv.IsInt64() {
+		return nil, 0, common.ErrAssetPoolInvalidAmount
+	}
 
 	return pool, fv.Int64(), nil
 }

--- a/core/kapp/kdaFeesPool/actions_test.go
+++ b/core/kapp/kdaFeesPool/actions_test.go
@@ -1140,3 +1140,194 @@ func TestComputeUncached_ConcurrentWithProcessingWrites(t *testing.T) {
 	}
 	<-done
 }
+
+func TestUpdatePoolNonPositiveRatio(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NegativeRatioRejectedWithFork", func(t *testing.T) {
+		args := createMockArgsKDAFeesPool()
+		kapp, err := kdafeespool.NewKDAFeesPoolKApp(args)
+		require.NoError(t, err)
+
+		poolData := make(map[string][]byte)
+		kappAcc := &mock.KAppAccountHandlerStub{
+			GetStorageCalled: func(key []byte) []byte {
+				return poolData[string(key)]
+			},
+		}
+
+		cacher := &mock.AccountsCacherStub{
+			LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
+				return kappAcc, nil
+			},
+		}
+		_ = kapp.SetAccountsCacher(cacher)
+
+		receipts := &mock.ReceiptsContextStub{}
+		kappContext := &mock.KAppContextStub{
+			ReceiptsValue: receipts,
+		}
+		controller := &mock.KappsControllerMock{}
+		controller.SetCurrentKAppContext(kappContext)
+		_ = kapp.SetKAppController(controller)
+
+		poolID := []byte("pool-id")
+		assetOwner := make([]byte, 32)
+		copy(assetOwner, []byte("owner-address"))
+		sender := assetOwner
+		info := &transaction.KDAPoolInfo{
+			Active:       true,
+			AdminAddress: assetOwner,
+			FRatioKLV:    -1000000000,
+			FRatioKDA:    -1,
+		}
+
+		code, err := kapp.UpdatePool(poolID, assetOwner, sender, info)
+		require.Equal(t, transaction.Transaction_ParameterInvalid, code)
+		require.Equal(t, common.ErrAssetPoolInvalidAmount, err)
+	})
+
+	t.Run("NegativeRatioAcceptedWithoutFork", func(t *testing.T) {
+		args := createMockArgsKDAFeesPool()
+		marshalizer := &marshal.JSONMarshalizer{}
+		args.Marshalizer = marshalizer
+		args.ForkController = mock.NewForkControllerStub().SetFork("FixAuditChangesV3", false)
+		kapp, err := kdafeespool.NewKDAFeesPoolKApp(args)
+		require.NoError(t, err)
+
+		poolData := make(map[string][]byte)
+		var savedPool *kdafeespool.KDAFeesPoolData
+		kappAcc := &mock.KAppAccountHandlerStub{
+			GetStorageCalled: func(key []byte) []byte {
+				return poolData[string(key)]
+			},
+			SetStorageCalled: func(key []byte, value []byte) error {
+				if string(key) == "pool-id" {
+					savedPool = &kdafeespool.KDAFeesPoolData{}
+					_ = marshalizer.Unmarshal(savedPool, value)
+				}
+				return nil
+			},
+		}
+
+		cacher := &mock.AccountsCacherStub{
+			LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
+				return kappAcc, nil
+			},
+			UpdateKappCalled: func(account state.AccountHandler) error {
+				return nil
+			},
+		}
+		_ = kapp.SetAccountsCacher(cacher)
+
+		receipts := &mock.ReceiptsContextStub{}
+		kappContext := &mock.KAppContextStub{
+			ReceiptsValue: receipts,
+		}
+		controller := &mock.KappsControllerMock{}
+		controller.SetCurrentKAppContext(kappContext)
+		_ = kapp.SetKAppController(controller)
+
+		poolID := []byte("pool-id")
+		assetOwner := make([]byte, 32)
+		copy(assetOwner, []byte("owner-address"))
+		sender := assetOwner
+		info := &transaction.KDAPoolInfo{
+			Active:       true,
+			AdminAddress: assetOwner,
+			FRatioKLV:    -1000000000,
+			FRatioKDA:    -1,
+		}
+
+		code, err := kapp.UpdatePool(poolID, assetOwner, sender, info)
+		require.NoError(t, err)
+		require.Equal(t, transaction.Transaction_Ok, code)
+		require.NotNil(t, savedPool)
+		require.Equal(t, int64(-1000000000), savedPool.FRatioKLV)
+		require.Equal(t, int64(-1), savedPool.FRatioKDA)
+	})
+}
+
+func TestComputeOutOfRangePrice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OutOfRangeRejectedWithFork", func(t *testing.T) {
+		args := createMockArgsKDAFeesPool()
+		marshalizer := &marshal.JSONMarshalizer{}
+		args.Marshalizer = marshalizer
+		kapp, err := kdafeespool.NewKDAFeesPoolKApp(args)
+		require.NoError(t, err)
+
+		// klvFee * FRatioKDA / FRatioKLV = 1e18 * 1e6 / 1 = 1e24, beyond int64 range
+		poolData := &kdafeespool.KDAFeesPoolData{
+			OwnerAddress: []byte("owner"),
+			KDA:          []byte("asset-id"),
+			Active:       true,
+			KLVBalance:   10000,
+			FRatioKLV:    1,
+			FRatioKDA:    1000000,
+		}
+		poolBytes, _ := marshalizer.Marshal(poolData)
+
+		kappAcc := &mock.KAppAccountHandlerStub{
+			GetStorageCalled: func(key []byte) []byte {
+				return poolBytes
+			},
+		}
+
+		cacher := &mock.AccountsCacherStub{
+			LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
+				return kappAcc, nil
+			},
+		}
+		_ = kapp.SetAccountsCacher(cacher)
+
+		feeHandler := &KDAFeeHandlerStub{
+			kda:    []byte("asset-id"),
+			amount: 100,
+		}
+
+		_, err = kapp.Compute(1000000000000000000, feeHandler)
+		require.Equal(t, common.ErrAssetPoolInvalidAmount, err)
+	})
+
+	t.Run("OutOfRangeWrapsWithoutFork", func(t *testing.T) {
+		args := createMockArgsKDAFeesPool()
+		marshalizer := &marshal.JSONMarshalizer{}
+		args.Marshalizer = marshalizer
+		args.ForkController = mock.NewForkControllerStub().SetFork("FixAuditChangesV3", false)
+		kapp, err := kdafeespool.NewKDAFeesPoolKApp(args)
+		require.NoError(t, err)
+
+		poolData := &kdafeespool.KDAFeesPoolData{
+			OwnerAddress: []byte("owner"),
+			KDA:          []byte("asset-id"),
+			Active:       true,
+			KLVBalance:   10000,
+			FRatioKLV:    1,
+			FRatioKDA:    1000000,
+		}
+		poolBytes, _ := marshalizer.Marshal(poolData)
+
+		kappAcc := &mock.KAppAccountHandlerStub{
+			GetStorageCalled: func(key []byte) []byte {
+				return poolBytes
+			},
+		}
+
+		cacher := &mock.AccountsCacherStub{
+			LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
+				return kappAcc, nil
+			},
+		}
+		_ = kapp.SetAccountsCacher(cacher)
+
+		feeHandler := &KDAFeeHandlerStub{
+			kda:    []byte("asset-id"),
+			amount: 100,
+		}
+
+		_, err = kapp.Compute(1000000000000000000, feeHandler)
+		require.NoError(t, err)
+	})
+}

--- a/core/kapp/kdaFeesPool/actions_test.go
+++ b/core/kapp/kdaFeesPool/actions_test.go
@@ -1331,3 +1331,69 @@ func TestComputeOutOfRangePrice(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestComputeNeutralizesStoredNonPositiveRatio(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, fixActive bool, fRatioKLV, fRatioKDA int64) (int64, error) {
+		t.Helper()
+
+		args := createMockArgsKDAFeesPool()
+		marshalizer := &marshal.JSONMarshalizer{}
+		args.Marshalizer = marshalizer
+		args.ForkController = mock.NewForkControllerStub().SetFork("FixAuditChangesV3", fixActive)
+		kapp, err := kdafeespool.NewKDAFeesPoolKApp(args)
+		require.NoError(t, err)
+
+		poolData := &kdafeespool.KDAFeesPoolData{
+			OwnerAddress: []byte("owner"),
+			KDA:          []byte("asset-id"),
+			Active:       true,
+			KLVBalance:   1000000000,
+			FRatioKLV:    fRatioKLV,
+			FRatioKDA:    fRatioKDA,
+		}
+		poolBytes, _ := marshalizer.Marshal(poolData)
+
+		kappAcc := &mock.KAppAccountHandlerStub{
+			GetStorageCalled: func(key []byte) []byte {
+				return poolBytes
+			},
+		}
+		cacher := &mock.AccountsCacherStub{
+			LoadKAppCalled: func(address []byte) (state.KAppAccountHandler, error) {
+				return kappAcc, nil
+			},
+		}
+		_ = kapp.SetAccountsCacher(cacher)
+
+		feeHandler := &KDAFeeHandlerStub{
+			kda:    []byte("asset-id"),
+			amount: 100,
+		}
+
+		return kapp.Compute(1000, feeHandler)
+	}
+
+	t.Run("BothNegativeRejectedWithFork", func(t *testing.T) {
+		_, err := run(t, true, -1, -1)
+		require.Equal(t, common.ErrAssetPoolInvalidAmount, err)
+	})
+
+	t.Run("OneNegativeRejectedWithFork", func(t *testing.T) {
+		_, err := run(t, true, 1, -1)
+		require.Equal(t, common.ErrAssetPoolInvalidAmount, err)
+	})
+
+	t.Run("NegativeNotNeutralizedWithoutFork", func(t *testing.T) {
+		value, err := run(t, false, -1, -1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1000), value)
+	})
+
+	t.Run("PositiveRatioUnaffectedWithFork", func(t *testing.T) {
+		value, err := run(t, true, 1000, 100)
+		require.NoError(t, err)
+		require.Equal(t, int64(100), value)
+	})
+}

--- a/data/transaction/validate.go
+++ b/data/transaction/validate.go
@@ -239,7 +239,7 @@ type allowedAssetTriggerFields struct {
 	KDAPool   bool
 }
 
-func validateAssetTriggerFields(tc *AssetTriggerContract, allow allowedAssetTriggerFields, fc core.ForkController) bool {
+func validateDisallowedScalarFields(tc *AssetTriggerContract, allow allowedAssetTriggerFields) bool {
 	if !allow.ToAddress && len(tc.GetToAddress()) > 0 {
 		return false
 	}
@@ -260,17 +260,33 @@ func validateAssetTriggerFields(tc *AssetTriggerContract, allow allowedAssetTrig
 		return false
 	}
 
+	return true
+}
+
+func validateDisallowedRoleAndStaking(tc *AssetTriggerContract, allow allowedAssetTriggerFields) bool {
+	if !allow.Role && tc.GetRole() != nil && !proto.Equal(tc.GetRole(), &RolesInfo{}) {
+		return false
+	}
+
+	if !allow.Staking && tc.GetStaking() != nil && !proto.Equal(tc.GetStaking(), &StakingInfo{}) {
+		return false
+	}
+
+	return true
+}
+
+func validateAssetTriggerFields(tc *AssetTriggerContract, allow allowedAssetTriggerFields, fc core.ForkController) bool {
+	if !validateDisallowedScalarFields(tc, allow) {
+		return false
+	}
+
 	if allow.Royalties {
 		return validateRoyalties(tc.GetRoyalties())
 	} else if tc.GetRoyalties() != nil && !proto.Equal(tc.GetRoyalties(), &RoyaltiesInfo{}) {
 		return false
 	}
 
-	if !allow.Role && tc.GetRole() != nil && !proto.Equal(tc.GetRole(), &RolesInfo{}) {
-		return false
-	}
-
-	if !allow.Staking && tc.GetStaking() != nil && !proto.Equal(tc.GetStaking(), &StakingInfo{}) {
+	if !validateDisallowedRoleAndStaking(tc, allow) {
 		return false
 	}
 

--- a/data/transaction/validate.go
+++ b/data/transaction/validate.go
@@ -239,7 +239,7 @@ type allowedAssetTriggerFields struct {
 	KDAPool   bool
 }
 
-func validateAssetTriggerFields(tc *AssetTriggerContract, allow allowedAssetTriggerFields) bool {
+func validateAssetTriggerFields(tc *AssetTriggerContract, allow allowedAssetTriggerFields, fc core.ForkController) bool {
 	if !allow.ToAddress && len(tc.GetToAddress()) > 0 {
 		return false
 	}
@@ -275,7 +275,7 @@ func validateAssetTriggerFields(tc *AssetTriggerContract, allow allowedAssetTrig
 	}
 
 	if allow.KDAPool {
-		return validateKDAPool(tc.GetKDAPool())
+		return validateKDAPool(tc.GetKDAPool(), fc)
 	} else if tc.GetKDAPool() != nil && !proto.Equal(tc.GetKDAPool(), &KDAPoolInfo{}) {
 		return false
 	}
@@ -283,9 +283,13 @@ func validateAssetTriggerFields(tc *AssetTriggerContract, allow allowedAssetTrig
 	return true
 }
 
-func validateKDAPool(poolInfo *KDAPoolInfo) bool {
+func validateKDAPool(poolInfo *KDAPoolInfo, fc core.ForkController) bool {
 	if poolInfo == nil {
 		return false
+	}
+
+	if fc.FixAuditChangesV3() {
+		return poolInfo.FRatioKLV > 0 && poolInfo.FRatioKDA > 0
 	}
 
 	if poolInfo.FRatioKLV == 0 || poolInfo.FRatioKDA == 0 {
@@ -364,7 +368,7 @@ func (tc *AssetTriggerContract) Validate(fc core.ForkController) error {
 		return ErrInvalidTriggerType
 	}
 
-	if !validateAssetTriggerFields(tc, allowed) {
+	if !validateAssetTriggerFields(tc, allowed, fc) {
 		return fmt.Errorf("invalid contract fields, allowed fields: assetID:true + %+v", allowed)
 	}
 

--- a/data/transaction/validate_test.go
+++ b/data/transaction/validate_test.go
@@ -1191,6 +1191,92 @@ func TestAssetTriggerContractValidate(t *testing.T) {
 	}
 }
 
+func TestAssetTriggerContractValidate_KDAFeePoolRatio(t *testing.T) {
+	tests := []struct {
+		name        string
+		contract    *transaction.AssetTriggerContract
+		fc          core.ForkController
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "fork on positive ratios valid",
+			contract: &transaction.AssetTriggerContract{
+				TriggerType: transaction.AssetTriggerContract_UpdateKDAFeePool,
+				KDAPool: &transaction.KDAPoolInfo{
+					FRatioKLV: 1,
+					FRatioKDA: 1,
+				},
+			},
+			fc:          mock.NewForkControllerStub().SetFork("FixAuditChangesV3", true),
+			expectError: false,
+		},
+		{
+			name: "fork on negative ratio invalid",
+			contract: &transaction.AssetTriggerContract{
+				TriggerType: transaction.AssetTriggerContract_UpdateKDAFeePool,
+				KDAPool: &transaction.KDAPoolInfo{
+					FRatioKLV: -1,
+					FRatioKDA: 1,
+				},
+			},
+			fc:          mock.NewForkControllerStub().SetFork("FixAuditChangesV3", true),
+			expectError: true,
+			errorMsg:    "invalid contract fields",
+		},
+		{
+			name: "fork on zero ratio invalid",
+			contract: &transaction.AssetTriggerContract{
+				TriggerType: transaction.AssetTriggerContract_UpdateKDAFeePool,
+				KDAPool: &transaction.KDAPoolInfo{
+					FRatioKLV: 0,
+					FRatioKDA: 1,
+				},
+			},
+			fc:          mock.NewForkControllerStub().SetFork("FixAuditChangesV3", true),
+			expectError: true,
+			errorMsg:    "invalid contract fields",
+		},
+		{
+			name: "fork off zero ratio invalid",
+			contract: &transaction.AssetTriggerContract{
+				TriggerType: transaction.AssetTriggerContract_UpdateKDAFeePool,
+				KDAPool: &transaction.KDAPoolInfo{
+					FRatioKLV: 0,
+					FRatioKDA: 1,
+				},
+			},
+			fc:          mock.NewForkControllerStub().SetFork("FixAuditChangesV3", false),
+			expectError: true,
+			errorMsg:    "invalid contract fields",
+		},
+		{
+			name: "fork off negative ratio valid",
+			contract: &transaction.AssetTriggerContract{
+				TriggerType: transaction.AssetTriggerContract_UpdateKDAFeePool,
+				KDAPool: &transaction.KDAPoolInfo{
+					FRatioKLV: -1,
+					FRatioKDA: 1,
+				},
+			},
+			fc:          mock.NewForkControllerStub().SetFork("FixAuditChangesV3", false),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.contract.Validate(tt.fc)
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestUnfreezeContractValidate(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/integrationTest/mock/forkControllerStub.go
+++ b/integrationTest/mock/forkControllerStub.go
@@ -13,6 +13,7 @@ type ForkControllerStub struct {
 	EpochRewardsV2Called          func() bool
 	FixAuditChangesV2Called       func() bool
 	FixMarketBuyOverflowCalled    func() bool
+	FixAuditChangesV3Called       func() bool
 }
 
 // ProcessorFlowITOPrice -
@@ -110,6 +111,14 @@ func (fc *ForkControllerStub) FixAuditChangesV2() bool {
 func (fc *ForkControllerStub) FixMarketBuyOverflow() bool {
 	if fc.FixMarketBuyOverflowCalled != nil {
 		return fc.FixMarketBuyOverflowCalled()
+	}
+
+	return false
+}
+
+func (fc *ForkControllerStub) FixAuditChangesV3() bool {
+	if fc.FixAuditChangesV3Called != nil {
+		return fc.FixAuditChangesV3Called()
 	}
 
 	return false


### PR DESCRIPTION
`UpdatePool` only rejected a zero fee ratio, so negative and out-of-range `FRatioKLV`/`FRatioKDA` values were accepted and persisted, and the swap-price helper returned a bare `big.Int.Int64()` with no range check. This PR tightens both into proper input validation. It is defensive hardening: valid pools are unaffected, and the stored ratio feeds a validation gate rather than sizing any balance movement.

## What changed
- `UpdatePool` now rejects `FRatioKLV <= 0 || FRatioKDA <= 0` (previously only `== 0`).
- The swap-price `compute` now rejects an out-of-range result with an `IsInt64()` check instead of silently truncating via `Int64()`.
- Both checks are gated behind a new `FixAuditChangesV3` activation flag, so pre-fork behavior is unchanged.

## Why
The old `== 0` guard let nonsensical configurations (negative or absurd-magnitude ratios) persist, and the unchecked `Int64()` could wrap an out-of-range price. Routing the new behavior through an activation flag keeps it consensus-safe — nodes apply the stricter validation only from the configured epoch onward.

## Tests
- Added `TestUpdatePoolNonPositiveRatio` and `TestComputeOutOfRangePrice`, each covering the fork-on (rejected) and fork-off (legacy behavior preserved) cases.
- The full `kdaFeesPool` package, `go vet`, and `go build ./...` pass locally.

## Compatibility / risk
Consensus-affecting, so it is gated behind `FixAuditChangesV3`; before that epoch behavior is identical to today. No schema or API changes, and valid fee pools are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Defensive hardening for `KDAFeesPool` fee ratios + overflow-safe price computation (fork-gated)

This PR tightens a blockchain-critical KApp (`core/kapp/kdaFeesPool`) to prevent invalid fee-pool ratio parameters from being persisted and to avoid silent `big.Int` → `int64` truncation during swap/fee price computation. All behavior changes are guarded behind a new epoch-controlled fork flag (`FixAuditChangesV3`) to avoid pre-fork consensus divergence.

### Consensus-critical behavior (when `FixAuditChangesV3` is enabled)
**1) Stricter `UpdatePool` ratio validation (state integrity)**
- **Previously:** `UpdatePool` rejected only zero fee ratios (`FRatioKLV == 0 || FRatioKDA == 0`), allowing **negative** ratios to be stored.
- **Now (fork-gated):** rejects **non-positive** ratios (`FRatioKLV <= 0 || FRatioKDA <= 0`).
- **Failure path:** transaction processing returns `Transaction_ParameterInvalid` with `common.ErrAssetPoolInvalidAmount`.
- **Impact:** prevents malformed on-chain fee parameters from entering state and later affecting pricing/fee accounting.

**2) Range-checked `compute` conversion (transaction processing correctness)**
- **Previously:** unchecked `fv.Int64()` conversion could truncate out-of-range values.
- **Now (fork-gated):** validates the computed value with `fv.IsInt64()` before converting; otherwise returns `common.ErrAssetPoolInvalidAmount`.
- **Impact:** prevents overflow/truncation from producing incorrect fee/price values during execution.

### Fork gating & cross-cutting safety
- Adds epoch-controlled feature flag **`FixAuditChangesV3`**:
  - Implemented in `core/fork` as a new atomic flag (`flagFixAuditChangesV3`) with accessor `ForkController.FixAuditChangesV3()`.
  - Toggled by `EpochConfirmed()` when `epoch >= enableEpochs.FixAuditChangesV3`.
- Extends `core/interface.go` `ForkController` contract and updates mock/stub implementations used by tests/integration.

### Configuration / node enablement
- Introduces `fixAuditChangesV3` in `config/enableEpochs.go` and adds `fixAuditChangesV3: 0` to `config/node/enableEpochs.yaml`.

### Tests
- Adds `TestUpdatePoolNonPositiveRatio`: verifies fork-on rejection of negative ratios and fork-off legacy acceptance/persistence.
- Adds `TestComputeOutOfRangePrice`: verifies fork-on overflow/out-of-range rejection and fork-off legacy success.
- Adds `core/fork/forks_test.go` coverage ensuring `FixAuditChangesV3` toggles at the configured activation epoch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->