### PR TITLE
[KLC-2430] fix: set pubsub seen-messages TTL per instance to avoid data race

### DIFF
--- a/data/retriever/storageResolvers/selfSend_importdb_test.go
+++ b/data/retriever/storageResolvers/selfSend_importdb_test.go
@@ -77,8 +77,8 @@ func runWithin(t *testing.T, what string, fn func() error) error {
 // GHSA-hf2g-6j7h-98wg fix this must deliver to the response-topic processor synchronously (already
 // processed by the time RequestDataFromHash returns), with no error and no deadlock.
 func TestSliceResolver_RequestDataFromHash_SelfSendIsSynchronous(t *testing.T) {
-	// Not t.Parallel: messenger construction races on the libp2p global pubsub.TimeCacheDuration
-	// (KLC-2430), so two messengers cannot be built concurrently.
+	t.Parallel()
+
 	const responseTopic = "txBlockBodies_0_RESPONSE"
 	hash := []byte("mb-hash")
 	value := []byte("marshalled-miniblock-bytes")
@@ -134,7 +134,8 @@ func TestSliceResolver_RequestDataFromHash_SelfSendIsSynchronous(t *testing.T) {
 // TestSliceResolver_RequestDataFromHashArray_SelfSendDeliversEveryChunk guards the multi-message
 // self-send loop (one sendToSelf per packed chunk): every chunk must arrive synchronously, in order.
 func TestSliceResolver_RequestDataFromHashArray_SelfSendDeliversEveryChunk(t *testing.T) {
-	// Not t.Parallel: see TestSliceResolver_RequestDataFromHash_SelfSendIsSynchronous.
+	t.Parallel()
+
 	const responseTopic = "miniBlocks_0_RESPONSE"
 	hashes := [][]byte{[]byte("h1"), []byte("h2"), []byte("h3")}
 	values := [][]byte{[]byte("v1"), []byte("v2"), []byte("v3")}

--- a/network/p2p/libp2p/netMessenger.go
+++ b/network/p2p/libp2p/netMessenger.go
@@ -346,13 +346,18 @@ func createMessenger(
 }
 
 func (netMes *networkMessenger) createPubSub(withMessageSigning bool) error {
-	optsPS := make([]pubsub.Option, 0)
+	optsPS := []pubsub.Option{
+		// Configure the seen-messages TTL per pubsub instance instead of mutating
+		// the package-level pubsub.TimeCacheDuration global. Writing the global on
+		// every construction races when messengers are built concurrently (e.g.
+		// parallel tests). WithSeenMessagesTTL is the libp2p-recommended way to set
+		// this per instance.
+		pubsub.WithSeenMessagesTTL(pubsubTimeCacheDuration),
+	}
 	if !withMessageSigning {
 		log.Warn("signature verification is turned off in network messenger instance")
 		optsPS = append(optsPS, pubsub.WithMessageSignaturePolicy(noSignPolicy))
 	}
-
-	pubsub.TimeCacheDuration = pubsubTimeCacheDuration
 
 	var err error
 	netMes.pb, err = pubsub.NewGossipSub(netMes.ctx, netMes.p2pHost, optsPS...)

--- a/network/p2p/libp2p/netMessenger_race_test.go
+++ b/network/p2p/libp2p/netMessenger_race_test.go
@@ -1,0 +1,68 @@
+package libp2p_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/klever-io/klever-go/network/p2p/libp2p"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNetworkMessenger_ParallelConstructionIsRaceFree guards KLC-2430.
+// Constructing messengers concurrently must not race on libp2p's package-level
+// pubsub.TimeCacheDuration global. Before the fix, createPubSub wrote that global
+// on every construction, so two parallel constructions tripped the -race detector.
+// The seen-messages TTL is now set per instance via pubsub.WithSeenMessagesTTL, so
+// this test must pass cleanly under `go test -race`.
+//
+// Two paths are covered because they exercise different construction code:
+//   - mock:  NewMockMessenger -> createMessenger -> createPubSub (no host/loggers)
+//   - real:  NewNetworkMessenger -> setupExternalP2PLoggers + libp2p.New +
+//     createMessenger -> createPubSub (the full production path)
+//
+// The racy global lived in the shared createPubSub, but covering the real path too
+// asserts the *entire* construction sequence is race-free, matching the ticket's
+// concern that "any future test or tool that constructs messengers in parallel"
+// must be safe.
+func TestNetworkMessenger_ParallelConstructionIsRaceFree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is not a short test")
+	}
+
+	t.Run("mock messengers in parallel", func(t *testing.T) {
+		const numMessengers = 8
+
+		for i := range numMessengers {
+			t.Run(fmt.Sprintf("messenger-%d", i), func(t *testing.T) {
+				t.Parallel()
+
+				netw := mocknet.New()
+				mes, err := libp2p.NewMockMessenger(createMockNetworkArgs(), netw)
+				require.Nil(t, err)
+				defer func() { _ = mes.Close() }()
+
+				require.NotNil(t, mes)
+			})
+		}
+	})
+
+	t.Run("real messengers in parallel", func(t *testing.T) {
+		// Fewer instances: each opens a real libp2p host on an ephemeral port.
+		// This path also runs setupExternalP2PLoggers concurrently, so it guards
+		// the whole NewNetworkMessenger sequence, not just createPubSub.
+		const numMessengers = 4
+
+		for i := range numMessengers {
+			t.Run(fmt.Sprintf("messenger-%d", i), func(t *testing.T) {
+				t.Parallel()
+
+				mes, err := libp2p.NewNetworkMessenger(createMockNetworkArgs())
+				require.Nil(t, err)
+				defer func() { _ = mes.Close() }()
+
+				require.NotNil(t, mes)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`createPubSub` mutated the libp2p package-level global `pubsub.TimeCacheDuration` on **every** messenger construction. Two messengers built concurrently both write that global with no synchronization, which the Go race detector flags as a data race.

This replaces the global write with the per-instance option `pubsub.WithSeenMessagesTTL(pubsubTimeCacheDuration)` — libp2p's documented way to configure the seen-messages TTL per pubsub instance. The effective TTL is unchanged (10 min), and no production code reads the global.

## Why this is correct

- **Semantically equivalent:** libp2p seeds `seenMsgTTL` from the global default, then applies options before building the seen-cache, so `WithSeenMessagesTTL(10m)` yields the same `seenMsgTTL = 10m` the global write produced.
- **No other reader:** the only consumer of the `pubsub.TimeCacheDuration` global was libp2p's own `NewPubSub` default seed. `validMessageByTimestamp` uses the local const `pubsubTimeCacheDuration`, not the global, so the replay/timestamp window stays at 10 min.
- **Not production-reachable, but a real footgun:** production builds exactly one messenger sequentially at startup, so the race never triggers there — but any test or tool constructing messengers in parallel trips `-race` until this is fixed.

## Changes

- `network/p2p/libp2p/netMessenger.go` — global write → per-instance `WithSeenMessagesTTL`.
- `network/p2p/libp2p/netMessenger_race_test.go` — new regression test building messengers in parallel (mock and real paths); fails under `-race` without the fix.
- `data/retriever/storageResolvers/selfSend_importdb_test.go` — restore `t.Parallel()` on the two self-send tests that had it dropped for this race.

## Testing

- `go test -race` on both affected packages → clean (0 data races); full non-short `libp2p` suite green.
- Regression test catches the race 10/10 when the fix is reverted (deterministic detector), and passes across ~200 instrumented runs with the fix.
- `gofmt` / `go vet` / `go build ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Data Race Fix in Libp2p Network Messenger

This PR fixes a critical data race in the P2P networking layer affecting messenger construction under concurrent load.

### Issue
The `createPubSub` function in `network/p2p/libp2p/netMessenger.go` was mutating the package-level global variable `pubsub.TimeCacheDuration` during every messenger instantiation. When multiple messengers were constructed concurrently (e.g., during node startup or network rebalancing), unsynchronized writes to this global triggered Go's race detector.

### Solution
Replaced the unsafe global mutation with a per-instance configuration option using `pubsub.WithSeenMessagesTTL(pubsubTimeCacheDuration)`. This leverages libp2p's documented approach for setting seen-messages TTL per pubsub instance. The effective TTL remains unchanged at 10 minutes, and the configuration is semantically equivalent because libp2p applies per-instance options after seeding from the global default.

### Files Modified
- **network/p2p/libp2p/netMessenger.go** — Replaced global write with per-instance `WithSeenMessagesTTL` option
- **network/p2p/libp2p/netMessenger_race_test.go** — New regression test (`TestNetworkMessenger_ParallelConstructionIsRaceFree`) that constructs messengers in parallel under the race detector to catch future regressions
- **data/retriever/storageResolvers/selfSend_importdb_test.go** — Restored `t.Parallel()` on two self-send tests that were previously sequential due to the messenger construction race

### Impact
- **Node Stability**: Eliminates a data race that could manifest during high-concurrency scenarios, improving reliability under load
- **Networking**: Fixes an unsafe pattern in P2P messenger initialization without changing functional behavior
- **Concurrency Safety**: Demonstrates proper per-instance configuration patterns for shared libp2p components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->