### PR TITLE
[KLC-2440] Bound /subscribe WebSocket reads, connections, and subscriptions (GHSA-4fwh-wrm6-97xm)

### DIFF
--- a/common/facade/nodeFacade.go
+++ b/common/facade/nodeFacade.go
@@ -361,6 +361,30 @@ func (nf *nodeFacade) WSConnectionAPIKey() string {
 	return nf.config.WSConnectionAPIKey
 }
 
+// WSMaxConnections returns the node-wide cap on simultaneous live /subscribe
+// WebSocket connections (0 = unlimited).
+func (nf *nodeFacade) WSMaxConnections() uint32 {
+	return nf.wsAntifloodConfig.WebSocketConnections
+}
+
+// WSMaxConnectionsPerIP returns the per-source-IP cap on simultaneous live
+// /subscribe WebSocket connections (0 = unlimited).
+func (nf *nodeFacade) WSMaxConnectionsPerIP() uint32 {
+	return nf.wsAntifloodConfig.WebSocketConnectionsPerIP
+}
+
+// WSMaxAddressesPerSubscribe returns the per-call address cap for a /subscribe
+// request (0 = built-in default).
+func (nf *nodeFacade) WSMaxAddressesPerSubscribe() uint32 {
+	return nf.wsAntifloodConfig.WebSocketMaxAddressesPerSubscribe
+}
+
+// WSMaxAddressesPerClient returns the per-connection total address cap for
+// /subscribe (0 = built-in default).
+func (nf *nodeFacade) WSMaxAddressesPerClient() uint32 {
+	return nf.wsAntifloodConfig.WebSocketMaxAddressesPerClient
+}
+
 /***********
  *  Block
  ***********/

--- a/common/facade/nodeFacade_test.go
+++ b/common/facade/nodeFacade_test.go
@@ -41,6 +41,24 @@ func createMockArgNodeFacade() facade.ArgNodeFacade {
 	}
 }
 
+func TestNodeFacade_WSLimitGetters(t *testing.T) {
+	t.Parallel()
+
+	args := createMockArgNodeFacade()
+	args.WsAntifloodConfig.WebSocketConnections = 1234
+	args.WsAntifloodConfig.WebSocketConnectionsPerIP = 56
+	args.WsAntifloodConfig.WebSocketMaxAddressesPerSubscribe = 78
+	args.WsAntifloodConfig.WebSocketMaxAddressesPerClient = 9012
+
+	nf, err := facade.NewNodeFacade(args)
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(1234), nf.WSMaxConnections())
+	require.Equal(t, uint32(56), nf.WSMaxConnectionsPerIP())
+	require.Equal(t, uint32(78), nf.WSMaxAddressesPerSubscribe())
+	require.Equal(t, uint32(9012), nf.WSMaxAddressesPerClient())
+}
+
 func TestNewNodeFacade(t *testing.T) {
 	t.Parallel()
 

--- a/config/antiflood.go
+++ b/config/antiflood.go
@@ -42,6 +42,20 @@ type WebServerAntifloodConfig struct {
 	SameSourceRequests           uint32                      `yaml:"sameSourceRequests"`
 	SameSourceResetIntervalInSec uint32                      `yaml:"sameSourceResetIntervalInSec"`
 	EndpointsThrottlers          []EndpointsThrottlersConfig `yaml:"endpointsThrottlers"`
+	// WebSocketConnections caps simultaneous live /subscribe WebSocket connections
+	// node-wide; the gin throttlers above do not bound live WS connections. 0 = unlimited.
+	WebSocketConnections uint32 `yaml:"webSocketConnections"`
+	// WebSocketConnectionsPerIP caps simultaneous live /subscribe connections from a
+	// single source IP. Behind a reverse proxy all clients share the proxy IP, so size
+	// this accordingly or set 0 to disable the per-IP cap. 0 = unlimited.
+	WebSocketConnectionsPerIP uint32 `yaml:"webSocketConnectionsPerIP"`
+	// WebSocketMaxAddressesPerSubscribe caps addresses accepted in one /subscribe call.
+	// The inbound frame read limit is derived from this so a maximal subscribe always
+	// fits. 0 = built-in default.
+	WebSocketMaxAddressesPerSubscribe uint32 `yaml:"webSocketMaxAddressesPerSubscribe"`
+	// WebSocketMaxAddressesPerClient caps the total addresses one connection may watch
+	// across all of its subscribe calls. 0 = built-in default.
+	WebSocketMaxAddressesPerClient uint32 `yaml:"webSocketMaxAddressesPerClient"`
 }
 
 // TopicMaxMessagesConfig will hold the maximum number of messages/sec per topic value

--- a/config/node/api.yaml
+++ b/config/node/api.yaml
@@ -15,6 +15,10 @@ apiPackages:
         open: true
   subscribe:
     routes:
+      # /subscribe is a public WebSocket event feed. `open: true` keeps it enabled for
+      # development; set `secured: true` (in addition) to require Basic Auth on the
+      # handshake for public/mainnet deployments. Connection and message limits are
+      # enforced in code and tuned via webServer.* in config.yaml.
       - name: /subscribe
         open: true
   asset:

--- a/config/node/config.yaml
+++ b/config/node/config.yaml
@@ -185,6 +185,20 @@ antiflood:
     sameSourceRequests: 10000
     # SameSourceResetIntervalInSec time frame between counter reset, in seconds
     sameSourceResetIntervalInSec: 1
+    # WebSocketConnections caps simultaneous live /subscribe WebSocket connections node-wide.
+    # The throttlers above release their slot at the HTTP->WS upgrade and so do not bound live
+    # WS connections. 0 = unlimited.
+    webSocketConnections: 4096
+    # WebSocketConnectionsPerIP caps simultaneous live /subscribe connections from a single
+    # source IP. Behind a reverse proxy every client shares the proxy IP, so raise this (or set
+    # 0 to disable) for proxied/public deployments. 0 = unlimited.
+    webSocketConnectionsPerIP: 1024
+    # WebSocketMaxAddressesPerSubscribe caps addresses accepted in one /subscribe call. The
+    # inbound frame read limit is derived from this so a maximal subscribe always fits. 0 = default.
+    webSocketMaxAddressesPerSubscribe: 10000
+    # WebSocketMaxAddressesPerClient caps the total addresses one connection may watch across all
+    # of its subscribe calls. 0 = default.
+    webSocketMaxAddressesPerClient: 50000
     # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
     endpointsThrottlers:
       - endpoint: /transaction/:hash

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -138,10 +138,29 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 		registerLoggerWsRoute(ws, marshalizerForLogs, routesConfig)
 	}
 
+	// secured only attaches the auth handler; the route is registered on open. Warn on
+	// the secured-but-not-open footgun so it does not read as "auth-protected" when it
+	// is actually absent.
+	if routesConfig.IsRouteSecured("subscribe", "/subscribe") && !routesConfig.IsRouteEnabled("subscribe", "/subscribe") {
+		log.Warn("subscribe route has secured:true but open:false; /subscribe will not be registered. Set open:true to enable it (secured then requires Basic Auth).")
+	}
+
 	if routesConfig.IsRouteEnabled("subscribe", "/subscribe") {
 		var postConnUrl, postConnApiKey string
+		var subscribeOpts wsocket.SubscribeOptions
+		var hubLimits clientSocket.Limits
 		if ok {
 			postConnUrl, postConnApiKey = apiHandler.WSConnectionURL(), apiHandler.WSConnectionAPIKey()
+			subscribeOpts.MaxConnections = apiHandler.WSMaxConnections()
+			subscribeOpts.MaxConnectionsPerIP = apiHandler.WSMaxConnectionsPerIP()
+			hubLimits.MaxAddressesPerSubscribe = int(apiHandler.WSMaxAddressesPerSubscribe())
+			hubLimits.MaxAddressesPerClient = int(apiHandler.WSMaxAddressesPerClient())
+		}
+		// Honour `secured: true` for /subscribe. The route is registered directly on the
+		// engine (not via the RouterWrapper), so the auth handler must be applied here or
+		// the flag is silently ignored (GHSA-4fwh-wrm6-97xm).
+		if routesConfig.IsRouteSecured("subscribe", "/subscribe") {
+			subscribeOpts.AuthHandlers = []gin.HandlerFunc{authHandler}
 		}
 
 		var wsFacade clientSocket.WSFacade
@@ -150,8 +169,8 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 		}
 
 		indexer.UseEventQueue = true
-		hub := clientSocket.NewHub(postConnUrl, postConnApiKey, wsFacade)
-		wsocket.SubscribeTopics(ws, hub)
+		hub := clientSocket.NewHub(postConnUrl, postConnApiKey, wsFacade, hubLimits)
+		wsocket.SubscribeTopics(ws, hub, subscribeOpts)
 		go hub.StartServer(ctx)
 	}
 }

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -46,6 +46,9 @@ var log = logger.GetOrCreate("api")
 const (
 	logPackage = "log"
 	logRoute   = "/log"
+
+	subscribePackage = "subscribe"
+	subscribeRoute   = "/subscribe"
 )
 
 type validatorInput struct {
@@ -141,11 +144,11 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 	// secured only attaches the auth handler; the route is registered on open. Warn on
 	// the secured-but-not-open footgun so it does not read as "auth-protected" when it
 	// is actually absent.
-	if routesConfig.IsRouteSecured("subscribe", "/subscribe") && !routesConfig.IsRouteEnabled("subscribe", "/subscribe") {
+	if routesConfig.IsRouteSecured(subscribePackage, subscribeRoute) && !routesConfig.IsRouteEnabled(subscribePackage, subscribeRoute) {
 		log.Warn("subscribe route has secured:true but open:false; /subscribe will not be registered. Set open:true to enable it (secured then requires Basic Auth).")
 	}
 
-	if routesConfig.IsRouteEnabled("subscribe", "/subscribe") {
+	if routesConfig.IsRouteEnabled(subscribePackage, subscribeRoute) {
 		var postConnUrl, postConnApiKey string
 		var subscribeOpts wsocket.SubscribeOptions
 		var hubLimits clientSocket.Limits
@@ -159,7 +162,7 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 		// Honour `secured: true` for /subscribe. The route is registered directly on the
 		// engine (not via the RouterWrapper), so the auth handler must be applied here or
 		// the flag is silently ignored (GHSA-4fwh-wrm6-97xm).
-		if routesConfig.IsRouteSecured("subscribe", "/subscribe") {
+		if routesConfig.IsRouteSecured(subscribePackage, subscribeRoute) {
 			subscribeOpts.AuthHandlers = []gin.HandlerFunc{authHandler}
 		}
 

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -153,8 +153,8 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 			postConnUrl, postConnApiKey = apiHandler.WSConnectionURL(), apiHandler.WSConnectionAPIKey()
 			subscribeOpts.MaxConnections = apiHandler.WSMaxConnections()
 			subscribeOpts.MaxConnectionsPerIP = apiHandler.WSMaxConnectionsPerIP()
-			hubLimits.MaxAddressesPerSubscribe = int(apiHandler.WSMaxAddressesPerSubscribe())
-			hubLimits.MaxAddressesPerClient = int(apiHandler.WSMaxAddressesPerClient())
+			hubLimits.MaxAddressesPerSubscribe = wsocket.ClampUint32ToInt(apiHandler.WSMaxAddressesPerSubscribe())
+			hubLimits.MaxAddressesPerClient = wsocket.ClampUint32ToInt(apiHandler.WSMaxAddressesPerClient())
 		}
 		// Honour `secured: true` for /subscribe. The route is registered directly on the
 		// engine (not via the RouterWrapper), so the auth handler must be applied here or

--- a/network/api/api_test.go
+++ b/network/api/api_test.go
@@ -28,9 +28,10 @@ func subscribeRoutesConfig(open, secured bool) config.APIRoutesConfig {
 
 // subscribeStatus registers the routes for cfg and returns the HTTP status of a plain
 // (non-WebSocket) GET /subscribe, which is enough to distinguish the three behaviors:
-//   404 — route not registered (open:false)
-//   401 — auth enforced before the upgrade (secured:true) — the bug this PR fixes
-//   400 — handler reached, no auth gate, fails the WS handshake (open, not secured)
+//
+//	404 — route not registered (open:false)
+//	401 — auth enforced before the upgrade (secured:true) — the bug this PR fixes
+//	400 — handler reached, no auth gate, fails the WS handshake (open, not secured)
 func subscribeStatus(t *testing.T, cfg config.APIRoutesConfig) int {
 	t.Helper()
 	ws := gin.New()

--- a/network/api/api_test.go
+++ b/network/api/api_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/klever-io/klever-go/config"
+	"github.com/klever-io/klever-go/network/api/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func subscribeRoutesConfig(open, secured bool) config.APIRoutesConfig {
+	return config.APIRoutesConfig{
+		APIPackages: map[string]config.APIPackageConfig{
+			"subscribe": {Routes: []config.RouteConfig{{Name: "/subscribe", Open: open, Secured: secured}}},
+		},
+		Credentials: []config.Credential{{Username: "u", Password: "p"}},
+		Hasher:      config.TypeConfig{Type: "sha256"},
+	}
+}
+
+// subscribeStatus registers the routes for cfg and returns the HTTP status of a plain
+// (non-WebSocket) GET /subscribe, which is enough to distinguish the three behaviors:
+//   404 — route not registered (open:false)
+//   401 — auth enforced before the upgrade (secured:true) — the bug this PR fixes
+//   400 — handler reached, no auth gate, fails the WS handshake (open, not secured)
+func subscribeStatus(t *testing.T, cfg config.APIRoutesConfig) int {
+	t.Helper()
+	ws := gin.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	RegisterRoutes(ctx, ws, cfg, &mock.Facade{})
+
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/subscribe", nil))
+	return resp.Code
+}
+
+// secured:true must enforce auth before the upgrade — an unauthenticated handshake is
+// rejected with 401. Previously secured was silently ignored (the route bypassed the
+// auth wrapper), so this guards the actual fix end-to-end through RegisterRoutes.
+func TestRegisterRoutes_SecuredRejectsUnauthenticated(t *testing.T) {
+	assert.Equal(t, http.StatusUnauthorized, subscribeStatus(t, subscribeRoutesConfig(true, true)))
+}
+
+// open:true, secured:false — no auth gate; the plain GET reaches the handler and fails
+// the WS upgrade (400). Proves the route is live and NOT auth-gated (would be 401) and
+// is registered (would be 404).
+func TestRegisterRoutes_OpenNotSecuredReachesHandler(t *testing.T) {
+	assert.Equal(t, http.StatusBadRequest, subscribeStatus(t, subscribeRoutesConfig(true, false)))
+}
+
+// open:false — the route is not registered at all (404), even with secured:true.
+func TestRegisterRoutes_NotOpenNotRegistered(t *testing.T) {
+	assert.Equal(t, http.StatusNotFound, subscribeStatus(t, subscribeRoutesConfig(false, true)))
+}

--- a/network/api/interface.go
+++ b/network/api/interface.go
@@ -15,5 +15,9 @@ type MainAPIHandler interface {
 	PprofEnabled() bool
 	WSConnectionURL() string
 	WSConnectionAPIKey() string
+	WSMaxConnections() uint32
+	WSMaxConnectionsPerIP() uint32
+	WSMaxAddressesPerSubscribe() uint32
+	WSMaxAddressesPerClient() uint32
 	IsInterfaceNil() bool
 }

--- a/network/api/mock/facade.go
+++ b/network/api/mock/facade.go
@@ -93,6 +93,26 @@ func (f *Facade) WSConnectionAPIKey() string {
 	return ""
 }
 
+// WSMaxConnections -
+func (f *Facade) WSMaxConnections() uint32 {
+	return 0
+}
+
+// WSMaxConnectionsPerIP -
+func (f *Facade) WSMaxConnectionsPerIP() uint32 {
+	return 0
+}
+
+// WSMaxAddressesPerSubscribe -
+func (f *Facade) WSMaxAddressesPerSubscribe() uint32 {
+	return 0
+}
+
+// WSMaxAddressesPerClient -
+func (f *Facade) WSMaxAddressesPerClient() uint32 {
+	return 0
+}
+
 // TpsBenchmark is the mock implementation for retreiving the TpsBenchmark
 func (f *Facade) TpsBenchmark() *statistics.TpsBenchmark {
 	if f.TpsBenchmarkHandler != nil {

--- a/network/api/websocket/connlimiter.go
+++ b/network/api/websocket/connlimiter.go
@@ -1,0 +1,75 @@
+package websocket
+
+import (
+	"math"
+	"sync"
+)
+
+// connLimiter caps the number of simultaneous live /subscribe WebSocket connections,
+// both node-wide and per source IP. The gin global throttler cannot do this: it
+// releases its slot at the HTTP->WS upgrade, so live connections are uncounted
+// (GHSA-4fwh-wrm6-97xm, GAP#3). A slot is acquired before the upgrade and released
+// exactly once when the connection is torn down.
+//
+// A zero maximum means "unlimited" for that dimension. Per-IP must be tunable to 0
+// because behind a reverse proxy every client shares the proxy's source IP.
+type connLimiter struct {
+	mu        sync.Mutex
+	global    int
+	maxGlobal int
+	perIP     map[string]int
+	maxPerIP  int
+}
+
+func newConnLimiter(maxGlobal, maxPerIP uint32) *connLimiter {
+	return &connLimiter{
+		maxGlobal: clampUint32ToInt(maxGlobal),
+		maxPerIP:  clampUint32ToInt(maxPerIP),
+		perIP:     make(map[string]int),
+	}
+}
+
+// clampUint32ToInt converts a uint32 cap to int without the negative wrap a direct
+// conversion would cause on 32-bit platforms — a negative max would silently DISABLE
+// the cap (treated as unlimited) instead of enforcing it.
+func clampUint32ToInt(v uint32) int {
+	if uint64(v) > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(v)
+}
+
+// acquire reserves a connection slot for ip. It returns an idempotent release func
+// and true on success, or nil and false when a cap is reached.
+func (l *connLimiter) acquire(ip string) (func(), bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.maxGlobal > 0 && l.global >= l.maxGlobal {
+		return nil, false
+	}
+	if l.maxPerIP > 0 && l.perIP[ip] >= l.maxPerIP {
+		return nil, false
+	}
+
+	l.global++
+	if l.maxPerIP > 0 {
+		l.perIP[ip]++
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			l.mu.Lock()
+			defer l.mu.Unlock()
+			l.global--
+			if l.maxPerIP > 0 {
+				if l.perIP[ip] <= 1 {
+					delete(l.perIP, ip)
+				} else {
+					l.perIP[ip]--
+				}
+			}
+		})
+	}, true
+}

--- a/network/api/websocket/connlimiter.go
+++ b/network/api/websocket/connlimiter.go
@@ -23,16 +23,17 @@ type connLimiter struct {
 
 func newConnLimiter(maxGlobal, maxPerIP uint32) *connLimiter {
 	return &connLimiter{
-		maxGlobal: clampUint32ToInt(maxGlobal),
-		maxPerIP:  clampUint32ToInt(maxPerIP),
+		maxGlobal: ClampUint32ToInt(maxGlobal),
+		maxPerIP:  ClampUint32ToInt(maxPerIP),
 		perIP:     make(map[string]int),
 	}
 }
 
-// clampUint32ToInt converts a uint32 cap to int without the negative wrap a direct
-// conversion would cause on 32-bit platforms — a negative max would silently DISABLE
-// the cap (treated as unlimited) instead of enforcing it.
-func clampUint32ToInt(v uint32) int {
+// ClampUint32ToInt converts a uint32 config value to int without the negative wrap a
+// direct conversion would cause on 32-bit platforms. A wrapped-negative value would
+// silently drop the operator's configured value — disabling a connection cap, or falling
+// back to a default address cap — instead of honoring the (large) value they set.
+func ClampUint32ToInt(v uint32) int {
 	if uint64(v) > uint64(math.MaxInt) {
 		return math.MaxInt
 	}

--- a/network/api/websocket/hardening_test.go
+++ b/network/api/websocket/hardening_test.go
@@ -67,6 +67,26 @@ func TestSubscribe_ReadLimit_RejectsOversizedFrame(t *testing.T) {
 	}
 }
 
+func TestSubscribe_RejectsTooManyAddresses(t *testing.T) {
+	hub := socket.NewHub("", "", nil, socket.Limits{MaxAddressesPerSubscribe: 2})
+	addr, cleanup := startTestServerOpts(t, hub, wsocket.SubscribeOptions{})
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.NoError(t, conn.WriteJSON(map[string]interface{}{
+		"subscribed_types": []string{"accounts"},
+		"addresses":        []string{"a", "b", "c"}, // > per-subscribe cap of 2
+	}))
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp map[string]string
+	require.NoError(t, conn.ReadJSON(&resp))
+	assert.Contains(t, resp["error"], "too many addresses")
+}
+
 func TestSubscribe_GlobalConnectionCap(t *testing.T) {
 	hub := socket.NewHub("", "", nil)
 	addr, cleanup := startTestServerOpts(t, hub, wsocket.SubscribeOptions{MaxConnections: 2})

--- a/network/api/websocket/hardening_test.go
+++ b/network/api/websocket/hardening_test.go
@@ -1,0 +1,170 @@
+package websocket_test
+
+import (
+	"context"
+	"encoding/base64"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	wsocket "github.com/klever-io/klever-go/network/api/websocket"
+	socket "github.com/klever-io/klever-go/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func startTestServerOpts(t *testing.T, hub *socket.SocketHub, opts wsocket.SubscribeOptions) (string, func()) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ws := gin.New()
+	wsocket.SubscribeTopics(ws, hub, opts)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &http.Server{Handler: ws, ReadHeaderTimeout: time.Second}
+	go func() { _ = srv.Serve(listener) }()
+
+	return listener.Addr().String(), func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}
+}
+
+// TestSubscribe_ReadLimit_RejectsOversizedFrame confirms GAP#2 is closed: a single
+// frame larger than MaxMessageSize is rejected with WebSocket close 1009 instead of
+// being buffered whole.
+func TestSubscribe_ReadLimit_RejectsOversizedFrame(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServerOpts(t, hub, wsocket.SubscribeOptions{})
+	defer cleanup()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// A valid-JSON subscribe frame whose address string pushes the message past the
+	// read limit, so the decoder keeps reading until SetReadLimit fires (a non-JSON
+	// blob would fail to parse on the first byte, before the limit triggers).
+	oversized := []byte(`{"subscribed_types":["accounts"],"addresses":["` +
+		strings.Repeat("A", int(hub.MaxMessageSize())) + `"]}`)
+
+	// Write from a goroutine and ignore its error: the server stops reading and hard-
+	// closes at the limit, which can reset the client mid-write. The security property
+	// is that the frame is rejected, not buffered whole.
+	go func() { _ = conn.WriteMessage(websocket.TextMessage, oversized) }()
+
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err, "oversized frame must terminate the connection, not be accepted")
+	if ce, ok := err.(*websocket.CloseError); ok {
+		assert.Equal(t, websocket.CloseMessageTooBig, ce.Code, "clean close must be 1009 (message too big)")
+	}
+}
+
+func TestSubscribe_GlobalConnectionCap(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServerOpts(t, hub, wsocket.SubscribeOptions{MaxConnections: 2})
+	defer cleanup()
+
+	var conns []*websocket.Conn
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+
+	for i := 0; i < 2; i++ {
+		c, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+		require.NoErrorf(t, err, "connection %d within the cap should be accepted", i)
+		conns = append(conns, c)
+	}
+
+	_, resp, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.Error(t, err, "connection beyond the global cap must be rejected")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestSubscribe_PerIPConnectionCap(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServerOpts(t, hub, wsocket.SubscribeOptions{MaxConnectionsPerIP: 2})
+	defer cleanup()
+
+	var conns []*websocket.Conn
+	defer func() {
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	}()
+
+	for i := 0; i < 2; i++ {
+		c, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+		require.NoError(t, err)
+		conns = append(conns, c)
+	}
+
+	_, resp, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.Error(t, err, "connection beyond the per-IP cap must be rejected")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestSubscribe_ConnectionCap_ReleasedOnClose(t *testing.T) {
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServerOpts(t, hub, wsocket.SubscribeOptions{MaxConnections: 1})
+	defer cleanup()
+
+	c1, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.NoError(t, err)
+
+	// Cap reached.
+	_, resp, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.Error(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	// Close the first connection; the slot must free up.
+	_ = c1.Close()
+	require.Eventually(t, func() bool {
+		c, _, derr := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+		if derr != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, 3*time.Second, 50*time.Millisecond, "slot must be released after the connection closes")
+}
+
+// TestSubscribe_Secured confirms the AuthHandlers wiring runs before the WebSocket
+// upgrade, so `secured: true` is honoured instead of silently ignored.
+func TestSubscribe_Secured(t *testing.T) {
+	auth := func(c *gin.Context) {
+		user, pass, ok := c.Request.BasicAuth()
+		if !ok || user != "u" || pass != "p" {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+
+	hub := socket.NewHub("", "", nil)
+	addr, cleanup := startTestServerOpts(t, hub, wsocket.SubscribeOptions{AuthHandlers: []gin.HandlerFunc{auth}})
+	defer cleanup()
+
+	_, resp, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", nil)
+	require.Error(t, err, "handshake without auth must be rejected")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("u:p")))
+	conn, resp2, err := websocket.DefaultDialer.Dial("ws://"+addr+"/subscribe", hdr)
+	require.NoError(t, err, "handshake with valid auth must be accepted")
+	require.Equal(t, http.StatusSwitchingProtocols, resp2.StatusCode)
+	_ = conn.Close()
+}

--- a/network/api/websocket/routes.go
+++ b/network/api/websocket/routes.go
@@ -21,6 +21,8 @@ const (
 )
 
 var upgrader = gorilla.Upgrader{
+	// Origin isn't enforced here by design: the node runs headless behind an operator proxy
+	// that owns origin/CORS policy, and /subscribe carries no ambient credentials (KLC-2450).
 	CheckOrigin: func(r *http.Request) bool {
 		return true
 	},

--- a/network/api/websocket/routes.go
+++ b/network/api/websocket/routes.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -30,23 +31,68 @@ type subscribeRequest struct {
 	Types     []string `json:"subscribed_types"`
 }
 
-func SubscribeTopics(ws *gin.Engine, hub *websocket.SocketHub) {
-	ws.GET("/subscribe", func(c *gin.Context) {
-		handleSubscribe(c, hub)
-	})
+// SubscribeOptions configures the hardening applied to the /subscribe route.
+type SubscribeOptions struct {
+	// MaxConnections caps simultaneous live connections node-wide (0 = unlimited).
+	MaxConnections uint32
+	// MaxConnectionsPerIP caps simultaneous live connections per source IP (0 = unlimited).
+	MaxConnectionsPerIP uint32
+	// AuthHandlers run before the WebSocket upgrade when /subscribe is `secured`.
+	AuthHandlers []gin.HandlerFunc
 }
 
-func handleSubscribe(c *gin.Context, hub *websocket.SocketHub) {
+func SubscribeTopics(ws *gin.Engine, hub *websocket.SocketHub, opts ...SubscribeOptions) {
+	var opt SubscribeOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	// One limiter shared by every connection for the server lifetime.
+	limiter := newConnLimiter(opt.MaxConnections, opt.MaxConnectionsPerIP)
+
+	handlers := append([]gin.HandlerFunc{}, opt.AuthHandlers...)
+	handlers = append(handlers, func(c *gin.Context) {
+		handleSubscribe(c, hub, limiter)
+	})
+	ws.GET("/subscribe", handlers...)
+}
+
+func handleSubscribe(c *gin.Context, hub *websocket.SocketHub, limiter *connLimiter) {
+	release, ok := limiter.acquire(remoteIP(c.Request))
+	if !ok {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, map[string]string{"error": "too many websocket connections"})
+		return
+	}
+
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
+		release()
 		log.Error(subscribeOp, "err", err.Error())
 		return
 	}
 
-	go processSubscription(conn, hub)
+	go processSubscription(conn, hub, release)
 }
 
-func processSubscription(conn *gorilla.Conn, hub *websocket.SocketHub) {
+// remoteIP returns the connecting peer's IP from the raw remote address. It does not
+// trust X-Forwarded-For, so the per-IP connection cap cannot be spoofed (matches the
+// existing sourceThrottler middleware).
+func remoteIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+func processSubscription(conn *gorilla.Conn, hub *websocket.SocketHub, release func()) {
+	// Held for the whole connection lifetime: fires on every early return below and, once
+	// the client is live, after <-client.Done() unblocks at teardown.
+	defer release()
+
+	// Bound the handshake frame before it is read.
+	conn.SetReadLimit(hub.MaxMessageSize())
+
 	if err := conn.SetReadDeadline(time.Now().Add(subscribeReadTimeout)); err != nil {
 		log.Error(subscribeOp, "err", err.Error())
 		_ = conn.Close()
@@ -59,12 +105,7 @@ func processSubscription(conn *gorilla.Conn, hub *websocket.SocketHub) {
 		_ = conn.Close()
 		return
 	}
-
-	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		log.Error(subscribeOp, "err", err.Error())
-		_ = conn.Close()
-		return
-	}
+	// Deadline intentionally left armed; loopIn re-arms a lifetime deadline immediately.
 
 	if len(req.Types) == 0 {
 		_ = conn.WriteJSON(map[string]string{"error": "subscribed_types must not be empty"})
@@ -79,9 +120,24 @@ func processSubscription(conn *gorilla.Conn, hub *websocket.SocketHub) {
 		return
 	}
 
+	if len(req.Addresses) > hub.MaxAddressesPerSubscribe() {
+		_ = conn.WriteJSON(map[string]string{"error": "too many addresses in a single subscribe"})
+		_ = conn.Close()
+		return
+	}
+
 	log.Debug(subscribeOp, "types", fmt.Sprintf("%v", parsedTypes), "addresses", fmt.Sprintf("%v", req.Addresses))
 	client := websocket.NewClient(conn, hub)
-	hub.HandleClientInsertion(parsedTypes, req.Addresses, client)
+	if err := hub.HandleClientInsertion(parsedTypes, req.Addresses, client); err != nil {
+		// Unreachable for a fresh client (resolve keeps per-client >= per-subscribe, and
+		// req.Addresses was pre-checked); guard defensively.
+		log.Warn(subscribeOp, "err", err.Error())
+		_ = conn.Close()
+		return
+	}
+
+	// Block until the connection is torn down so release() fires exactly at teardown.
+	<-client.Done()
 }
 
 func parseEventTypes(types []string) ([]indexer.EventType, error) {

--- a/network/api/websocket/routes.go
+++ b/network/api/websocket/routes.go
@@ -126,7 +126,7 @@ func processSubscription(conn *gorilla.Conn, hub *websocket.SocketHub, release f
 		return
 	}
 
-	log.Debug(subscribeOp, "types", fmt.Sprintf("%v", parsedTypes), "addresses", fmt.Sprintf("%v", req.Addresses))
+	log.Debug(subscribeOp, "types", fmt.Sprintf("%v", parsedTypes), "addressCount", len(req.Addresses))
 	client := websocket.NewClient(conn, hub)
 	if err := hub.HandleClientInsertion(parsedTypes, req.Addresses, client); err != nil {
 		// Unreachable for a fresh client (resolve keeps per-client >= per-subscribe, and

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -146,8 +146,14 @@ func (c *client) loopOut() {
 			if !ok {
 				return
 			}
-			err := c.conn.WriteJSON(m)
-			if err != nil {
+			// Bound the write: a client that re-arms its read deadline but never drains its
+			// socket would otherwise park this goroutine here indefinitely (GHSA-4fwh-wrm6-97xm).
+			if err := c.conn.SetWriteDeadline(time.Now().Add(pingPeriod)); err != nil {
+				log.Warn("ws.loopOut", "err", err.Error())
+				c.close()
+				return
+			}
+			if err := c.conn.WriteJSON(m); err != nil {
 				log.Warn("ws.loopOut", "err", err.Error())
 				c.close()
 				return

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -36,6 +36,13 @@ func (c *client) IsAlive() bool {
 	return c.alive
 }
 
+// Done returns a channel that is closed once the client connection is torn down.
+// It lets the connection owner (processSubscription) block for the connection
+// lifetime so a per-connection resource slot can be released exactly on close.
+func (c *client) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
 func (c *client) send(msg interface{}) {
 	c.aliveLock.Lock()
 	defer c.aliveLock.Unlock()
@@ -73,6 +80,15 @@ func (c *client) loopIn() {
 		c.hub.handleClientDelete(c)
 	}()
 
+	// Bound every inbound frame and keep a lifetime read deadline, refreshed by the pong
+	// handler and each read. loopOut's pings keep a live client warm while a dead/idle one
+	// is reclaimed at pongWait (GHSA-4fwh-wrm6-97xm).
+	c.conn.SetReadLimit(c.hub.limits.maxMessageSize)
+	_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		return c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	})
+
 	for {
 		messageType, message, err := c.conn.ReadMessage()
 		if err != nil {
@@ -81,38 +97,47 @@ func (c *client) loopIn() {
 			}
 			break
 		}
+		_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
 
-		switch messageType {
-		case ws.CloseMessage:
-			return
-		case ws.PingMessage:
-			err = c.conn.WriteControl(ws.PongMessage, nil, time.Now().Add(pingPeriod))
-			if err != nil {
-				log.Warn("ws.loopIn.pong", "err", err.Error())
-				return
-			}
-		case ws.TextMessage:
-			var req WSRequest
-			if err := json.Unmarshal(message, &req); err != nil {
-				c.send(WSResponse{Error: "invalid json: " + err.Error()})
-				continue
-			}
-			c.sem <- struct{}{}
-			ctx := c.ctx
-			go func(ctx context.Context, req WSRequest) {
-				defer func() { <-c.sem }()
-				select {
-				case <-ctx.Done():
-					return
-				default:
-				}
-				c.hub.HandleClientRequest(c, req)
-			}(ctx, req)
+		// ReadMessage only yields data frames; gorilla answers client ping and close
+		// control frames through its default handlers (close surfaces as a read error
+		// above). Only text frames carry client requests.
+		if messageType != ws.TextMessage {
+			continue
 		}
+
+		var req WSRequest
+		if err := json.Unmarshal(message, &req); err != nil {
+			c.send(WSResponse{Error: "invalid json: " + err.Error()})
+			continue
+		}
+		// Acquire a worker slot, but abandon the read loop if the connection is torn
+		// down meanwhile, so loopIn never lingers blocked on a full semaphore at close.
+		select {
+		case c.sem <- struct{}{}:
+		case <-c.ctx.Done():
+			return
+		}
+		ctx := c.ctx
+		go func(ctx context.Context, req WSRequest) {
+			defer func() { <-c.sem }()
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			c.hub.HandleClientRequest(c, req)
+		}(ctx, req)
 	}
 }
 
 func (c *client) loopOut() {
+	// Ping the client periodically; its pong refreshes loopIn's read deadline, keeping
+	// passive-but-live subscribers up while dead ones time out. WriteControl is safe to
+	// call concurrently with the other writer.
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-c.ctx.Done():
@@ -124,6 +149,12 @@ func (c *client) loopOut() {
 			err := c.conn.WriteJSON(m)
 			if err != nil {
 				log.Warn("ws.loopOut", "err", err.Error())
+				c.close()
+				return
+			}
+		case <-ticker.C:
+			if err := c.conn.WriteControl(ws.PingMessage, nil, time.Now().Add(pingPeriod)); err != nil {
+				log.Warn("ws.loopOut.ping", "err", err.Error())
 				c.close()
 				return
 			}

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -6,4 +6,65 @@ const (
 	pingPeriod     = time.Duration(15) * time.Second
 	outChannelSize = 500
 	maxWorkers     = 4
+
+	// pongWait is the lifetime read deadline; it must exceed pingPeriod so a live client
+	// can answer a server ping before it elapses.
+	pongWait = time.Duration(30) * time.Second
+
+	// defaultMaxAddressesPerSubscribe caps addresses per subscribe call when unset.
+	defaultMaxAddressesPerSubscribe = 10000
+
+	// defaultMaxAddressesPerClient caps total addresses watched per connection when unset.
+	defaultMaxAddressesPerClient = 50000
+
+	// minMaxMessageSize is the floor (and default) for the inbound frame read limit;
+	// gorilla's default is unlimited (GHSA-4fwh-wrm6-97xm, GAP#2). resolve raises it to
+	// fit a larger per-subscribe address cap.
+	minMaxMessageSize = 1 << 20 // 1 MiB
+
+	// addressJSONOverhead is the per-address byte budget (address + JSON separators, with
+	// headroom) used to derive the read limit from the address cap.
+	addressJSONOverhead = 96
 )
+
+// Limits bounds /subscribe resource usage. Zero-valued fields fall back to safe
+// defaults, so a partial config can't disable the protection. The read limit is not a
+// separate knob — it is derived from the per-subscribe cap (see resolve).
+type Limits struct {
+	MaxAddressesPerSubscribe int
+	MaxAddressesPerClient    int
+}
+
+// resolvedLimits holds the effective limits after defaults are applied.
+type resolvedLimits struct {
+	maxAddressesPerSubscribe int
+	maxAddressesPerClient    int
+	maxMessageSize           int64
+}
+
+func (l Limits) resolve() resolvedLimits {
+	perSubscribe := l.MaxAddressesPerSubscribe
+	if perSubscribe <= 0 {
+		perSubscribe = defaultMaxAddressesPerSubscribe
+	}
+	perClient := l.MaxAddressesPerClient
+	if perClient <= 0 {
+		perClient = defaultMaxAddressesPerClient
+	}
+	// A per-connection cap below the per-call cap is incoherent (one max subscribe could
+	// never fit); clamp it up so a fresh client's first subscribe always fits.
+	if perClient < perSubscribe {
+		perClient = perSubscribe
+	}
+
+	readLimit := int64(minMaxMessageSize)
+	if derived := int64(perSubscribe)*addressJSONOverhead + 1024; derived > readLimit {
+		readLimit = derived
+	}
+
+	return resolvedLimits{
+		maxAddressesPerSubscribe: perSubscribe,
+		maxAddressesPerClient:    perClient,
+		maxMessageSize:           readLimit,
+	}
+}

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -3,13 +3,8 @@ package websocket
 import "time"
 
 const (
-	pingPeriod     = time.Duration(15) * time.Second
 	outChannelSize = 500
 	maxWorkers     = 4
-
-	// pongWait is the lifetime read deadline; it must exceed pingPeriod so a live client
-	// can answer a server ping before it elapses.
-	pongWait = time.Duration(30) * time.Second
 
 	// defaultMaxAddressesPerSubscribe caps addresses per subscribe call when unset.
 	defaultMaxAddressesPerSubscribe = 10000
@@ -25,6 +20,15 @@ const (
 	// addressJSONOverhead is the per-address byte budget (address + JSON separators, with
 	// headroom) used to derive the read limit from the address cap.
 	addressJSONOverhead = 96
+)
+
+// pingPeriod and pongWait are the /subscribe keepalive timings. They are vars only so
+// tests can shorten them to exercise the idle-client read-deadline reclamation quickly;
+// nothing in production mutates them. pongWait (the lifetime read deadline) must exceed
+// pingPeriod so a live client can answer a server ping before it elapses.
+var (
+	pingPeriod = 15 * time.Second
+	pongWait   = 30 * time.Second
 )
 
 // Limits bounds /subscribe resource usage. Zero-valued fields fall back to safe

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -20,6 +20,12 @@ const (
 	// addressJSONOverhead is the per-address byte budget (address + JSON separators, with
 	// headroom) used to derive the read limit from the address cap.
 	addressJSONOverhead = 96
+
+	// maxEncodedAddressLength caps each retained subscription address by byte size: a klv
+	// bech32 address is 62 chars (matches the node's own encoded-address cap), so a longer
+	// string can never match a real address and would only feed a per-connection
+	// memory-amplification path (GHSA-4fwh-wrm6-97xm).
+	maxEncodedAddressLength = 62
 )
 
 // pingPeriod and pongWait are the /subscribe keepalive timings. They are vars only so

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -90,6 +90,26 @@ func TestHandleClientInsertion_DuplicateAddressesCountOnce(t *testing.T) {
 	assert.Equal(t, 3, hub.clientAddresses[c], "a duplicated new address must count once")
 }
 
+// TestHandleClientInsertion_NonAddressScopedIgnoresAddresses verifies that a
+// blocks/transactions-only subscribe neither counts nor stores its addresses:
+// such entries would never match (both accept flags false) yet would otherwise
+// burn the per-connection address budget (GHSA-4fwh-wrm6-97xm, Impact C).
+func TestHandleClientInsertion_NonAddressScopedIgnoresAddresses(t *testing.T) {
+	hub := NewHub("", "", nil, Limits{MaxAddressesPerSubscribe: 3, MaxAddressesPerClient: 3})
+	c := newTestClient(hub)
+
+	// BLOCKS-only with an oversized address list attached: addresses are irrelevant
+	// here, so neither the per-subscribe cap nor the per-client budget applies.
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.BLOCKS}, []string{"a", "b", "c", "d", "e"}, c))
+
+	hub.mu.RLock()
+	defer hub.mu.RUnlock()
+	assert.Equal(t, 0, hub.clientAddresses[c], "non-address-scoped subscribe must not consume the address budget")
+	assert.Equal(t, 0, len(hub.addressSubscription), "non-address-scoped subscribe must not store addresses")
+	_, subscribed := hub.blockSubscription[c]
+	assert.True(t, subscribed, "the global BLOCKS subscription must still be registered")
+}
+
 func TestLimits_Resolve_ClampsPerClientToPerSubscribe(t *testing.T) {
 	// An incoherent config (per-connection cap below per-call cap) is clamped up so a
 	// single maximal subscribe always fits the per-connection budget.

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -1,0 +1,147 @@
+package websocket
+
+import (
+	"fmt"
+	"testing"
+
+	indexer "github.com/klever-io/klever-go/indexer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleClientDelete_ReclaimsAddressKeys is the regression test for the Impact C
+// leak (GHSA-4fwh-wrm6-97xm): a disconnecting client must release every address-map
+// outer key it created, not just remove itself from the inner maps.
+func TestHandleClientDelete_ReclaimsAddressKeys(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+	// Mark the client dead before inserting: newTestClient has a nil conn, so the
+	// c.close() inside handleClientDelete must be a no-op. killClient flips alive=false
+	// so close() skips the (nil) conn, letting us drive handleClientDelete directly.
+	killClient(c)
+
+	const n = 5000
+	addresses := make([]string, n)
+	for i := range addresses {
+		addresses[i] = fmt.Sprintf("klv-addr-%d", i)
+	}
+
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, addresses, c))
+
+	hub.mu.RLock()
+	require.Equal(t, n, len(hub.addressSubscription))
+	require.Equal(t, n, hub.clientAddresses[c])
+	hub.mu.RUnlock()
+
+	hub.handleClientDelete(c)
+
+	hub.mu.RLock()
+	defer hub.mu.RUnlock()
+	assert.Equal(t, 0, len(hub.addressSubscription), "outer address keys must be reclaimed on disconnect")
+	_, hasCount := hub.clientAddresses[c]
+	assert.False(t, hasCount, "per-client address count must be cleared on disconnect")
+}
+
+func TestHandleClientInsertion_RejectsOversizedSubscribe(t *testing.T) {
+	hub := NewHub("", "", nil, Limits{MaxAddressesPerSubscribe: 3})
+	c := newTestClient(hub)
+
+	err := hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{"a", "b", "c", "d"}, c)
+	require.Error(t, err)
+
+	hub.mu.RLock()
+	assert.Equal(t, 0, len(hub.addressSubscription), "rejected subscribe must not mutate the hub")
+	hub.mu.RUnlock()
+}
+
+func TestHandleClientInsertion_RejectsPerClientCap(t *testing.T) {
+	hub := NewHub("", "", nil, Limits{MaxAddressesPerSubscribe: 5, MaxAddressesPerClient: 5})
+	c := newTestClient(hub)
+
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{"a", "b", "c", "d", "e"}, c))
+
+	hub.mu.RLock()
+	require.Equal(t, 5, hub.clientAddresses[c])
+	hub.mu.RUnlock()
+
+	// One more new address (across a second call) must be rejected.
+	err := hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{"one-too-many"}, c)
+	require.Error(t, err)
+
+	hub.mu.RLock()
+	_, exists := hub.addressSubscription["one-too-many"]
+	hub.mu.RUnlock()
+	assert.False(t, exists)
+}
+
+// TestHandleClientInsertion_DuplicateAddressesCountOnce guards the per-client cap
+// gate: a duplicated NEW address in one call must count once, so a client near the cap
+// is not falsely rejected. Cap 3, already holding 2; a {"x","x"} call adds one (total
+// 3, accepted) — counting the duplicate twice would wrongly reject it as 4.
+func TestHandleClientInsertion_DuplicateAddressesCountOnce(t *testing.T) {
+	hub := NewHub("", "", nil, Limits{MaxAddressesPerSubscribe: 3, MaxAddressesPerClient: 3})
+	c := newTestClient(hub)
+
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{"a", "b"}, c))
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{"x", "x"}, c))
+
+	hub.mu.RLock()
+	defer hub.mu.RUnlock()
+	assert.Equal(t, 3, hub.clientAddresses[c], "a duplicated new address must count once")
+}
+
+func TestLimits_Resolve_ClampsPerClientToPerSubscribe(t *testing.T) {
+	// An incoherent config (per-connection cap below per-call cap) is clamped up so a
+	// single maximal subscribe always fits the per-connection budget.
+	r := Limits{MaxAddressesPerSubscribe: 100, MaxAddressesPerClient: 10}.resolve()
+	assert.Equal(t, 100, r.maxAddressesPerSubscribe)
+	assert.Equal(t, 100, r.maxAddressesPerClient, "per-client cap clamped up to per-subscribe")
+}
+
+func TestLimits_Resolve_AppliesDefaults(t *testing.T) {
+	r := Limits{}.resolve()
+	assert.Equal(t, defaultMaxAddressesPerSubscribe, r.maxAddressesPerSubscribe)
+	assert.Equal(t, defaultMaxAddressesPerClient, r.maxAddressesPerClient)
+	assert.Equal(t, int64(minMaxMessageSize), r.maxMessageSize, "default read limit is the floor")
+}
+
+func TestLimits_Resolve_DerivesReadLimitFromAddressCap(t *testing.T) {
+	// A per-subscribe cap large enough to exceed the floor must raise the read limit so
+	// a maximal subscribe still fits while staying bounded.
+	r := Limits{MaxAddressesPerSubscribe: 100000}.resolve()
+	assert.Equal(t, 100000, r.maxAddressesPerSubscribe)
+	assert.Equal(t, int64(100000)*addressJSONOverhead+1024, r.maxMessageSize)
+	assert.Greater(t, r.maxMessageSize, int64(minMaxMessageSize))
+}
+
+func TestClientAddresses_DecrementOnRemoval(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{"a", "b", "c"}, c))
+	hub.mu.RLock()
+	require.Equal(t, 3, hub.clientAddresses[c])
+	hub.mu.RUnlock()
+
+	hub.HandleClientRemoval([]indexer.EventType{indexer.ACCOUNTS}, []string{"a"}, c)
+
+	hub.mu.RLock()
+	defer hub.mu.RUnlock()
+	assert.Equal(t, 2, hub.clientAddresses[c], "removing an address must lower the per-client count")
+	_, hasA := hub.addressSubscription["a"]
+	assert.False(t, hasA, "fully unsubscribed address key must be reclaimed")
+}
+
+// TestHandleClientInsertion_ReSubscribeDoesNotDoubleCount ensures re-subscribing to an
+// address already watched by the client does not inflate the per-client count.
+func TestHandleClientInsertion_ReSubscribeDoesNotDoubleCount(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{"x"}, c))
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.USER_TRANSACTIONS}, []string{"x"}, c))
+
+	hub.mu.RLock()
+	defer hub.mu.RUnlock()
+	assert.Equal(t, 1, hub.clientAddresses[c])
+}

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -2,8 +2,13 @@ package websocket
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	ws "github.com/gorilla/websocket"
 	indexer "github.com/klever-io/klever-go/indexer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -164,4 +169,52 @@ func TestHandleClientInsertion_ReSubscribeDoesNotDoubleCount(t *testing.T) {
 	hub.mu.RLock()
 	defer hub.mu.RUnlock()
 	assert.Equal(t, 1, hub.clientAddresses[c])
+}
+
+// setKeepaliveForTest shortens the /subscribe keepalive timings so the read-deadline
+// reclamation fires in milliseconds, and returns a restore func.
+func setKeepaliveForTest(ping, pong time.Duration) func() {
+	origPing, origPong := pingPeriod, pongWait
+	pingPeriod, pongWait = ping, pong
+	return func() { pingPeriod, pongWait = origPing, origPong }
+}
+
+// TestClient_IdleConnectionReclaimedAtPongWait covers the core new defense
+// (GHSA-4fwh-wrm6-97xm): a silent/dead client that never answers server pings must have
+// its connection torn down when the lifetime read deadline (pongWait) elapses, so the
+// per-connection slot the owner holds via Done() is released instead of leaking.
+func TestClient_IdleConnectionReclaimedAtPongWait(t *testing.T) {
+	defer setKeepaliveForTest(20*time.Millisecond, 60*time.Millisecond)()
+
+	hub := newTestHub(nil)
+	upgrader := ws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	released := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		c := NewClient(conn, hub)
+		// Mirror processSubscription: the owner blocks on Done() and frees the slot at teardown.
+		go func() {
+			<-c.Done()
+			close(released)
+		}()
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := ws.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Never read from the connection: gorilla only answers server pings while the app reads,
+	// so a client that never reads is indistinguishable from a dead one and never pongs.
+	select {
+	case <-released:
+		// Read deadline elapsed and reclaimed the idle client — the slot is freed.
+	case <-time.After(2 * time.Second):
+		t.Fatal("idle client was not reclaimed at pongWait; connection slot leaked")
+	}
 }

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -59,6 +59,38 @@ func TestHandleClientInsertion_RejectsOversizedSubscribe(t *testing.T) {
 	hub.mu.RUnlock()
 }
 
+// TestHandleClientInsertion_RejectsOversizedAddress guards the memory-amplification path
+// (GHSA-4fwh-wrm6-97xm): an address longer than a real klv bech32 address can never match,
+// so it must be rejected before it is retained as a subscription key rather than counting
+// only toward the count caps.
+func TestHandleClientInsertion_RejectsOversizedAddress(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	oversized := strings.Repeat("a", maxEncodedAddressLength+1)
+	err := hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{oversized}, c)
+	require.Error(t, err)
+
+	hub.mu.RLock()
+	defer hub.mu.RUnlock()
+	assert.Equal(t, 0, len(hub.addressSubscription), "an oversized address must not be retained as a key")
+	assert.Equal(t, 0, hub.clientAddresses[c], "a rejected subscribe must not consume the address budget")
+}
+
+// TestHandleClientInsertion_AcceptsMaxLengthAddress confirms the length cap is inclusive:
+// a real, full-length (62-char) address is accepted.
+func TestHandleClientInsertion_AcceptsMaxLengthAddress(t *testing.T) {
+	hub := newTestHub(nil)
+	c := newTestClient(hub)
+
+	addr := strings.Repeat("a", maxEncodedAddressLength)
+	require.NoError(t, hub.HandleClientInsertion([]indexer.EventType{indexer.ACCOUNTS}, []string{addr}, c))
+
+	hub.mu.RLock()
+	defer hub.mu.RUnlock()
+	assert.Equal(t, 1, hub.clientAddresses[c])
+}
+
 func TestHandleClientInsertion_RejectsPerClientCap(t *testing.T) {
 	hub := NewHub("", "", nil, Limits{MaxAddressesPerSubscribe: 5, MaxAddressesPerClient: 5})
 	c := newTestClient(hub)

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -284,6 +284,18 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 		return fmt.Errorf("too many addresses in a single subscribe: %d (max %d)", len(addresses), h.limits.maxAddressesPerSubscribe)
 	}
 
+	// Bound each address by byte size before it is retained as a subscription key. The count
+	// caps alone leave a memory-amplification path: a long-lived connection could otherwise
+	// keep sending unique oversized strings that can never match a real address yet are
+	// retained per connection (GHSA-4fwh-wrm6-97xm).
+	if wantsAddresses {
+		for _, address := range addresses {
+			if len(address) > maxEncodedAddressLength {
+				return fmt.Errorf("subscription address exceeds the maximum length of %d bytes", maxEncodedAddressLength)
+			}
+		}
+	}
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/klever-io/klever-go/cmd/operator/utils"
@@ -39,19 +40,38 @@ type SocketHub struct {
 	blockSubscription       map[*client]struct{}
 	transactionSubscription map[*client]struct{}
 	addressSubscription     map[string]map[*client]userOptions
+	clientAddresses         map[*client]int
+	limits                  resolvedLimits
 	unregister              chan *client
 }
 
-func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade) *SocketHub {
+func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade, limits ...Limits) *SocketHub {
+	var l Limits
+	if len(limits) > 0 {
+		l = limits[0]
+	}
+
 	return &SocketHub{
 		unregister:              make(chan *client),
 		addressSubscription:     make(map[string]map[*client]userOptions),
+		clientAddresses:         make(map[*client]int),
 		blockSubscription:       make(map[*client]struct{}),
 		transactionSubscription: make(map[*client]struct{}),
 		postConnectionURL:       postConnectionURL,
 		postConnectionAPIKey:    postConnectionAPIKey,
 		facade:                  facade,
+		limits:                  l.resolve(),
 	}
+}
+
+// MaxMessageSize returns the inbound WebSocket frame read limit (bytes).
+func (h *SocketHub) MaxMessageSize() int64 {
+	return h.limits.maxMessageSize
+}
+
+// MaxAddressesPerSubscribe returns the per-call address cap for a subscribe request.
+func (h *SocketHub) MaxAddressesPerSubscribe() int {
+	return h.limits.maxAddressesPerSubscribe
 }
 
 func (h *SocketHub) asyncPost(parsed *Send) {
@@ -253,9 +273,33 @@ func (h *SocketHub) RemoveClient(c *client) {
 	h.unregister <- c
 }
 
-func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, addresses []string, c *client) {
+func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, addresses []string, c *client) error {
+	if len(addresses) > h.limits.maxAddressesPerSubscribe {
+		return fmt.Errorf("too many addresses in a single subscribe: %d (max %d)", len(addresses), h.limits.maxAddressesPerSubscribe)
+	}
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	// Reject before mutating if the per-connection cap would be exceeded. Only addresses
+	// new to this client count, and duplicates count once — matching the insertion below.
+	newForClient := 0
+	seen := make(map[string]struct{}, len(addresses))
+	for _, address := range addresses {
+		if _, dup := seen[address]; dup {
+			continue
+		}
+		seen[address] = struct{}{}
+		if inner, ok := h.addressSubscription[address]; ok {
+			if _, has := inner[c]; has {
+				continue
+			}
+		}
+		newForClient++
+	}
+	if h.clientAddresses[c]+newForClient > h.limits.maxAddressesPerClient {
+		return fmt.Errorf("address subscription limit reached for this connection (max %d)", h.limits.maxAddressesPerClient)
+	}
 
 	var acceptTransactions bool
 	var acceptAccounts bool
@@ -273,11 +317,16 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 	}
 
 	for _, address := range addresses {
-		if _, ok := h.addressSubscription[address]; !ok {
-			h.addressSubscription[address] = make(map[*client]userOptions)
+		value, ok := h.addressSubscription[address]
+		if !ok {
+			value = make(map[*client]userOptions)
+			h.addressSubscription[address] = value
 		}
 
-		value := h.addressSubscription[address]
+		if _, has := value[c]; !has {
+			h.clientAddresses[c]++
+		}
+
 		existing := value[c]
 		if acceptAccounts {
 			existing.acceptAccount = true
@@ -286,9 +335,9 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 			existing.acceptTransaction = true
 		}
 		value[c] = existing
-
-		h.addressSubscription[address] = value
 	}
+
+	return nil
 }
 
 func closeAndClear(subscription map[*client]struct{}) {
@@ -302,12 +351,14 @@ func (h *SocketHub) deleteAll() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	for _, clients := range h.addressSubscription {
+	for addr, clients := range h.addressSubscription {
 		for cl := range clients {
 			cl.close()
 			delete(clients, cl)
 		}
+		delete(h.addressSubscription, addr)
 	}
+	h.clientAddresses = make(map[*client]int)
 
 	closeAndClear(h.blockSubscription)
 	closeAndClear(h.transactionSubscription)
@@ -320,13 +371,18 @@ func (h *SocketHub) handleClientDelete(c *client) {
 	delete(h.blockSubscription, c)
 	delete(h.transactionSubscription, c)
 	c.close()
-	for _, clients := range h.addressSubscription {
-		for cl := range clients {
-			if cl == c {
-				delete(clients, c)
-			}
+	// Remove the client from every watched address and reclaim the outer key when its
+	// inner map empties. Without this, a disconnect leaks one map entry per address
+	// permanently (GHSA-4fwh-wrm6-97xm, Impact C).
+	for addr, clients := range h.addressSubscription {
+		if _, ok := clients[c]; ok {
+			delete(clients, c)
+		}
+		if len(clients) == 0 {
+			delete(h.addressSubscription, addr)
 		}
 	}
+	delete(h.clientAddresses, c)
 }
 
 func (h *SocketHub) HandleClientRequest(c *client, req WSRequest) {
@@ -433,7 +489,10 @@ func (h *SocketHub) handleDynamicSubscribe(c *client, req WSRequest) {
 		return
 	}
 
-	h.HandleClientInsertion(eventTypes, params.Addresses, c)
+	if err := h.HandleClientInsertion(eventTypes, params.Addresses, c); err != nil {
+		c.send(WSResponse{ID: req.ID, Error: err.Error()})
+		return
+	}
 	c.send(WSResponse{ID: req.ID, Data: "subscribed"})
 }
 
@@ -494,10 +553,21 @@ func (h *SocketHub) removeClientFromAddress(addr string, c *client, removeAccoun
 	}
 	if !existing.acceptAccount && !existing.acceptTransaction {
 		delete(clients, c)
+		h.decrClientAddresses(c)
 	} else {
 		clients[c] = existing
 	}
 	if len(clients) == 0 {
 		delete(h.addressSubscription, addr)
 	}
+}
+
+// decrClientAddresses lowers a client's tracked address count, removing the entry
+// at zero so the map cannot accumulate stale clients.
+func (h *SocketHub) decrClientAddresses(c *client) {
+	if h.clientAddresses[c] <= 1 {
+		delete(h.clientAddresses, c)
+		return
+	}
+	h.clientAddresses[c]--
 }

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -281,10 +281,22 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	// Reject before mutating if the per-connection cap would be exceeded. Only addresses
-	// new to this client count, and duplicates count once — matching the insertion below.
-	newForClient := 0
+	// Reject before mutating if the per-connection cap would be exceeded; only addresses
+	// new to this client count (GHSA-4fwh-wrm6-97xm, Impact C).
+	if h.clientAddresses[c]+h.countNewAddresses(addresses, c) > h.limits.maxAddressesPerClient {
+		return fmt.Errorf("address subscription limit reached for this connection (max %d)", h.limits.maxAddressesPerClient)
+	}
+
+	acceptAccounts, acceptTransactions := h.applyEventTypes(eventType, c)
+	h.addAddressSubscriptions(addresses, c, acceptAccounts, acceptTransactions)
+	return nil
+}
+
+// countNewAddresses returns how many of addresses are not yet watched by c, counting
+// duplicates within the call once. The caller must hold h.mu.
+func (h *SocketHub) countNewAddresses(addresses []string, c *client) int {
 	seen := make(map[string]struct{}, len(addresses))
+	count := 0
 	for _, address := range addresses {
 		if _, dup := seen[address]; dup {
 			continue
@@ -295,16 +307,16 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 				continue
 			}
 		}
-		newForClient++
+		count++
 	}
-	if h.clientAddresses[c]+newForClient > h.limits.maxAddressesPerClient {
-		return fmt.Errorf("address subscription limit reached for this connection (max %d)", h.limits.maxAddressesPerClient)
-	}
+	return count
+}
 
-	var acceptTransactions bool
-	var acceptAccounts bool
-	for _, types := range eventType {
-		switch types {
+// applyEventTypes registers the global block/transaction subscriptions for c and returns
+// the per-address accept flags. The caller must hold h.mu.
+func (h *SocketHub) applyEventTypes(eventType []indexer.EventType, c *client) (acceptAccounts, acceptTransactions bool) {
+	for _, t := range eventType {
+		switch t {
 		case indexer.BLOCKS:
 			h.blockSubscription[c] = struct{}{}
 		case indexer.TRANSACTIONS:
@@ -315,7 +327,12 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 			acceptAccounts = true
 		}
 	}
+	return acceptAccounts, acceptTransactions
+}
 
+// addAddressSubscriptions adds c to each address with the given accept flags, bumping the
+// per-client count for newly added (address, client) pairs. The caller must hold h.mu.
+func (h *SocketHub) addAddressSubscriptions(addresses []string, c *client, acceptAccounts, acceptTransactions bool) {
 	for _, address := range addresses {
 		value, ok := h.addressSubscription[address]
 		if !ok {
@@ -336,8 +353,6 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 		}
 		value[c] = existing
 	}
-
-	return nil
 }
 
 func closeAndClear(subscription map[*client]struct{}) {
@@ -375,9 +390,7 @@ func (h *SocketHub) handleClientDelete(c *client) {
 	// inner map empties. Without this, a disconnect leaks one map entry per address
 	// permanently (GHSA-4fwh-wrm6-97xm, Impact C).
 	for addr, clients := range h.addressSubscription {
-		if _, ok := clients[c]; ok {
-			delete(clients, c)
-		}
+		delete(clients, c)
 		if len(clients) == 0 {
 			delete(h.addressSubscription, addr)
 		}

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -274,7 +274,13 @@ func (h *SocketHub) RemoveClient(c *client) {
 }
 
 func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, addresses []string, c *client) error {
-	if len(addresses) > h.limits.maxAddressesPerSubscribe {
+	// Addresses are only meaningful for the address-scoped types (ACCOUNTS,
+	// USER_TRANSACTIONS). A blocks/transactions-only subscribe must not count or
+	// store them, or it would burn the per-connection address budget on entries
+	// that never match anything (GHSA-4fwh-wrm6-97xm, Impact C).
+	wantsAddresses := containsAddressScoped(eventType)
+
+	if wantsAddresses && len(addresses) > h.limits.maxAddressesPerSubscribe {
 		return fmt.Errorf("too many addresses in a single subscribe: %d (max %d)", len(addresses), h.limits.maxAddressesPerSubscribe)
 	}
 
@@ -282,14 +288,27 @@ func (h *SocketHub) HandleClientInsertion(eventType []indexer.EventType, address
 	defer h.mu.Unlock()
 
 	// Reject before mutating if the per-connection cap would be exceeded; only addresses
-	// new to this client count (GHSA-4fwh-wrm6-97xm, Impact C).
-	if h.clientAddresses[c]+h.countNewAddresses(addresses, c) > h.limits.maxAddressesPerClient {
+	// new to this client count.
+	if wantsAddresses && h.clientAddresses[c]+h.countNewAddresses(addresses, c) > h.limits.maxAddressesPerClient {
 		return fmt.Errorf("address subscription limit reached for this connection (max %d)", h.limits.maxAddressesPerClient)
 	}
 
 	acceptAccounts, acceptTransactions := h.applyEventTypes(eventType, c)
-	h.addAddressSubscriptions(addresses, c, acceptAccounts, acceptTransactions)
+	if wantsAddresses {
+		h.addAddressSubscriptions(addresses, c, acceptAccounts, acceptTransactions)
+	}
 	return nil
+}
+
+// containsAddressScoped reports whether eventType includes a type for which the
+// request's addresses are meaningful (ACCOUNTS or USER_TRANSACTIONS).
+func containsAddressScoped(eventType []indexer.EventType) bool {
+	for _, t := range eventType {
+		if t == indexer.ACCOUNTS || t == indexer.USER_TRANSACTIONS {
+			return true
+		}
+	}
+	return false
 }
 
 // countNewAddresses returns how many of addresses are not yet watched by c, counting


### PR DESCRIPTION
## Summary

Hardens the unauthenticated `/subscribe` WebSocket endpoint, which had no resource bounds. Because the REST/WS API runs in-process with the node, unbounded reads/connections/subscriptions are an unauthenticated remote resource-exhaustion vector (CWE-770).

## Changes

- **Inbound read limit** on both read paths (handshake `processSubscription` and `client.loopIn`), plus a **lifetime read deadline** refreshed by a server ping ticker — passive-but-live subscribers stay connected while dead/idle ones are reclaimed at `pongWait`.
- **Address caps** per subscribe call and per connection, rejected before mutating hub state and counting distinct new addresses once. The read limit is **derived** from the per-subscribe cap, so a maximal subscribe always fits while staying bounded (it is never a separate, weaker-able knob).
- **Map-leak fix**: `handleClientDelete`/`deleteAll` now reclaim empty `addressSubscription` keys, fixing a permanent per-address leak on disconnect.
- **Connection limiter** (global + per source IP) held for the connection lifetime — the gin throttler releases its slot at the HTTP→WS upgrade and so does not bound live WS connections. Keyed on the raw remote address (not `X-Forwarded-For`).
- **`secured: true` now works** for `/subscribe`: the route bypassed the router wrapper, so the flag was silently ignored. Auth now runs before the upgrade.

## Configuration

Connection and address caps are operator-tunable under `webServer.*` (`0 = unlimited` for connections; built-in safe defaults for address caps). Defaults keep the dev/example config usable (`open: true`).

## Scope

Cross-origin (`CheckOrigin`) and direct network exposure remain operator/deployment responsibilities — the node is headless and expected to sit behind a reverse proxy that terminates TLS and enforces origin/auth. Those are intentionally **not** in-node changes here.

## Tests

Oversized frame → close 1009; global and per-IP connection caps (503 over cap, slot release on close); secured handshake (401 without auth, 101 with); address-map leak reclamation; per-subscribe and per-client caps; duplicate-address counting; and the read-limit derivation/per-client clamp. `go build`, `go vet`, and `go test -race` on the affected packages are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Hardening `/subscribe` WebSocket endpoint against resource exhaustion (CWE-770)

This PR hardens the unauthenticated remote `/subscribe` WebSocket path against resource-exhaustion attacks **without changing blockchain-critical logic** (consensus, transaction execution, state/chain storage, or KVM). The scope is limited to **network/API routing** and the **in-process WebSocket subscription hub/client lifecycle** that delivers blockchain event notifications.

### Networking & API-level hardening
- **Lifetime WebSocket connection limiter (global + per-source-IP)**: Enforces concurrent connection caps across the server and per remote IP by acquiring capacity before the HTTP→WS upgrade; rejects over-cap handshakes with **HTTP 503** and releases capacity on teardown. Uses the host portion of `RemoteAddr` (no `X-Forwarded-For`).
- **Authentication enforced before WS upgrade**: Makes `/subscribe` respect `secured:true` by running authentication handlers **before** upgrading to WebSocket (adds route misconfiguration warning behavior when `open:false` but `secured:true`).
- **Configurable operator limits plumbed via `webServer.*`**:
  - max live `/subscribe` connections (node-wide and per-IP; `0` = unlimited)
  - max addresses allowed **per `/subscribe` request**
  - max watched addresses allowed **per WebSocket client connection**
  - accessors added throughout facade/interface/mocks to expose these values.

### Bounded subscription state & concurrency/error handling
- **Per-subscribe + per-client address caps with bounded mutation**:
  - Validates address counts **before** mutating hub state.
  - **Deduplicates** addresses within a single subscribe request and counts only **new** addresses against the per-client cap.
  - Rejects over-cap insertions cleanly (and ensures insertion failures are propagated to the requesting client rather than silently ignored).
- **Inbound read/frame exhaustion protections on both read paths**:
  - Adds **read limits** during the handshake subscription processing and in the steady-state `client.loopIn`.
  - Introduces a refreshable read deadline extended via **ping/pong** so “passive but alive” subscribers remain connected while idle/dead ones are reclaimed at `pongWait`.
  - Oversized frames are terminated with **WebSocket close code 1009**.
  - Derives the effective inbound read limit from the effective per-subscribe address cap (including coherence/clamping rules) to keep behavior bounded.
- **Teardown coordination to prevent goroutine/resource leaks**:
  - Adds `client.Done()` and ensures limiter capacity is held for the full WebSocket connection lifetime and released exactly once at teardown.

### Memory/resource leak prevention in hub cleanup
- **Reclaims empty subscription buckets**:
  - Fixes a map leak by reclaiming empty `addressSubscription` keys and correctly updating per-client address tracking on disconnect/unsubscribe paths (`handleClientDelete`/`deleteAll`), preventing unbounded key growth.

### Test coverage
Adds/extends tests to cover:
- oversized frame rejection (**1009**),
- global/per-IP connection caps and **release-on-close** behavior (**503**),
- secured handshake enforcement (**401** unauthenticated, **101** authenticated),
- address-map reclamation on disconnect,
- per-subscribe/per-client cap enforcement, duplicate counting semantics (counts once), and read-limit derivation/clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->