### PR TITLE
[KLC-2506] feat: add /network/economics and /network/account-totals supply endpoints

### DIFF
--- a/common/facade/interface.go
+++ b/common/facade/interface.go
@@ -70,6 +70,9 @@ type NodeHandler interface {
 	// GetEconomics returns live KLV supply figures and node-state held aggregates
 	GetEconomics() (*models.EconomicsResponse, error)
 
+	// GetAccountTotals returns aggregates over all user accounts (count, KLV balance, allowance)
+	GetAccountTotals() (*models.AccountTotalsResponse, error)
+
 	// GetNFT returns an assetResponse containing information
 	// about the asset and userKDA correlated with provided address
 	GetNFT(owner string, address string) (*kapps.UserKDA, *kapps.KDAData, error)

--- a/common/facade/interface.go
+++ b/common/facade/interface.go
@@ -12,6 +12,7 @@ import (
 	"github.com/klever-io/klever-go/data/transaction"
 	indexerData "github.com/klever-io/klever-go/indexer/data"
 	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/network/api/models"
 	"github.com/klever-io/klever-go/node/heartbeat/data"
 	"github.com/klever-io/klever-go/tools/debug"
 	"github.com/klever-io/klever-go/vmcommon"
@@ -65,6 +66,9 @@ type NodeHandler interface {
 	// GetAsset returns an assetResponse containing information
 	//  about the asset correlated with provided assetID
 	GetAsset(assetID string) (*kapps.KDAData, error)
+
+	// GetEconomics returns live KLV supply figures and node-state held aggregates
+	GetEconomics() (*models.EconomicsResponse, error)
 
 	// GetNFT returns an assetResponse containing information
 	// about the asset and userKDA correlated with provided address

--- a/common/facade/nodeFacade.go
+++ b/common/facade/nodeFacade.go
@@ -489,6 +489,11 @@ func (nf *nodeFacade) GetEconomics() (*models.EconomicsResponse, error) {
 	return nf.node.GetEconomics()
 }
 
+// GetAccountTotals returns aggregates over all user accounts (count, KLV balance, allowance). See KLC-2506.
+func (nf *nodeFacade) GetAccountTotals() (*models.AccountTotalsResponse, error) {
+	return nf.node.GetAccountTotals()
+}
+
 // GetNFT returns an assetResponse containing information
 // about the asset and userKDA correlated with provided address
 func (nf *nodeFacade) GetNFT(owner string, address string) (*kapps.UserKDA, *kapps.KDAData, error) {

--- a/common/facade/nodeFacade.go
+++ b/common/facade/nodeFacade.go
@@ -484,6 +484,11 @@ func (nf *nodeFacade) GetAsset(assetID string) (*kapps.KDAData, error) {
 	return nf.node.GetAsset(assetID)
 }
 
+// GetEconomics returns live KLV supply figures and node-state held aggregates. See KLC-2506.
+func (nf *nodeFacade) GetEconomics() (*models.EconomicsResponse, error) {
+	return nf.node.GetEconomics()
+}
+
 // GetNFT returns an assetResponse containing information
 // about the asset and userKDA correlated with provided address
 func (nf *nodeFacade) GetNFT(owner string, address string) (*kapps.UserKDA, *kapps.KDAData, error) {

--- a/common/facade/nodeFacade_test.go
+++ b/common/facade/nodeFacade_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/config"
 	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/network/api/models"
 	"github.com/klever-io/klever-go/statusHandler"
 	"github.com/stretchr/testify/require"
 )
@@ -298,4 +299,36 @@ func TestHelperFunctions(t *testing.T) {
 		require.NotNil(t, throttlers)
 		require.Empty(t, throttlers) // Invalid throttler should be skipped
 	})
+}
+
+func TestNodeFacade_GetEconomics(t *testing.T) {
+	t.Parallel()
+
+	expected := &models.EconomicsResponse{CirculatingSupply: 9_000, TotalStaked: 5_000}
+	args := createMockArgNodeFacade()
+	args.Node = &mock.NodeHandlerStub{
+		GetEconomicsCalled: func() (*models.EconomicsResponse, error) { return expected, nil },
+	}
+	nf, err := facade.NewNodeFacade(args)
+	require.NoError(t, err)
+
+	resp, err := nf.GetEconomics()
+	require.NoError(t, err)
+	require.Same(t, expected, resp)
+}
+
+func TestNodeFacade_GetAccountTotals(t *testing.T) {
+	t.Parallel()
+
+	expected := &models.AccountTotalsResponse{AccountCount: 3, BalanceTotal: 1_000}
+	args := createMockArgNodeFacade()
+	args.Node = &mock.NodeHandlerStub{
+		GetAccountTotalsCalled: func() (*models.AccountTotalsResponse, error) { return expected, nil },
+	}
+	nf, err := facade.NewNodeFacade(args)
+	require.NoError(t, err)
+
+	resp, err := nf.GetAccountTotals()
+	require.NoError(t, err)
+	require.Same(t, expected, resp)
 }

--- a/common/mock/kappAccountHandlerStub.go
+++ b/common/mock/kappAccountHandlerStub.go
@@ -23,10 +23,14 @@ type KAppAccountHandlerStub struct {
 	SetDataTrieCalled        func(trie data.Trie)
 	DataTrieCalled           func() data.Trie
 	DataTrieTrackerCalled    func() state.DataTrieTracker
+	GetUserKDACalled         func(assetID []byte, nonce []byte) (*kapps.UserKDA, error)
 	state.AccountHandler
 }
 
 func (k *KAppAccountHandlerStub) GetUserKDA(assetID []byte, nonce []byte, _ bool) (*kapps.UserKDA, error) {
+	if k.GetUserKDACalled != nil {
+		return k.GetUserKDACalled(assetID, nonce)
+	}
 	return nil, nil
 }
 

--- a/common/mock/kappsStub.go
+++ b/common/mock/kappsStub.go
@@ -94,7 +94,9 @@ func (k KappsDBMock) IsInterfaceNil() bool {
 }
 
 type KappsControllerMock struct {
-	kappContext kapp.KappContext
+	kappContext    kapp.KappContext
+	ValidatorsKapp kapp.ValidatorsKapp
+	MarketKapp     kapp.MarketKapp
 }
 
 func (k *KappsControllerMock) SetCurrentKAppContext(kappContext kapp.KappContext) {
@@ -109,7 +111,7 @@ func (k *KappsControllerMock) InitKApps(_ state.AccountsCacher) error {
 }
 
 func (k *KappsControllerMock) GetValidatorsKApp() kapp.ValidatorsKapp {
-	return nil
+	return k.ValidatorsKapp
 }
 
 func (k *KappsControllerMock) GetKDAFeesPoolKApp() kapp.KDAFeesPoolKapp {
@@ -137,7 +139,7 @@ func (k *KappsControllerMock) GetITOKApp() kapp.ITOKapp {
 
 // IsInterfaceNil -
 func (k *KappsControllerMock) GetMarketKApp() kapp.MarketKapp {
-	return nil
+	return k.MarketKapp
 }
 
 // IsInterfaceNil -

--- a/common/mock/nodeHandlerStub.go
+++ b/common/mock/nodeHandlerStub.go
@@ -17,7 +17,10 @@ import (
 )
 
 // NodeHandlerStub - minimal stub for NodeHandler interface
-type NodeHandlerStub struct{}
+type NodeHandlerStub struct {
+	GetEconomicsCalled     func() (*models.EconomicsResponse, error)
+	GetAccountTotalsCalled func() (*models.AccountTotalsResponse, error)
+}
 
 func (n *NodeHandlerStub) StartConsensus() error { return nil }
 func (n *NodeHandlerStub) ValidateTransaction(*transaction.Transaction, bool) error {
@@ -53,9 +56,15 @@ func (n *NodeHandlerStub) GetAvailableClaim(string, string) (int64, map[string]i
 }
 func (n *NodeHandlerStub) GetAsset(string) (*kapps.KDAData, error) { return nil, nil }
 func (n *NodeHandlerStub) GetEconomics() (*models.EconomicsResponse, error) {
+	if n.GetEconomicsCalled != nil {
+		return n.GetEconomicsCalled()
+	}
 	return nil, nil
 }
 func (n *NodeHandlerStub) GetAccountTotals() (*models.AccountTotalsResponse, error) {
+	if n.GetAccountTotalsCalled != nil {
+		return n.GetAccountTotalsCalled()
+	}
 	return nil, nil
 }
 func (n *NodeHandlerStub) GetNFT(string, string) (*kapps.UserKDA, *kapps.KDAData, error) {

--- a/common/mock/nodeHandlerStub.go
+++ b/common/mock/nodeHandlerStub.go
@@ -11,6 +11,7 @@ import (
 	"github.com/klever-io/klever-go/data/transaction"
 	indexerData "github.com/klever-io/klever-go/indexer/data"
 	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/network/api/models"
 	heartbeatData "github.com/klever-io/klever-go/node/heartbeat/data"
 	"github.com/klever-io/klever-go/tools/debug"
 )
@@ -51,6 +52,9 @@ func (n *NodeHandlerStub) GetAvailableClaim(string, string) (int64, map[string]i
 	return 0, nil, 0, nil
 }
 func (n *NodeHandlerStub) GetAsset(string) (*kapps.KDAData, error) { return nil, nil }
+func (n *NodeHandlerStub) GetEconomics() (*models.EconomicsResponse, error) {
+	return nil, nil
+}
 func (n *NodeHandlerStub) GetNFT(string, string) (*kapps.UserKDA, *kapps.KDAData, error) {
 	return nil, nil, nil
 }

--- a/common/mock/nodeHandlerStub.go
+++ b/common/mock/nodeHandlerStub.go
@@ -55,6 +55,9 @@ func (n *NodeHandlerStub) GetAsset(string) (*kapps.KDAData, error) { return nil,
 func (n *NodeHandlerStub) GetEconomics() (*models.EconomicsResponse, error) {
 	return nil, nil
 }
+func (n *NodeHandlerStub) GetAccountTotals() (*models.AccountTotalsResponse, error) {
+	return nil, nil
+}
 func (n *NodeHandlerStub) GetNFT(string, string) (*kapps.UserKDA, *kapps.KDAData, error) {
 	return nil, nil, nil
 }

--- a/common/mock/validatorKappStub.go
+++ b/common/mock/validatorKappStub.go
@@ -13,6 +13,7 @@ type ValidatorsKAppStub struct {
 	UndelegateCalled                         func(blockEpoch uint32, validator []byte, sender []byte, tc *transaction.UndelegateContract) (transaction.Transaction_TXResultCode, error)
 	ClaimPendingRewardsCalled                func(address []byte) (int64, error)
 	GetPendingRewardsCalled                  func(address []byte) (int64, error)
+	GetPendingRewardsTotalCalled             func() (int64, error)
 }
 
 // SetKAppController sets the KApp controller.
@@ -147,6 +148,14 @@ func (v *ValidatorsKAppStub) GetPendingRewards(address []byte) (int64, error) {
 func (v *ValidatorsKAppStub) ClaimPendingRewards(address []byte) (int64, error) {
 	if v.ClaimPendingRewardsCalled != nil {
 		return v.ClaimPendingRewardsCalled(address)
+	}
+	return 0, nil
+}
+
+// GetPendingRewardsTotal returns the aggregate of all pending rewards.
+func (v *ValidatorsKAppStub) GetPendingRewardsTotal() (int64, error) {
+	if v.GetPendingRewardsTotalCalled != nil {
+		return v.GetPendingRewardsTotalCalled()
 	}
 	return 0, nil
 }

--- a/config/node/api.yaml
+++ b/config/node/api.yaml
@@ -67,8 +67,10 @@ apiPackages:
         open: true
       - name: /economics
         open: false
+        secured: true
       - name: /account-totals
         open: false
+        secured: true
   node:
     routes:
       - name: /status

--- a/config/node/api.yaml
+++ b/config/node/api.yaml
@@ -65,6 +65,8 @@ apiPackages:
         open: true
       - name: /network-parameters
         open: true
+      - name: /economics
+        open: false
   node:
     routes:
       - name: /status

--- a/config/node/api.yaml
+++ b/config/node/api.yaml
@@ -67,6 +67,8 @@ apiPackages:
         open: true
       - name: /economics
         open: false
+      - name: /account-totals
+        open: false
   node:
     routes:
       - name: /status
@@ -84,7 +86,7 @@ apiPackages:
       - name: /statistics
         open: true
       - name: /set-redundancy
-        open: true
+        open: false
         secured: true
       - name: /enable-epochs
         open: true

--- a/core/kapp/interface.go
+++ b/core/kapp/interface.go
@@ -42,6 +42,8 @@ type ValidatorsKapp interface {
 	// V2 Epoch Rewards methods - for scalable rewards distribution
 	GetPendingRewards(address []byte) (int64, error)
 	ClaimPendingRewards(address []byte) (int64, error)
+	// GetPendingRewardsTotal returns the sum of all unclaimed PREW in the Validators KApp trie.
+	GetPendingRewardsTotal() (int64, error)
 
 	IsInterfaceNil() bool
 }
@@ -130,6 +132,8 @@ type MarketKapp interface {
 	GetAccountsCacher() state.AccountsCacher
 	GetMarketplace(marketplaceID []byte) (state.KAppAccountHandler, *kapps.Marketplace, error)
 	GetMarketOrder(orderID []byte) (state.KAppAccountHandler, *kapps.MarketOrderData, error)
+	// GetMarketEscrowTotal returns the total KLV escrowed across open market orders.
+	GetMarketEscrowTotal() (int64, error)
 	Buy(sender []byte, tc *transaction.BuyContract) (transaction.Transaction_TXResultCode, error)
 	Claim(sender []byte, tc *transaction.ClaimContract) (transaction.Transaction_TXResultCode, error)
 	Sell(sender []byte, tc *transaction.SellContract) (transaction.Transaction_TXResultCode, error)

--- a/core/kapp/market/market.go
+++ b/core/kapp/market/market.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"math"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -227,16 +228,24 @@ func (m *marketKapp) GetMarketEscrowTotal() (int64, error) {
 		}
 		order := &kapps.MarketOrderData{}
 		if err := m.marshalizer.Unmarshal(order, raw); err != nil {
-			log.Warn("GetMarketEscrowTotal: skipping undecodable market order", "error", err)
-			continue
+			return 0, err
 		}
 		if order.IsClaimed {
 			continue
 		}
-		total += order.RoyaltiesFixedDeposit
+		add := order.RoyaltiesFixedDeposit
 		if bytes.Equal(order.CurrencyID, kdautils.KLVIdentifier) {
-			total += order.CurrentBid
+			add += order.CurrentBid
 		}
+		if add < 0 {
+			log.Warn("GetMarketEscrowTotal: negative escrow amount, skipping", "key", hex.EncodeToString(key))
+			continue
+		}
+		if total > math.MaxInt64-add {
+			log.Warn("GetMarketEscrowTotal: sum would overflow int64, skipping entry")
+			continue
+		}
+		total += add
 	}
 
 	return total, nil

--- a/core/kapp/market/market.go
+++ b/core/kapp/market/market.go
@@ -192,6 +192,7 @@ func (m *marketKapp) GetMarketOrder(orderID []byte) (state.KAppAccountHandler, *
 
 // GetMarketEscrowTotal returns the total KLV held in open market orders: each unclaimed order's
 // RoyaltiesFixedDeposit (always KLV) plus its CurrentBid when the order is priced in KLV.
+// Mid-walk trie errors are swallowed upstream, so a truncated walk undercounts silently (KLC-2509).
 func (m *marketKapp) GetMarketEscrowTotal() (int64, error) {
 	app, err := m.accountsCacher.LoadKAppUncached(kapps.MarketKAppAddress)
 	if err != nil {

--- a/core/kapp/market/market.go
+++ b/core/kapp/market/market.go
@@ -2,12 +2,14 @@ package market
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"strconv"
 	"time"
 	"unicode/utf8"
 
+	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/kapp"
@@ -24,6 +26,8 @@ import (
 )
 
 var _ kapp.MarketKapp = (*marketKapp)(nil)
+
+var log = logger.GetOrCreate("kapp/market")
 
 type marketKapp struct {
 	hasher         hashing.Hasher
@@ -183,6 +187,59 @@ func (m *marketKapp) GetMarketOrder(orderID []byte) (state.KAppAccountHandler, *
 	}
 
 	return marketKapp, market, nil
+}
+
+// GetMarketEscrowTotal returns the total KLV held in open market orders: each unclaimed order's
+// RoyaltiesFixedDeposit (always KLV) plus its CurrentBid when the order is priced in KLV.
+func (m *marketKapp) GetMarketEscrowTotal() (int64, error) {
+	app, err := m.accountsCacher.LoadKAppUncached(kapps.MarketKAppAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	dataTrie := app.DataTrie()
+	if check.IfNil(dataTrie) {
+		return 0, nil
+	}
+
+	leavesChannel, err := dataTrie.GetAllLeavesOnChannel(app.GetRootHash(), context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	// Collect order keys first so the scan goroutine finishes before we read values back.
+	prefix := []byte(kapps.MarketOrderPrefix + kapps.Sp)
+	orderKeys := make([][]byte, 0)
+	for leaf := range leavesChannel {
+		if !bytes.HasPrefix(leaf.Key(), prefix) {
+			continue
+		}
+		key := make([]byte, len(leaf.Key()))
+		copy(key, leaf.Key())
+		orderKeys = append(orderKeys, key)
+	}
+
+	total := int64(0)
+	for _, key := range orderKeys {
+		raw := app.GetStorage(key) // trims the trie tail, unlike the raw leaf value
+		if len(raw) == 0 {
+			continue
+		}
+		order := &kapps.MarketOrderData{}
+		if err := m.marshalizer.Unmarshal(order, raw); err != nil {
+			log.Warn("GetMarketEscrowTotal: skipping undecodable market order", "error", err)
+			continue
+		}
+		if order.IsClaimed {
+			continue
+		}
+		total += order.RoyaltiesFixedDeposit
+		if bytes.Equal(order.CurrencyID, kdautils.KLVIdentifier) {
+			total += order.CurrentBid
+		}
+	}
+
+	return total, nil
 }
 
 func (m *marketKapp) SetMarketOrder(marketKapp state.KAppAccountHandler, order *kapps.MarketOrderData) error {

--- a/core/kapp/market/market.go
+++ b/core/kapp/market/market.go
@@ -223,24 +223,9 @@ func (m *marketKapp) GetMarketEscrowTotal() (int64, error) {
 
 	total := int64(0)
 	for _, key := range orderKeys {
-		raw := app.GetStorage(key) // trims the trie tail, unlike the raw leaf value
-		if len(raw) == 0 {
-			continue
-		}
-		order := &kapps.MarketOrderData{}
-		if err := m.marshalizer.Unmarshal(order, raw); err != nil {
+		add, err := m.orderEscrowAmount(app, key)
+		if err != nil {
 			return 0, err
-		}
-		if order.IsClaimed {
-			continue
-		}
-		add := order.RoyaltiesFixedDeposit
-		if bytes.Equal(order.CurrencyID, kdautils.KLVIdentifier) {
-			add += order.CurrentBid
-		}
-		if add < 0 {
-			log.Warn("GetMarketEscrowTotal: negative escrow amount, skipping", "key", hex.EncodeToString(key))
-			continue
 		}
 		if total > math.MaxInt64-add {
 			log.Warn("GetMarketEscrowTotal: sum would overflow int64, skipping entry")
@@ -250,6 +235,31 @@ func (m *marketKapp) GetMarketEscrowTotal() (int64, error) {
 	}
 
 	return total, nil
+}
+
+// orderEscrowAmount returns the KLV escrowed by one stored order: RoyaltiesFixedDeposit plus
+// CurrentBid when priced in KLV; zero for empty, claimed, or negative-value entries.
+func (m *marketKapp) orderEscrowAmount(app state.KAppAccountHandler, key []byte) (int64, error) {
+	raw := app.GetStorage(key) // trims the trie tail, unlike the raw leaf value
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	order := &kapps.MarketOrderData{}
+	if err := m.marshalizer.Unmarshal(order, raw); err != nil {
+		return 0, err
+	}
+	if order.IsClaimed {
+		return 0, nil
+	}
+	add := order.RoyaltiesFixedDeposit
+	if bytes.Equal(order.CurrencyID, kdautils.KLVIdentifier) {
+		add += order.CurrentBid
+	}
+	if add < 0 {
+		log.Warn("GetMarketEscrowTotal: negative escrow amount, skipping", "key", hex.EncodeToString(key))
+		return 0, nil
+	}
+	return add, nil
 }
 
 func (m *marketKapp) SetMarketOrder(marketKapp state.KAppAccountHandler, order *kapps.MarketOrderData) error {

--- a/core/kapp/market/market_test.go
+++ b/core/kapp/market/market_test.go
@@ -2,6 +2,8 @@ package market
 
 import (
 	"encoding/hex"
+	"errors"
+	"math"
 	"testing"
 
 	"github.com/klever-io/klever-go/common/mock"
@@ -1364,4 +1366,130 @@ func TestMarketKApp_GetMarketEscrowTotal(t *testing.T) {
 	total, err := mk.GetMarketEscrowTotal()
 	require.NoError(t, err)
 	require.Equal(t, int64(2150), total)
+}
+
+func TestMarketKApp_GetMarketEscrowTotal_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	newEscrowKApp := func(t *testing.T) kapp.MarketKapp {
+		mk, err := NewMarketKApp(&ArgsNewMarketKApp{
+			Hasher:         &sha256.Sha256{},
+			Marshalizer:    marshal.NewProtoMarshalizer(),
+			PubkeyConv:     mock.NewPubkeyConverterMock(32),
+			ForkController: mock.NewForkControllerStub(),
+		})
+		require.NoError(t, err)
+		return mk
+	}
+
+	appWithOrders := func(orders map[string][]byte) *mock.KAppAccountHandlerStub {
+		leaves := make([]data.KeyValueHolder, 0, len(orders))
+		for key := range orders {
+			leaves = append(leaves, keyValStorage.NewKeyValStorage([]byte(key), nil))
+		}
+		return &mock.KAppAccountHandlerStub{
+			DataTrieCalled: func() data.Trie {
+				return &mock.TrieStub{GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+					ch := make(chan data.KeyValueHolder, len(leaves))
+					for _, l := range leaves {
+						ch <- l
+					}
+					close(ch)
+					return ch, nil
+				}}
+			},
+			GetRootHashCalled: func() []byte { return []byte("root") },
+			GetStorageCalled:  func(key []byte) []byte { return orders[string(key)] },
+		}
+	}
+
+	setApp := func(t *testing.T, mk kapp.MarketKapp, app state.KAppAccountHandler) {
+		require.NoError(t, mk.SetAccountsCacher(&mock.AccountsCacherStub{
+			LoadKAppUncachedCalled: func(_ []byte) (state.KAppAccountHandler, error) { return app, nil },
+		}))
+	}
+
+	orderKey := func(id string) string { return string(kdautils.ToMarketOrderKey([]byte(id))) }
+
+	t.Run("LoadKAppUncached error propagates", func(t *testing.T) {
+		t.Parallel()
+		mk := newEscrowKApp(t)
+		expectedErr := errors.New("load failed")
+		require.NoError(t, mk.SetAccountsCacher(&mock.AccountsCacherStub{
+			LoadKAppUncachedCalled: func(_ []byte) (state.KAppAccountHandler, error) { return nil, expectedErr },
+		}))
+		total, err := mk.GetMarketEscrowTotal()
+		require.ErrorIs(t, err, expectedErr)
+		require.Zero(t, total)
+	})
+
+	t.Run("nil data trie returns zero", func(t *testing.T) {
+		t.Parallel()
+		mk := newEscrowKApp(t)
+		setApp(t, mk, &mock.KAppAccountHandlerStub{DataTrieCalled: func() data.Trie { return nil }})
+		total, err := mk.GetMarketEscrowTotal()
+		require.NoError(t, err)
+		require.Zero(t, total)
+	})
+
+	t.Run("GetAllLeavesOnChannel error propagates", func(t *testing.T) {
+		t.Parallel()
+		mk := newEscrowKApp(t)
+		expectedErr := errors.New("trie error")
+		setApp(t, mk, &mock.KAppAccountHandlerStub{
+			DataTrieCalled: func() data.Trie {
+				return &mock.TrieStub{GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+					return nil, expectedErr
+				}}
+			},
+			GetRootHashCalled: func() []byte { return []byte("root") },
+		})
+		total, err := mk.GetMarketEscrowTotal()
+		require.ErrorIs(t, err, expectedErr)
+		require.Zero(t, total)
+	})
+
+	t.Run("undecodable order errors out", func(t *testing.T) {
+		t.Parallel()
+		mk := newEscrowKApp(t)
+		setApp(t, mk, appWithOrders(map[string][]byte{orderKey("bad"): {0xff, 0xfe, 0xfd}}))
+		total, err := mk.GetMarketEscrowTotal()
+		require.Error(t, err)
+		require.Zero(t, total)
+	})
+
+	t.Run("empty and negative orders are skipped", func(t *testing.T) {
+		t.Parallel()
+		mk := newEscrowKApp(t)
+		marshalizer := marshal.NewProtoMarshalizer()
+		negRaw, err := marshalizer.Marshal(&kapps.MarketOrderData{ID: []byte("neg"), RoyaltiesFixedDeposit: -100})
+		require.NoError(t, err)
+		goodRaw, err := marshalizer.Marshal(&kapps.MarketOrderData{ID: []byte("ok"), CurrencyID: []byte("KLV"), CurrentBid: 500, RoyaltiesFixedDeposit: 100})
+		require.NoError(t, err)
+		setApp(t, mk, appWithOrders(map[string][]byte{
+			orderKey("empty"): nil, // deleted entry, skipped
+			orderKey("neg"):   negRaw,
+			orderKey("ok"):    goodRaw,
+		}))
+		total, err := mk.GetMarketEscrowTotal()
+		require.NoError(t, err)
+		require.Equal(t, int64(600), total)
+	})
+
+	t.Run("overflowing sum is skipped", func(t *testing.T) {
+		t.Parallel()
+		mk := newEscrowKApp(t)
+		marshalizer := marshal.NewProtoMarshalizer()
+		maxRaw, err := marshalizer.Marshal(&kapps.MarketOrderData{ID: []byte("max"), RoyaltiesFixedDeposit: math.MaxInt64})
+		require.NoError(t, err)
+		max2Raw, err := marshalizer.Marshal(&kapps.MarketOrderData{ID: []byte("max2"), RoyaltiesFixedDeposit: math.MaxInt64})
+		require.NoError(t, err)
+		setApp(t, mk, appWithOrders(map[string][]byte{
+			orderKey("max"):  maxRaw,
+			orderKey("max2"): max2Raw,
+		}))
+		total, err := mk.GetMarketEscrowTotal()
+		require.NoError(t, err)
+		require.Equal(t, int64(math.MaxInt64), total) // second entry skipped, no wrap-around
+	})
 }

--- a/core/kapp/market/market_test.go
+++ b/core/kapp/market/market_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/kapp"
+	"github.com/klever-io/klever-go/core/keyValStorage"
 	"github.com/klever-io/klever-go/core/process/kda/kdautils"
 	"github.com/klever-io/klever-go/crypto/hashing/sha256"
+	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/data/state/factory"
@@ -1307,4 +1309,59 @@ func TestMarketKApp_ExecuteBuyMarket_MultiRecipientGuardMidLoop(t *testing.T) {
 	require.NoError(t, err)
 	credited := r1acc.GetBalance(kdautils.KLVIdentifier, false) + r2acc.GetBalance(kdautils.KLVIdentifier, false)
 	require.Equal(t, expectedOne, credited)
+}
+
+func TestMarketKApp_GetMarketEscrowTotal(t *testing.T) {
+	t.Parallel()
+
+	marshalizer := marshal.NewProtoMarshalizer()
+	mk, err := NewMarketKApp(&ArgsNewMarketKApp{
+		Hasher:         &sha256.Sha256{},
+		Marshalizer:    marshalizer,
+		PubkeyConv:     mock.NewPubkeyConverterMock(32),
+		ForkController: mock.NewForkControllerStub(),
+	})
+	require.NoError(t, err)
+
+	orders := []*kapps.MarketOrderData{
+		{ID: []byte("o1"), CurrencyID: []byte("KLV"), CurrentBid: 500, RoyaltiesFixedDeposit: 100},                  // 600
+		{ID: []byte("o2"), CurrencyID: []byte("KLV"), CurrentBid: 1500, RoyaltiesFixedDeposit: 0},                   // 1500
+		{ID: []byte("o3"), CurrencyID: []byte("ABC"), CurrentBid: 9999, RoyaltiesFixedDeposit: 50},                  // 50: deposit only, bid not KLV
+		{ID: []byte("o4"), CurrencyID: []byte("KLV"), CurrentBid: 777, RoyaltiesFixedDeposit: 200, IsClaimed: true}, // 0: claimed
+	}
+
+	orderStore := make(map[string][]byte)
+	leaves := make([]data.KeyValueHolder, 0, len(orders)+1)
+	for _, o := range orders {
+		key := kdautils.ToMarketOrderKey(o.ID)
+		val, errMarshal := marshalizer.Marshal(o)
+		require.NoError(t, errMarshal)
+		orderStore[string(key)] = val
+		leaves = append(leaves, keyValStorage.NewKeyValStorage(key, nil))
+	}
+	// a non-order leaf must be ignored by the MKT prefix filter
+	leaves = append(leaves, keyValStorage.NewKeyValStorage([]byte("OTHER/x"), []byte("ignored")))
+
+	trieStub := &mock.TrieStub{
+		GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+			ch := make(chan data.KeyValueHolder, len(leaves))
+			for _, l := range leaves {
+				ch <- l
+			}
+			close(ch)
+			return ch, nil
+		},
+	}
+	app := &mock.KAppAccountHandlerStub{
+		DataTrieCalled:    func() data.Trie { return trieStub },
+		GetRootHashCalled: func() []byte { return []byte("root") },
+		GetStorageCalled:  func(key []byte) []byte { return orderStore[string(key)] },
+	}
+	require.NoError(t, mk.SetAccountsCacher(&mock.AccountsCacherStub{
+		LoadKAppUncachedCalled: func(_ []byte) (state.KAppAccountHandler, error) { return app, nil },
+	}))
+
+	total, err := mk.GetMarketEscrowTotal()
+	require.NoError(t, err)
+	require.Equal(t, int64(2150), total)
 }

--- a/core/kapp/validators/validators.go
+++ b/core/kapp/validators/validators.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"math"
@@ -1139,6 +1140,53 @@ func (v *validatorsKApp) ClaimPendingRewards(address []byte) (int64, error) {
 	}
 
 	return pendingAmount, nil
+}
+
+// GetPendingRewardsTotal sums every PREW entry in the Validators KApp trie (uncached, O(n)).
+// For low-frequency callers (economics endpoint / per-epoch indexer); KLC-2507 makes it O(1).
+func (v *validatorsKApp) GetPendingRewardsTotal() (int64, error) {
+	app, err := v.accountsCacher.LoadKAppUncached(kapps.ValidatorsKAppAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	dataTrie := app.DataTrie()
+	if check.IfNil(dataTrie) {
+		return 0, nil
+	}
+
+	leavesChannel, err := dataTrie.GetAllLeavesOnChannel(app.GetRootHash(), context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	prefix := []byte(PENDING_REWARDS + kapps.Sp)
+	total := int64(0)
+	for leaf := range leavesChannel {
+		if !bytes.HasPrefix(leaf.Key(), prefix) {
+			continue
+		}
+
+		// Value = 8-byte BE amount + trie tail (see TrackableDataTrie.SaveKeyValue).
+		value := leaf.Value()
+		if len(value) < 8 {
+			continue
+		}
+
+		//nolint:gosec // G115: stored as uint64, summed as int64 for API parity (see getPendingRewards)
+		amount := int64(binary.BigEndian.Uint64(value[:8]))
+		if amount < 0 {
+			log.Warn("GetPendingRewardsTotal: pending reward out of int64 range, skipping")
+			continue
+		}
+		if total > math.MaxInt64-amount { // unreachable; bounded by supply
+			log.Warn("GetPendingRewardsTotal: sum would overflow int64, skipping entry")
+			continue
+		}
+		total += amount
+	}
+
+	return total, nil
 }
 
 func (v *validatorsKApp) PeerAccountToValidatorInfo(pubkey []byte, revoked bool, peerAcc state.PeerAccountHandler) *state.ValidatorInfo {

--- a/core/kapp/validators/validators.go
+++ b/core/kapp/validators/validators.go
@@ -1144,6 +1144,7 @@ func (v *validatorsKApp) ClaimPendingRewards(address []byte) (int64, error) {
 
 // GetPendingRewardsTotal sums every PREW entry in the Validators KApp trie (uncached, O(n)).
 // For low-frequency callers (economics endpoint / per-epoch indexer); KLC-2507 makes it O(1).
+// Mid-walk trie errors are swallowed upstream, so a truncated walk undercounts silently (KLC-2509).
 func (v *validatorsKApp) GetPendingRewardsTotal() (int64, error) {
 	app, err := v.accountsCacher.LoadKAppUncached(kapps.ValidatorsKAppAddress)
 	if err != nil {
@@ -1179,7 +1180,7 @@ func (v *validatorsKApp) GetPendingRewardsTotal() (int64, error) {
 			log.Warn("GetPendingRewardsTotal: pending reward out of int64 range, skipping")
 			continue
 		}
-		if total > math.MaxInt64-amount { // unreachable; bounded by supply
+		if total > math.MaxInt64-amount {
 			log.Warn("GetPendingRewardsTotal: sum would overflow int64, skipping entry")
 			continue
 		}

--- a/core/kapp/validators/validators_test.go
+++ b/core/kapp/validators/validators_test.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -10,7 +11,9 @@ import (
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/kapp"
+	"github.com/klever-io/klever-go/core/keyValStorage"
 	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/data/transaction"
@@ -1217,4 +1220,90 @@ func TestGetPendingRewards_ConcurrentWithEpochRewardsWrites(t *testing.T) {
 		require.NoError(t, errGet)
 	}
 	<-done
+}
+
+func TestValidatorsKApp_GetPendingRewardsTotal(t *testing.T) {
+	v := setupValidatorsKApp(t)
+	addFunctionalCacher(t, v)
+
+	prefix := []byte(PENDING_REWARDS + kapps.Sp)
+	mkVal := func(n uint64) []byte {
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, n)
+		return b
+	}
+	prew := func(name string, amount uint64) data.KeyValueHolder {
+		key := append(append([]byte{}, prefix...), makeAddress(name)...)
+		return keyValStorage.NewKeyValStorage(key, mkVal(amount))
+	}
+
+	leaves := []data.KeyValueHolder{
+		prew("u1", 500000),
+		prew("u2", 1500000),
+		prew("u3", 7),
+		// non-PREW entries must be ignored
+		keyValStorage.NewKeyValStorage(append([]byte(VALIDATOR_PREFIX+kapps.Sp), makeAddress("v1")...), mkVal(999999)),
+		keyValStorage.NewKeyValStorage(append([]byte(VALIDATOR_BLS_PREFIX+kapps.Sp), []byte("bls")...), []byte("x")),
+	}
+
+	trie := &mock.TrieStub{
+		GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+			ch := make(chan data.KeyValueHolder, len(leaves))
+			for _, l := range leaves {
+				ch <- l
+			}
+			close(ch)
+			return ch, nil
+		},
+	}
+	app := &mock.KAppAccountHandlerStub{
+		DataTrieCalled:    func() data.Trie { return trie },
+		GetRootHashCalled: func() []byte { return []byte("root") },
+	}
+	v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppUncachedCalled = func(_ []byte) (state.KAppAccountHandler, error) {
+		return app, nil
+	}
+
+	total, err := v.GetPendingRewardsTotal()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2000007), total)
+}
+
+func TestValidatorsKApp_PendingRewards_ErrorPaths(t *testing.T) {
+	t.Run("GetPendingRewardsTotal: nil data trie returns zero", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		app := &mock.KAppAccountHandlerStub{
+			DataTrieCalled: func() data.Trie { return nil },
+		}
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppUncachedCalled = func(_ []byte) (state.KAppAccountHandler, error) {
+			return app, nil
+		}
+
+		total, err := v.GetPendingRewardsTotal()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), total)
+	})
+
+	t.Run("GetPendingRewardsTotal: GetAllLeavesOnChannel error propagates", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		expectedErr := errors.New("trie error")
+		trie := &mock.TrieStub{
+			GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+				return nil, expectedErr
+			},
+		}
+		app := &mock.KAppAccountHandlerStub{
+			DataTrieCalled:    func() data.Trie { return trie },
+			GetRootHashCalled: func() []byte { return []byte("root") },
+		}
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppUncachedCalled = func(_ []byte) (state.KAppAccountHandler, error) {
+			return app, nil
+		}
+
+		total, err := v.GetPendingRewardsTotal()
+		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, int64(0), total)
+	})
 }

--- a/core/kapp/validators/validators_test.go
+++ b/core/kapp/validators/validators_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/klever-io/klever-go/common"
@@ -1305,5 +1306,60 @@ func TestValidatorsKApp_PendingRewards_ErrorPaths(t *testing.T) {
 		total, err := v.GetPendingRewardsTotal()
 		assert.Equal(t, expectedErr, err)
 		assert.Equal(t, int64(0), total)
+	})
+
+	t.Run("GetPendingRewardsTotal: LoadKAppUncached error propagates", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		expectedErr := errors.New("load failed")
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppUncachedCalled = func(_ []byte) (state.KAppAccountHandler, error) {
+			return nil, expectedErr
+		}
+
+		total, err := v.GetPendingRewardsTotal()
+		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, int64(0), total)
+	})
+
+	t.Run("GetPendingRewardsTotal: short, out-of-range, and overflowing values are skipped", func(t *testing.T) {
+		v := setupValidatorsKApp(t)
+		addFunctionalCacher(t, v)
+		prefix := []byte(PENDING_REWARDS + kapps.Sp)
+		mkVal := func(n uint64) []byte {
+			b := make([]byte, 8)
+			binary.BigEndian.PutUint64(b, n)
+			return b
+		}
+		prew := func(name string, value []byte) data.KeyValueHolder {
+			key := append(append([]byte{}, prefix...), makeAddress(name)...)
+			return keyValStorage.NewKeyValStorage(key, value)
+		}
+		leaves := []data.KeyValueHolder{
+			prew("short", []byte{0x01}),                // < 8 bytes, skipped
+			prew("neg", mkVal(uint64(1)<<63)),          // negative as int64, skipped
+			prew("max", mkVal(uint64(math.MaxInt64))),  // fills the total
+			prew("over", mkVal(uint64(math.MaxInt64))), // would overflow, skipped
+		}
+		trie := &mock.TrieStub{
+			GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+				ch := make(chan data.KeyValueHolder, len(leaves))
+				for _, l := range leaves {
+					ch <- l
+				}
+				close(ch)
+				return ch, nil
+			},
+		}
+		app := &mock.KAppAccountHandlerStub{
+			DataTrieCalled:    func() data.Trie { return trie },
+			GetRootHashCalled: func() []byte { return []byte("root") },
+		}
+		v.accountsCacher.(*mock.AccountsCacherStub).LoadKAppUncachedCalled = func(_ []byte) (state.KAppAccountHandler, error) {
+			return app, nil
+		}
+
+		total, err := v.GetPendingRewardsTotal()
+		require.NoError(t, err)
+		assert.Equal(t, int64(math.MaxInt64), total)
 	})
 }

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -1807,7 +1807,7 @@ func (ei *elasticProcessor) SaveEpochInfo(epoch uint32, validators []kapp.Valida
 	if err != nil {
 		return err
 	}
-	if len(klvStakingBytes) == 0 {
+	if len(kfiStakingBytes) == 0 {
 		return common.ErrEmptyString
 	}
 
@@ -1820,10 +1820,10 @@ func (ei *elasticProcessor) SaveEpochInfo(epoch uint32, validators []kapp.Valida
 	epochInfo := &data.EpochInfo{
 		Epoch:                epoch,
 		Validators:           validatorsInfo,
-		KFICirculatingSupply: klvKDA.CirculatingSupply,
-		KLVTotalStaked:       klvStaking.TotalStaked,
-		KLVCirculatingSupply: kfiKDA.CirculatingSupply,
+		KFICirculatingSupply: kfiKDA.CirculatingSupply,
+		KLVCirculatingSupply: klvKDA.CirculatingSupply,
 		KFITotalStaked:       kfiStaking.TotalStaked,
+		KLVTotalStaked:       klvStaking.TotalStaked,
 	}
 
 	var buff bytes.Buffer

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -1713,6 +1713,51 @@ func (ei *elasticProcessor) SaveEpochInfo(epoch uint32, validators []kapp.Valida
 		return nil
 	}
 
+	validatorsInfo := ei.buildEpochValidatorsInfo(validators)
+
+	kdaKapp, err := ei.loadKAppHandler(kapps.KDAKAppAddress)
+	if err != nil {
+		return err
+	}
+	stakingKapp, err := ei.loadKAppHandler(kapps.StakingKAppAddress)
+	if err != nil {
+		return err
+	}
+
+	klvKey := kdautils.ToKDAKey([]byte(kdautils.KLVIdentifier), nil)
+	kfiKey := kdautils.ToKDAKey([]byte(kdautils.KFIIdentifier), nil)
+
+	klvKDA, err := ei.readEpochKDAData(kdaKapp, klvKey)
+	if err != nil {
+		return err
+	}
+	klvStaking, err := ei.readEpochStakingData(stakingKapp, klvKey)
+	if err != nil {
+		return err
+	}
+	kfiKDA, err := ei.readEpochKDAData(kdaKapp, kfiKey)
+	if err != nil {
+		return err
+	}
+	kfiStaking, err := ei.readEpochStakingData(stakingKapp, kfiKey)
+	if err != nil {
+		return err
+	}
+
+	epochInfo := &data.EpochInfo{
+		Epoch:                epoch,
+		Validators:           validatorsInfo,
+		KFICirculatingSupply: kfiKDA.CirculatingSupply,
+		KLVCirculatingSupply: klvKDA.CirculatingSupply,
+		KFITotalStaked:       kfiStaking.TotalStaked,
+		KLVTotalStaked:       klvStaking.TotalStaked,
+	}
+
+	return ei.indexEpochInfo(epoch, epochInfo)
+}
+
+// buildEpochValidatorsInfo maps validator account handlers into the indexer's ValidatorInfo docs.
+func (ei *elasticProcessor) buildEpochValidatorsInfo(validators []kapp.ValidatorAccountInfoHandler) []*data.ValidatorInfo {
 	var validatorsInfo []*data.ValidatorInfo
 	for _, val := range validators {
 		validatorsInfo = append(validatorsInfo, &data.ValidatorInfo{
@@ -1737,106 +1782,65 @@ func (ei *elasticProcessor) SaveEpochInfo(epoch uint32, validators []kapp.Valida
 			URIs:           ei.convertURIs(val.GetURIs()),
 		})
 	}
+	return validatorsInfo
+}
 
-	//GET KLV and KFI total staked and circulation supply
-	assetKDAaccount, err := ei.kappsDB.LoadAccount(kapps.KDAKAppAddress)
+// loadKAppHandler loads a KApp account and asserts it to the handler interface.
+func (ei *elasticProcessor) loadKAppHandler(address []byte) (state.KAppAccountHandler, error) {
+	account, err := ei.kappsDB.LoadAccount(address)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	kdaKapp, ok := assetKDAaccount.(state.KAppAccountHandler)
+	handler, ok := account.(state.KAppAccountHandler)
 	if !ok {
-		return common.ErrWrongTypeAssertion
+		return nil, common.ErrWrongTypeAssertion
 	}
+	return handler, nil
+}
 
-	stakingKDAaccount, err := ei.kappsDB.LoadAccount(kapps.StakingKAppAddress)
+// readEpochKDAData reads and unmarshals a KDAData record; a missing record is an error.
+func (ei *elasticProcessor) readEpochKDAData(app state.KAppAccountHandler, key []byte) (*kapps.KDAData, error) {
+	raw, err := app.DataTrieTracker().RetrieveValue(key)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	stakingKapp, ok := stakingKDAaccount.(state.KAppAccountHandler)
-	if !ok {
-		return common.ErrWrongTypeAssertion
+	if len(raw) == 0 {
+		return nil, common.ErrEmptyString
 	}
+	kda := &kapps.KDAData{}
+	if err := ei.marshalizer.Unmarshal(kda, raw); err != nil {
+		return nil, err
+	}
+	return kda, nil
+}
 
-	//KLV
-	klvKey := kdautils.ToKDAKey([]byte(kdautils.KLVIdentifier), nil)
-	klvKDABytes, err := kdaKapp.DataTrieTracker().RetrieveValue(klvKey)
+// readEpochStakingData reads and unmarshals a StakingData record; a missing record is an error.
+func (ei *elasticProcessor) readEpochStakingData(app state.KAppAccountHandler, key []byte) (*kapps.StakingData, error) {
+	raw, err := app.DataTrieTracker().RetrieveValue(key)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if len(klvKDABytes) == 0 {
-		return common.ErrEmptyString
+	if len(raw) == 0 {
+		return nil, common.ErrEmptyString
 	}
-	klvKDA := &kapps.KDAData{}
-	err = ei.marshalizer.Unmarshal(klvKDA, klvKDABytes)
-	if err != nil {
-		return err
+	staking := &kapps.StakingData{}
+	if err := ei.marshalizer.Unmarshal(staking, raw); err != nil {
+		return nil, err
 	}
+	return staking, nil
+}
 
-	klvStakingBytes, err := stakingKapp.DataTrieTracker().RetrieveValue(klvKey)
-	if err != nil {
-		return err
-	}
-	if len(klvStakingBytes) == 0 {
-		return common.ErrEmptyString
-	}
-
-	klvStaking := &kapps.StakingData{}
-	err = ei.marshalizer.Unmarshal(klvStaking, klvStakingBytes)
-	if err != nil {
-		return err
-	}
-
-	//KFI
-	kfiKey := kdautils.ToKDAKey([]byte(kdautils.KFIIdentifier), nil)
-	kfiKDABytes, err := kdaKapp.DataTrieTracker().RetrieveValue(kfiKey)
-	if err != nil {
-		return err
-	}
-	if len(kfiKDABytes) == 0 {
-		return common.ErrEmptyString
-	}
-	kfiKDA := &kapps.KDAData{}
-	err = ei.marshalizer.Unmarshal(kfiKDA, kfiKDABytes)
-	if err != nil {
-		return err
-	}
-
-	kfiStakingBytes, err := stakingKapp.DataTrieTracker().RetrieveValue(kfiKey)
-	if err != nil {
-		return err
-	}
-	if len(kfiStakingBytes) == 0 {
-		return common.ErrEmptyString
-	}
-
-	kfiStaking := &kapps.StakingData{}
-	err = ei.marshalizer.Unmarshal(kfiStaking, kfiStakingBytes)
-	if err != nil {
-		return err
-	}
-
-	epochInfo := &data.EpochInfo{
-		Epoch:                epoch,
-		Validators:           validatorsInfo,
-		KFICirculatingSupply: kfiKDA.CirculatingSupply,
-		KLVCirculatingSupply: klvKDA.CirculatingSupply,
-		KFITotalStaked:       kfiStaking.TotalStaked,
-		KLVTotalStaked:       klvStaking.TotalStaked,
-	}
-
-	var buff bytes.Buffer
-
+// indexEpochInfo marshals the epoch document and writes it to the epoch index.
+func (ei *elasticProcessor) indexEpochInfo(epoch uint32, epochInfo *data.EpochInfo) error {
 	marshalizedEpochInfo, err := json.Marshal(epochInfo)
 	if err != nil {
 		log.Debug("indexer: marshal", "error", "could not marshal epoch info")
 		return err
 	}
 
+	var buff bytes.Buffer
 	buff.Grow(len(marshalizedEpochInfo))
-	_, err = buff.Write(marshalizedEpochInfo)
-	if err != nil {
+	if _, err = buff.Write(marshalizedEpochInfo); err != nil {
 		log.Warn("elastic search: epoch, write", "error", err.Error())
 	}
 

--- a/indexer/elasticProcessor_test.go
+++ b/indexer/elasticProcessor_test.go
@@ -13,9 +13,11 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/kapp"
+	"github.com/klever-io/klever-go/core/process/kda/kdautils"
 	nodeData "github.com/klever-io/klever-go/data"
 	dataBlock "github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/indexer"
@@ -1594,5 +1596,88 @@ func TestBuildAccountInfo(t *testing.T) {
 		require.NotNil(t, result)
 		// Base allowance (500) + pending rewards (250) = 750
 		require.Equal(t, int64(750), result.Allowance)
+	})
+}
+
+func TestElasticProcessor_SaveEpochInfo(t *testing.T) {
+	t.Parallel()
+
+	klvKey := string(kdautils.ToKDAKey(kdautils.KLVIdentifier, nil))
+	kfiKey := string(kdautils.ToKDAKey([]byte(kdautils.KFIIdentifier), nil))
+
+	// mustMarshal encodes with MarshalizerMock, matching createMockElasticProcessorArgs's marshalizer
+	// (the one SaveEpochInfo decodes with).
+	mustMarshal := func(t *testing.T, obj interface{}) []byte {
+		raw, err := (&mock.MarshalizerMock{}).Marshal(obj)
+		require.NoError(t, err)
+		return raw
+	}
+
+	newEpochProcessor := func(t *testing.T, stakingRecords map[string][]byte, capture **esapi.IndexRequest) *elasticProcessor {
+		args := createMockElasticProcessorArgs()
+		args.EnabledIndexes = map[string]struct{}{epochIndex: {}}
+
+		kdaRecords := map[string][]byte{
+			klvKey: mustMarshal(t, &kapps.KDAData{CirculatingSupply: 9_000}),
+			kfiKey: mustMarshal(t, &kapps.KDAData{CirculatingSupply: 21_000}),
+		}
+		newApp := func(records map[string][]byte) state.AccountHandler {
+			return &mock.KAppAccountHandlerStub{
+				DataTrieTrackerCalled: func() state.DataTrieTracker {
+					return &mock.DataTrieTrackerStub{RetrieveValueCalled: func(key []byte) ([]byte, error) {
+						return records[string(key)], nil
+					}}
+				},
+			}
+		}
+		apps := map[string]state.AccountHandler{
+			string(kapps.KDAKAppAddress):     newApp(kdaRecords),
+			string(kapps.StakingKAppAddress): newApp(stakingRecords),
+		}
+		args.KappsDB = &mock.AccountsStub{LoadAccountCalled: func(address []byte) (state.AccountHandler, error) {
+			app, ok := apps[string(address)]
+			require.True(t, ok, "unexpected KApp address")
+			return app, nil
+		}}
+
+		dbWriter := &imock.DatabaseWriterStub{DoRequestCalled: func(req *esapi.IndexRequest) error {
+			*capture = req
+			return nil
+		}}
+		return newTestElasticSearchDatabase(dbWriter, args)
+	}
+
+	t.Run("indexes per-asset supply and staking figures", func(t *testing.T) {
+		t.Parallel()
+		var captured *esapi.IndexRequest
+		ep := newEpochProcessor(t, map[string][]byte{
+			klvKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 5_000}),
+			kfiKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 800}),
+		}, &captured)
+
+		require.NoError(t, ep.SaveEpochInfo(7, nil))
+		require.NotNil(t, captured)
+		require.Equal(t, epochIndex, captured.Index)
+		require.Equal(t, "7", captured.DocumentID)
+
+		body, err := io.ReadAll(captured.Body)
+		require.NoError(t, err)
+		doc := map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(body, &doc))
+		require.EqualValues(t, 9_000, doc["klvCirculationSupply"])
+		require.EqualValues(t, 21_000, doc["kfiCirculationSupply"])
+		require.EqualValues(t, 5_000, doc["klvTotalStaked"])
+		require.EqualValues(t, 800, doc["kfiTotalStaked"])
+	})
+
+	t.Run("missing KFI staking record fails loudly", func(t *testing.T) {
+		t.Parallel()
+		var captured *esapi.IndexRequest
+		ep := newEpochProcessor(t, map[string][]byte{
+			klvKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 5_000}),
+		}, &captured)
+
+		require.ErrorIs(t, ep.SaveEpochInfo(7, nil), common.ErrEmptyString)
+		require.Nil(t, captured)
 	})
 }

--- a/network/api/errors/errors.go
+++ b/network/api/errors/errors.go
@@ -62,6 +62,9 @@ var ErrGetProposalParameters = errors.New("error getting proposal parameters")
 // ErrGetEconomics signals that an error occurred while getting economics data
 var ErrGetEconomics = errors.New("error getting economics data")
 
+// ErrGetAccountTotals signals that an error occurred while getting account totals data
+var ErrGetAccountTotals = errors.New("error getting account totals data")
+
 // ErrInvalidBlockNonce signals an invalid block nonce was provided
 var ErrInvalidBlockNonce = errors.New("invalid block nonce")
 

--- a/network/api/errors/errors.go
+++ b/network/api/errors/errors.go
@@ -59,6 +59,9 @@ var ErrGetPidInfo = errors.New("error getting peer id info")
 // ErrGetProposalParameters signals that an error occurred while getting proposal parameters
 var ErrGetProposalParameters = errors.New("error getting proposal parameters")
 
+// ErrGetEconomics signals that an error occurred while getting economics data
+var ErrGetEconomics = errors.New("error getting economics data")
+
 // ErrInvalidBlockNonce signals an invalid block nonce was provided
 var ErrInvalidBlockNonce = errors.New("invalid block nonce")
 

--- a/network/api/mock/facade.go
+++ b/network/api/mock/facade.go
@@ -31,6 +31,7 @@ type Facade struct {
 	BalanceHandler                 func(string, string) (*models.BalanceResponse, error)
 	GetUserKDAHandler              func(string, string) (*kapps.UserKDA, error)
 	RewardsAvailableToClaimHandler func(address string, assetId string) (*models.AvailableClaimResponse, error)
+	GetEconomicsHandler            func() (*models.EconomicsResponse, error)
 	StatusMetricsHandler           func() core.StatusMetricsHandler
 	GetNodeOverviewHandler         func() (models.NodeOverview, error)
 	ValidatorStatisticsHandler     func() (map[string]*state.ValidatorApiResponse, error)
@@ -245,6 +246,13 @@ func (f *Facade) GetNextNonce(address string) (*models.AccountNonceResponse, err
 
 func (f *Facade) GetProposalParameters() (map[int32]*kapps.Parameter, error) {
 	return make(map[int32]*kapps.Parameter), nil
+}
+
+func (f *Facade) GetEconomics() (*models.EconomicsResponse, error) {
+	if f.GetEconomicsHandler != nil {
+		return f.GetEconomicsHandler()
+	}
+	return &models.EconomicsResponse{}, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/network/api/mock/facade.go
+++ b/network/api/mock/facade.go
@@ -32,6 +32,7 @@ type Facade struct {
 	GetUserKDAHandler              func(string, string) (*kapps.UserKDA, error)
 	RewardsAvailableToClaimHandler func(address string, assetId string) (*models.AvailableClaimResponse, error)
 	GetEconomicsHandler            func() (*models.EconomicsResponse, error)
+	GetAccountTotalsHandler        func() (*models.AccountTotalsResponse, error)
 	StatusMetricsHandler           func() core.StatusMetricsHandler
 	GetNodeOverviewHandler         func() (models.NodeOverview, error)
 	ValidatorStatisticsHandler     func() (map[string]*state.ValidatorApiResponse, error)
@@ -253,6 +254,13 @@ func (f *Facade) GetEconomics() (*models.EconomicsResponse, error) {
 		return f.GetEconomicsHandler()
 	}
 	return &models.EconomicsResponse{}, nil
+}
+
+func (f *Facade) GetAccountTotals() (*models.AccountTotalsResponse, error) {
+	if f.GetAccountTotalsHandler != nil {
+		return f.GetAccountTotalsHandler()
+	}
+	return &models.AccountTotalsResponse{}, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/network/api/models/accountTotals.go
+++ b/network/api/models/accountTotals.go
@@ -1,0 +1,9 @@
+package models
+
+// AccountTotalsResponse holds aggregates over all user accounts (count + inline KLV Balance and
+// Allowance totals). Frozen/unfrozen are excluded (sub-trie; totalStaked covers frozen). See KLC-2506.
+type AccountTotalsResponse struct {
+	AccountCount   int64 `json:"accountCount"`
+	BalanceTotal   int64 `json:"balanceTotal"`
+	AllowanceTotal int64 `json:"allowanceTotal"`
+}

--- a/network/api/models/economics.go
+++ b/network/api/models/economics.go
@@ -1,7 +1,7 @@
 package models
 
 // EconomicsResponse holds live KLV supply figures plus node-state held aggregates
-// (pending rewards, market escrow, fees-pool KLV, system-account KLV). See KLC-2506.
+// (pending rewards, market escrow, fees-pool KLV, FPR pool KLV, system-account KLV). See KLC-2506.
 type EconomicsResponse struct {
 	InitialSupply           int64 `json:"initialSupply"`
 	MaxSupply               int64 `json:"maxSupply"`

--- a/network/api/models/economics.go
+++ b/network/api/models/economics.go
@@ -1,0 +1,17 @@
+package models
+
+// EconomicsResponse holds live KLV supply figures plus node-state held aggregates
+// (pending rewards, market escrow, fees-pool KLV, system-account KLV). See KLC-2506.
+type EconomicsResponse struct {
+	InitialSupply           int64 `json:"initialSupply"`
+	MaxSupply               int64 `json:"maxSupply"`
+	MintedValue             int64 `json:"mintedValue"`
+	BurnedValue             int64 `json:"burnedValue"`
+	CirculatingSupply       int64 `json:"circulatingSupply"`
+	TotalStaked             int64 `json:"totalStaked"`
+	PendingRewardsTotal     int64 `json:"pendingRewardsTotal"`
+	MarketEscrowTotal       int64 `json:"marketEscrowTotal"`
+	FeesPoolKLVTotal        int64 `json:"feesPoolKlvTotal"`
+	FPRPoolTotal            int64 `json:"fprPoolTotal"`
+	SystemAccountKLVBalance int64 `json:"systemAccountKlvBalance"`
+}

--- a/network/api/models/economics.go
+++ b/network/api/models/economics.go
@@ -1,7 +1,7 @@
 package models
 
-// EconomicsResponse holds live KLV supply figures plus node-state held aggregates
-// (pending rewards, market escrow, fees-pool KLV, FPR pool KLV, system-account KLV). See KLC-2506.
+// EconomicsResponse holds live KLV supply figures plus node-state held aggregates. All held aggregates
+// are KLV already inside CirculatingSupply. See KLC-2506.
 type EconomicsResponse struct {
 	InitialSupply           int64 `json:"initialSupply"`
 	MaxSupply               int64 `json:"maxSupply"`
@@ -13,5 +13,6 @@ type EconomicsResponse struct {
 	MarketEscrowTotal       int64 `json:"marketEscrowTotal"`
 	FeesPoolKLVTotal        int64 `json:"feesPoolKlvTotal"`
 	FPRPoolTotal            int64 `json:"fprPoolTotal"`
+	AccumulatedFeesTotal    int64 `json:"accumulatedFeesTotal"`
 	SystemAccountKLVBalance int64 `json:"systemAccountKlvBalance"`
 }

--- a/network/api/network/routes.go
+++ b/network/api/network/routes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/kapps"
 	"github.com/klever-io/klever-go/network/api/errors"
+	"github.com/klever-io/klever-go/network/api/models"
 	"github.com/klever-io/klever-go/network/api/shared"
 	"github.com/klever-io/klever-go/network/api/wrapper"
 )
@@ -23,6 +24,7 @@ const (
 type FacadeHandler interface {
 	StatusMetrics() core.StatusMetricsHandler
 	GetProposalParameters() (map[int32]*kapps.Parameter, error)
+	GetEconomics() (*models.EconomicsResponse, error)
 	IsInterfaceNil() bool
 }
 
@@ -36,6 +38,7 @@ func Routes(router *wrapper.RouterWrapper) {
 	router.RegisterHandler(http.MethodGet, getConfigPath, GetNetworkConfig)
 	router.RegisterHandler(http.MethodGet, getStatusPath, GetNetworkStatus)
 	router.RegisterHandler(http.MethodGet, proposalParametersPath, GetProposalParameters)
+	router.RegisterHandler(http.MethodGet, economicsPath, GetEconomics)
 }
 
 func getFacade(c *gin.Context) (FacadeHandler, bool) {
@@ -158,36 +161,38 @@ func GetProposalParameters(c *gin.Context) {
 	)
 }
 
-// TODO: Total Staked Value Query
-// EconomicsMetrics is the endpoint that will return the economics data such as total supply
-// func EconomicsMetrics(c *gin.Context) {
-// 	facade, ok := getFacade(c)
-// 	if !ok {
-// 		return
-// 	}
+// @Summary returns KLV economics: supply figures plus node-state held aggregates
+// @Tags Network
+// @Produce json
+// @Success 200 object shared.GenericAPIResponse{data=object{economics=models.EconomicsResponse}} "ok"
+// @Failure 500 object shared.GenericAPIResponse "internal error"
+// @Router /network/economics [get]
+// GetEconomics returns live KLV supply figures and node-state held aggregates. See KLC-2506.
+func GetEconomics(c *gin.Context) {
+	facade, ok := getFacade(c)
+	if !ok {
+		return
+	}
 
-// 	stakeValues, err := facade.GetTotalStakedValue()
-// 	if err != nil {
-// 		c.JSON(
-// 			http.StatusInternalServerError,
-// 			shared.GenericAPIResponse{
-// 				Data:  nil,
-// 				Error: err.Error(),
-// 				Code:  shared.ReturnCodeInternalError,
-// 			},
-// 		)
-// 		return
-// 	}
+	economics, err := facade.GetEconomics()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetEconomics.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
 
-// 	metrics := facade.StatusMetrics().EconomicsMetrics()
-// 	metrics[core.MetricTotalStakedValue] = stakeValues
-
-// 	c.JSON(
-// 		http.StatusOK,
-// 		shared.GenericAPIResponse{
-// 			Data:  gin.H{"metrics": metrics},
-// 			Error: "",
-// 			Code:  shared.ReturnCodeSuccess,
-// 		},
-// 	)
-// }
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"economics": economics},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}

--- a/network/api/network/routes.go
+++ b/network/api/network/routes.go
@@ -19,6 +19,9 @@ const (
 	economicsPath          = "/economics"
 	accountTotalsPath      = "/account-totals"
 	proposalParametersPath = "/network-parameters"
+
+	// errWrapFormat wraps a sentinel API error with the underlying cause in an Error response.
+	errWrapFormat = "%s: %s"
 )
 
 // FacadeHandler interface defines methods that can be used by the gin webserver
@@ -139,7 +142,7 @@ func GetProposalParameters(c *gin.Context) {
 			http.StatusInternalServerError,
 			shared.GenericAPIResponse{
 				Data:  nil,
-				Error: fmt.Sprintf("%s: %s", errors.ErrGetProposalParameters.Error(), err.Error()),
+				Error: fmt.Sprintf(errWrapFormat, errors.ErrGetProposalParameters.Error(), err.Error()),
 				Code:  shared.ReturnCodeInternalError,
 			},
 		)
@@ -183,7 +186,7 @@ func GetEconomics(c *gin.Context) {
 			http.StatusInternalServerError,
 			shared.GenericAPIResponse{
 				Data:  nil,
-				Error: fmt.Sprintf("%s: %s", errors.ErrGetEconomics.Error(), err.Error()),
+				Error: fmt.Sprintf(errWrapFormat, errors.ErrGetEconomics.Error(), err.Error()),
 				Code:  shared.ReturnCodeInternalError,
 			},
 		)
@@ -219,7 +222,7 @@ func GetAccountTotals(c *gin.Context) {
 			http.StatusInternalServerError,
 			shared.GenericAPIResponse{
 				Data:  nil,
-				Error: fmt.Sprintf("%s: %s", errors.ErrGetAccountTotals.Error(), err.Error()),
+				Error: fmt.Sprintf(errWrapFormat, errors.ErrGetAccountTotals.Error(), err.Error()),
 				Code:  shared.ReturnCodeInternalError,
 			},
 		)

--- a/network/api/network/routes.go
+++ b/network/api/network/routes.go
@@ -17,6 +17,7 @@ const (
 	getConfigPath          = "/config"
 	getStatusPath          = "/status"
 	economicsPath          = "/economics"
+	accountTotalsPath      = "/account-totals"
 	proposalParametersPath = "/network-parameters"
 )
 
@@ -25,6 +26,7 @@ type FacadeHandler interface {
 	StatusMetrics() core.StatusMetricsHandler
 	GetProposalParameters() (map[int32]*kapps.Parameter, error)
 	GetEconomics() (*models.EconomicsResponse, error)
+	GetAccountTotals() (*models.AccountTotalsResponse, error)
 	IsInterfaceNil() bool
 }
 
@@ -39,6 +41,7 @@ func Routes(router *wrapper.RouterWrapper) {
 	router.RegisterHandler(http.MethodGet, getStatusPath, GetNetworkStatus)
 	router.RegisterHandler(http.MethodGet, proposalParametersPath, GetProposalParameters)
 	router.RegisterHandler(http.MethodGet, economicsPath, GetEconomics)
+	router.RegisterHandler(http.MethodGet, accountTotalsPath, GetAccountTotals)
 }
 
 func getFacade(c *gin.Context) (FacadeHandler, bool) {
@@ -191,6 +194,42 @@ func GetEconomics(c *gin.Context) {
 		http.StatusOK,
 		shared.GenericAPIResponse{
 			Data:  gin.H{"economics": economics},
+			Error: "",
+			Code:  shared.ReturnCodeSuccess,
+		},
+	)
+}
+
+// @Summary returns aggregates over all user accounts (count, KLV balance, allowance)
+// @Tags Network
+// @Produce json
+// @Success 200 object shared.GenericAPIResponse{data=object{accountTotals=models.AccountTotalsResponse}} "ok"
+// @Failure 500 object shared.GenericAPIResponse "internal error"
+// @Router /network/account-totals [get]
+// GetAccountTotals returns aggregates over every user account via a full trie walk. See KLC-2506.
+func GetAccountTotals(c *gin.Context) {
+	facade, ok := getFacade(c)
+	if !ok {
+		return
+	}
+
+	accountTotals, err := facade.GetAccountTotals()
+	if err != nil {
+		c.JSON(
+			http.StatusInternalServerError,
+			shared.GenericAPIResponse{
+				Data:  nil,
+				Error: fmt.Sprintf("%s: %s", errors.ErrGetAccountTotals.Error(), err.Error()),
+				Code:  shared.ReturnCodeInternalError,
+			},
+		)
+		return
+	}
+
+	c.JSON(
+		http.StatusOK,
+		shared.GenericAPIResponse{
+			Data:  gin.H{"accountTotals": accountTotals},
 			Error: "",
 			Code:  shared.ReturnCodeSuccess,
 		},

--- a/network/api/network/routes_test.go
+++ b/network/api/network/routes_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/klever-io/klever-go/network/api/errors"
 	"github.com/klever-io/klever-go/network/api/middleware"
 	"github.com/klever-io/klever-go/network/api/mock"
+	"github.com/klever-io/klever-go/network/api/models"
 	"github.com/klever-io/klever-go/network/api/network"
 	"github.com/klever-io/klever-go/network/api/shared"
 	"github.com/klever-io/klever-go/network/api/wrapper"
@@ -187,4 +188,67 @@ func getRoutesConfig() config.APIRoutesConfig {
 			},
 		},
 	}
+}
+
+func TestGetEconomics_NilContextShouldError(t *testing.T) {
+	t.Parallel()
+	ws := startNodeServer(nil)
+
+	req, _ := http.NewRequest("GET", "/network/economics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+	assert.True(t, strings.Contains(response.Error, errors.ErrNilAppContext.Error()))
+}
+
+func TestGetEconomics_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{}
+	facade.GetEconomicsHandler = func() (*models.EconomicsResponse, error) {
+		return &models.EconomicsResponse{
+			CirculatingSupply:   9633939185032557,
+			TotalStaked:         3871472571301027,
+			PendingRewardsTotal: 15334122011363,
+		}, nil
+	}
+
+	ws := startNodeServer(&facade)
+	req, _ := http.NewRequest("GET", "/network/economics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	respBytes, _ := io.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Contains(t, respStr, "pendingRewardsTotal")
+	assert.Contains(t, respStr, "15334122011363")
+	assert.Contains(t, respStr, "circulatingSupply")
+}
+
+func TestGetEconomics_FacadeErrorShouldReturnInternalError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := fmt.Errorf("some facade error")
+	facade := mock.Facade{}
+	facade.GetEconomicsHandler = func() (*models.EconomicsResponse, error) {
+		return nil, expectedErr
+	}
+
+	ws := startNodeServer(&facade)
+	req, _ := http.NewRequest("GET", "/network/economics", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+	assert.Contains(t, response.Error, errors.ErrGetEconomics.Error())
+	assert.Contains(t, response.Error, expectedErr.Error())
 }

--- a/network/api/network/routes_test.go
+++ b/network/api/network/routes_test.go
@@ -183,6 +183,7 @@ func getRoutesConfig() config.APIRoutesConfig {
 					{Name: "/config", Open: true},
 					{Name: "/status", Open: true},
 					{Name: "/economics", Open: true},
+					{Name: "/account-totals", Open: true},
 					{Name: "/total-staked", Open: true},
 				},
 			},
@@ -250,5 +251,54 @@ func TestGetEconomics_FacadeErrorShouldReturnInternalError(t *testing.T) {
 	loadResponse(resp.Body, &response)
 	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
 	assert.Contains(t, response.Error, errors.ErrGetEconomics.Error())
+	assert.Contains(t, response.Error, expectedErr.Error())
+}
+
+func TestGetAccountTotals_ShouldWork(t *testing.T) {
+	t.Parallel()
+
+	facade := mock.Facade{}
+	facade.GetAccountTotalsHandler = func() (*models.AccountTotalsResponse, error) {
+		return &models.AccountTotalsResponse{
+			AccountCount:   175551,
+			BalanceTotal:   6101789314059000,
+			AllowanceTotal: 61185514904078,
+		}, nil
+	}
+
+	ws := startNodeServer(&facade)
+	req, _ := http.NewRequest("GET", "/network/account-totals", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	respBytes, _ := io.ReadAll(resp.Body)
+	respStr := string(respBytes)
+	assert.Contains(t, respStr, "accountCount")
+	assert.Contains(t, respStr, "allowanceTotal")
+	assert.Contains(t, respStr, "61185514904078")
+}
+
+func TestGetAccountTotals_FacadeErrorShouldReturnInternalError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := fmt.Errorf("some facade error")
+	facade := mock.Facade{}
+	facade.GetAccountTotalsHandler = func() (*models.AccountTotalsResponse, error) {
+		return nil, expectedErr
+	}
+
+	ws := startNodeServer(&facade)
+	req, _ := http.NewRequest("GET", "/network/account-totals", nil)
+	resp := httptest.NewRecorder()
+	ws.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+
+	response := shared.GenericAPIResponse{}
+	loadResponse(resp.Body, &response)
+	assert.Equal(t, shared.ReturnCodeInternalError, response.Code)
+	assert.Contains(t, response.Error, errors.ErrGetAccountTotals.Error())
 	assert.Contains(t, response.Error, expectedErr.Error())
 }

--- a/node/blockCache.go
+++ b/node/blockCache.go
@@ -1,11 +1,14 @@
 package node
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/tools/check"
 )
+
+var errNilComputeResult = errors.New("blockCache: compute returned nil without error")
 
 // blockCache memoizes a value per block, keyed on the chain header nonce: callers within a block share
 // one result; the first call after a new block recomputes. The returned pointer is shared — read-only.
@@ -34,6 +37,9 @@ func (c *blockCache[T]) get(blkc data.ChainHandler, compute func() (*T, error)) 
 	computed, err := compute()
 	if err != nil {
 		return nil, err
+	}
+	if computed == nil {
+		return nil, errNilComputeResult
 	}
 
 	c.cached = computed

--- a/node/blockCache.go
+++ b/node/blockCache.go
@@ -1,0 +1,44 @@
+package node
+
+import (
+	"sync"
+
+	"github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/tools/check"
+)
+
+// blockCache memoizes a value per block, keyed on the chain header nonce: callers within a block share
+// one result; the first call after a new block recomputes. The returned pointer is shared — read-only.
+type blockCache[T any] struct {
+	mu     sync.Mutex
+	nonce  uint64
+	valid  bool
+	cached *T
+}
+
+// get returns the cached value, recomputing under lock when the block advanced (so concurrent callers
+// on a fresh block share one compute).
+func (c *blockCache[T]) get(blkc data.ChainHandler, compute func() (*T, error)) (*T, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	currentNonce := uint64(0)
+	if header := blkc.GetCurrentBlockHeader(); !check.IfNil(header) {
+		currentNonce = header.GetNonce()
+	}
+
+	if c.valid && c.nonce == currentNonce && c.cached != nil {
+		return c.cached, nil
+	}
+
+	computed, err := compute()
+	if err != nil {
+		return nil, err
+	}
+
+	c.cached = computed
+	c.nonce = currentNonce
+	c.valid = true
+
+	return computed, nil
+}

--- a/node/blockCache.go
+++ b/node/blockCache.go
@@ -1,36 +1,40 @@
 package node
 
 import (
-	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/tools/check"
 )
 
-var errNilComputeResult = errors.New("blockCache: compute returned nil without error")
-
-// blockCache memoizes a value per block, keyed on the chain header nonce: callers within a block share
-// one result; the first call after a new block recomputes. The returned pointer is shared — read-only.
+// blockCache memoizes a value per block, keyed on header nonce plus state root: callers within a
+// block share one result; a new block — or a reorg swapping the block at the same nonce — triggers
+// a recompute. The returned pointer is shared — read-only.
 type blockCache[T any] struct {
 	mu     sync.Mutex
-	nonce  uint64
-	valid  bool
+	key    string
 	cached *T
 }
 
-// get returns the cached value, recomputing under lock when the block advanced (so concurrent callers
+// blockCacheKey derives the memoization key. The sentinel keeps the no-header state distinct from
+// any real block (genesis also sits at nonce 0).
+func blockCacheKey(blkc data.ChainHandler) string {
+	header := blkc.GetCurrentBlockHeader()
+	if check.IfNil(header) {
+		return "no-header"
+	}
+	return fmt.Sprintf("%d:%x", header.GetNonce(), blkc.GetCurrentBlockRootHash())
+}
+
+// get returns the cached value, recomputing under lock when the block changed (so concurrent callers
 // on a fresh block share one compute).
 func (c *blockCache[T]) get(blkc data.ChainHandler, compute func() (*T, error)) (*T, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	currentNonce := uint64(0)
-	if header := blkc.GetCurrentBlockHeader(); !check.IfNil(header) {
-		currentNonce = header.GetNonce()
-	}
-
-	if c.valid && c.nonce == currentNonce && c.cached != nil {
+	key := blockCacheKey(blkc)
+	if c.cached != nil && c.key == key {
 		return c.cached, nil
 	}
 
@@ -38,13 +42,9 @@ func (c *blockCache[T]) get(blkc data.ChainHandler, compute func() (*T, error)) 
 	if err != nil {
 		return nil, err
 	}
-	if computed == nil {
-		return nil, errNilComputeResult
-	}
 
 	c.cached = computed
-	c.nonce = currentNonce
-	c.valid = true
+	c.key = key
 
 	return computed, nil
 }

--- a/node/blockCache_test.go
+++ b/node/blockCache_test.go
@@ -1,0 +1,53 @@
+package node
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/data"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockCache_get(t *testing.T) {
+	t.Parallel()
+
+	// nil header => nonce 0, so repeated calls stay within the "same block".
+	blkc := &mock.BlockChainMock{GetCurrentBlockHeaderCalled: func() data.HeaderHandler { return nil }}
+
+	t.Run("memoizes within the same block", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		c := &blockCache[int]{}
+		compute := func() (*int, error) {
+			calls++
+			v := 42
+			return &v, nil
+		}
+		v1, err := c.get(blkc, compute)
+		require.NoError(t, err)
+		require.Equal(t, 42, *v1)
+
+		v2, err := c.get(blkc, compute)
+		require.NoError(t, err)
+		require.Same(t, v1, v2) // served from cache
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("nil compute result is an error", func(t *testing.T) {
+		t.Parallel()
+		c := &blockCache[int]{}
+		v, err := c.get(blkc, func() (*int, error) { return nil, nil })
+		require.ErrorIs(t, err, errNilComputeResult)
+		require.Nil(t, v)
+	})
+
+	t.Run("propagates compute error", func(t *testing.T) {
+		t.Parallel()
+		c := &blockCache[int]{}
+		expectedErr := errors.New("boom")
+		v, err := c.get(blkc, func() (*int, error) { return nil, expectedErr })
+		require.ErrorIs(t, err, expectedErr)
+		require.Nil(t, v)
+	})
+}

--- a/node/blockCache_test.go
+++ b/node/blockCache_test.go
@@ -14,7 +14,7 @@ import (
 func TestBlockCache_get(t *testing.T) {
 	t.Parallel()
 
-	// nil header => nonce 0, so repeated calls stay within the "same block".
+	// nil header => sentinel key, so repeated calls stay within the "same block".
 	blkc := &mock.BlockChainMock{GetCurrentBlockHeaderCalled: func() data.HeaderHandler { return nil }}
 
 	t.Run("memoizes within the same block", func(t *testing.T) {
@@ -34,14 +34,6 @@ func TestBlockCache_get(t *testing.T) {
 		require.NoError(t, err)
 		require.Same(t, v1, v2) // served from cache
 		require.Equal(t, 1, calls)
-	})
-
-	t.Run("nil compute result is an error", func(t *testing.T) {
-		t.Parallel()
-		c := &blockCache[int]{}
-		v, err := c.get(blkc, func() (*int, error) { return nil, nil })
-		require.ErrorIs(t, err, errNilComputeResult)
-		require.Nil(t, v)
 	})
 
 	t.Run("propagates compute error", func(t *testing.T) {
@@ -79,6 +71,61 @@ func TestBlockCache_get(t *testing.T) {
 		v2, err := c.get(bc, compute)
 		require.NoError(t, err)
 		require.Equal(t, 2, *v2)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("recomputes on a reorg at the same nonce", func(t *testing.T) {
+		t.Parallel()
+		rootHash := []byte("root-a")
+		bc := &mock.BlockChainMock{
+			GetCurrentBlockHeaderCalled: func() data.HeaderHandler {
+				return &mock.HeaderHandlerStub{GetNonceCalled: func() uint64 { return 5 }}
+			},
+			GetCurrentBlockRootHashCalled: func() []byte { return rootHash },
+		}
+		calls := 0
+		c := &blockCache[int]{}
+		compute := func() (*int, error) {
+			calls++
+			v := calls
+			return &v, nil
+		}
+
+		_, err := c.get(bc, compute)
+		require.NoError(t, err)
+		require.Equal(t, 1, calls)
+
+		rootHash = []byte("root-b") // same nonce, different state => recompute
+		v, err := c.get(bc, compute)
+		require.NoError(t, err)
+		require.Equal(t, 2, *v)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("does not serve the no-header value for genesis", func(t *testing.T) {
+		t.Parallel()
+		var header data.HeaderHandler // no header yet
+		bc := &mock.BlockChainMock{
+			GetCurrentBlockHeaderCalled:   func() data.HeaderHandler { return header },
+			GetCurrentBlockRootHashCalled: func() []byte { return []byte("genesis-root") },
+		}
+		calls := 0
+		c := &blockCache[int]{}
+		compute := func() (*int, error) {
+			calls++
+			v := calls
+			return &v, nil
+		}
+
+		_, err := c.get(bc, compute)
+		require.NoError(t, err)
+		require.Equal(t, 1, calls)
+
+		// genesis lands at nonce 0, which must not alias the pre-genesis sentinel
+		header = &mock.HeaderHandlerStub{GetNonceCalled: func() uint64 { return 0 }}
+		v, err := c.get(bc, compute)
+		require.NoError(t, err)
+		require.Equal(t, 2, *v)
 		require.Equal(t, 2, calls)
 	})
 

--- a/node/blockCache_test.go
+++ b/node/blockCache_test.go
@@ -2,6 +2,8 @@ package node
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/klever-io/klever-go/common/mock"
@@ -49,5 +51,68 @@ func TestBlockCache_get(t *testing.T) {
 		v, err := c.get(blkc, func() (*int, error) { return nil, expectedErr })
 		require.ErrorIs(t, err, expectedErr)
 		require.Nil(t, v)
+	})
+
+	t.Run("recomputes when the block nonce advances", func(t *testing.T) {
+		t.Parallel()
+		nonce := uint64(1)
+		bc := &mock.BlockChainMock{GetCurrentBlockHeaderCalled: func() data.HeaderHandler {
+			return &mock.HeaderHandlerStub{GetNonceCalled: func() uint64 { return nonce }}
+		}}
+		calls := 0
+		c := &blockCache[int]{}
+		compute := func() (*int, error) {
+			calls++
+			v := int(nonce)
+			return &v, nil
+		}
+
+		v1, err := c.get(bc, compute)
+		require.NoError(t, err)
+		require.Equal(t, 1, *v1)
+
+		_, err = c.get(bc, compute) // same nonce => cache hit
+		require.NoError(t, err)
+		require.Equal(t, 1, calls)
+
+		nonce = 2 // block advanced => recompute
+		v2, err := c.get(bc, compute)
+		require.NoError(t, err)
+		require.Equal(t, 2, *v2)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("computes once under concurrent callers", func(t *testing.T) {
+		t.Parallel()
+		bc := &mock.BlockChainMock{GetCurrentBlockHeaderCalled: func() data.HeaderHandler { return nil }}
+		c := &blockCache[int]{}
+		var calls int32
+		compute := func() (*int, error) {
+			atomic.AddInt32(&calls, 1)
+			v := 7
+			return &v, nil
+		}
+
+		const n = 32
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(n)
+		results := make([]*int, n)
+		errs := make([]error, n)
+		for i := 0; i < n; i++ {
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				results[i], errs[i] = c.get(bc, compute)
+			}(i)
+		}
+		close(start) // release all callers at once
+		wg.Wait()
+
+		require.Equal(t, int32(1), atomic.LoadInt32(&calls)) // single compute under the lock
+		for i := 0; i < n; i++ {
+			require.NoError(t, errs[i])
+			require.Same(t, results[0], results[i]) // all share the one cached pointer
+		}
 	})
 }

--- a/node/heartbeat/mock/validatorsProviderStub.go
+++ b/node/heartbeat/mock/validatorsProviderStub.go
@@ -18,7 +18,7 @@ func (vp *ValidatorsProviderStub) GetLatestValidators() map[string]*state.Valida
 
 // GetLatestPeers -
 func (vp *ValidatorsProviderStub) GetLatestPeers() []state.PeerAccountHandler {
-	if vp.GetLatestValidatorsCalled != nil {
+	if vp.GetLatestPeersCalled != nil {
 		return vp.GetLatestPeersCalled()
 	}
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -41,6 +41,7 @@ import (
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/eventNotifier"
+	"github.com/klever-io/klever-go/network/api/models"
 	"github.com/klever-io/klever-go/network/p2p"
 	"github.com/klever-io/klever-go/node/heartbeat/componentHandler"
 	heartbeatData "github.com/klever-io/klever-go/node/heartbeat/data"
@@ -117,7 +118,8 @@ type Node struct {
 	blkc             data.ChainHandler
 	dataPool         retriever.PoolsHolder
 	store            retriever.StorageService
-	economics        economicsCache
+	economics        blockCache[models.EconomicsResponse]
+	accountTotals    blockCache[models.AccountTotalsResponse]
 	nodesCoordinator sharding.NodesCoordinator
 
 	networkShardingCollector NetworkShardingCollector

--- a/node/node.go
+++ b/node/node.go
@@ -117,6 +117,7 @@ type Node struct {
 	blkc             data.ChainHandler
 	dataPool         retriever.PoolsHolder
 	store            retriever.StorageService
+	economics        economicsCache
 	nodesCoordinator sharding.NodesCoordinator
 
 	networkShardingCollector NetworkShardingCollector

--- a/node/nodeAccountTotals.go
+++ b/node/nodeAccountTotals.go
@@ -1,0 +1,53 @@
+package node
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/klever-io/klever-go/common"
+	"github.com/klever-io/klever-go/data/state"
+	"github.com/klever-io/klever-go/network/api/models"
+	"github.com/klever-io/klever-go/tools/check"
+)
+
+// GetAccountTotals returns per-account aggregates (count + inline KLV Balance and Allowance), memoized
+// per block. The `/network/account-totals` route is opt-in (disabled by default in api.yaml). See KLC-2506.
+func (n *Node) GetAccountTotals() (*models.AccountTotalsResponse, error) {
+	return n.accountTotals.get(n.blkc, n.computeAccountTotals)
+}
+
+// computeAccountTotals walks the user-accounts trie, summing each account's inline Balance and Allowance
+// (frozen/unfrozen live in sub-tries, excluded). Code leaves share this trie and can decode cleanly into
+// UserAccountData, so accounts are identified by Address == leaf key, not by decode success. Mid-walk trie
+// errors are swallowed upstream (KLC-2509). Use GetAccountTotals (cached).
+func (n *Node) computeAccountTotals() (*models.AccountTotalsResponse, error) {
+	if check.IfNil(n.accounts) {
+		return nil, common.ErrNilAccountsAdapter
+	}
+
+	rootHash, err := n.accounts.RootHash()
+	if err != nil {
+		return nil, err
+	}
+
+	leavesChannel, err := n.accounts.GetAllLeaves(rootHash, context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	totals := &models.AccountTotalsResponse{}
+	for leaf := range leavesChannel {
+		acc := &state.UserAccountData{}
+		if errUnmarshal := n.internalMarshalizer.Unmarshal(acc, leaf.Value()); errUnmarshal != nil {
+			continue
+		}
+		if !bytes.Equal(acc.GetAddress(), leaf.Key()) {
+			continue // code leaf, not an account
+		}
+		totals.AccountCount++
+		totals.BalanceTotal += acc.GetBalance()
+		totals.AllowanceTotal += acc.GetAllowance()
+	}
+
+	return totals, nil
+}

--- a/node/nodeAccountTotals_test.go
+++ b/node/nodeAccountTotals_test.go
@@ -1,0 +1,84 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core/keyValStorage"
+	"github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/data/state"
+	"github.com/klever-io/klever-go/tools/marshal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNode_computeAccountTotals(t *testing.T) {
+	t.Parallel()
+
+	marshalizer := marshal.NewProtoMarshalizer()
+	leaves := make([]data.KeyValueHolder, 0)
+	// A real account is stored at its address, so its inline Address == the leaf key.
+	add := func(key string, balance, allowance int64) {
+		raw, err := marshalizer.Marshal(&state.UserAccountData{Address: []byte(key), Balance: balance, Allowance: allowance})
+		require.NoError(t, err)
+		leaves = append(leaves, keyValStorage.NewKeyValStorage([]byte(key), raw))
+	}
+	add("addr-a", 1000, 50)
+	add("addr-b", 2500, 0)
+	add("addr-c", 0, 700)
+	// an undecodable leaf is skipped.
+	leaves = append(leaves, keyValStorage.NewKeyValStorage([]byte("garbage"), []byte{0xff, 0xff, 0xff, 0xff}))
+	// a code leaf decodes cleanly into UserAccountData, but its Address (bytecode) != the leaf key
+	// (code hash), so it must be skipped — its 9999 balance must NOT be summed.
+	codeRaw, err := marshalizer.Marshal(&state.UserAccountData{Address: []byte("wasm-bytecode-blob"), Balance: 9999})
+	require.NoError(t, err)
+	leaves = append(leaves, keyValStorage.NewKeyValStorage([]byte("codehash"), codeRaw))
+
+	n := &Node{
+		accounts: &mock.AccountsStub{
+			RootHashCalled: func() ([]byte, error) { return []byte("root"), nil },
+			GetAllLeavesCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+				ch := make(chan data.KeyValueHolder, len(leaves))
+				for _, l := range leaves {
+					ch <- l
+				}
+				close(ch)
+				return ch, nil
+			},
+		},
+		internalMarshalizer: marshalizer,
+	}
+
+	totals, err := n.computeAccountTotals()
+	require.NoError(t, err)
+	require.Equal(t, int64(3), totals.AccountCount)     // code leaf skipped
+	require.Equal(t, int64(3500), totals.BalanceTotal)  // 1000 + 2500 + 0
+	require.Equal(t, int64(750), totals.AllowanceTotal) // 50 + 0 + 700
+}
+
+// validatorsProviderStub is a minimal local stub (the shared heartbeat one has a wrong-field guard).
+type validatorsProviderStub struct {
+	peers []state.PeerAccountHandler
+}
+
+func (v *validatorsProviderStub) GetLatestValidators() map[string]*state.ValidatorApiResponse {
+	return nil
+}
+func (v *validatorsProviderStub) GetLatestPeers() []state.PeerAccountHandler { return v.peers }
+func (v *validatorsProviderStub) IsInterfaceNil() bool                       { return v == nil }
+
+func TestNode_loadAccumulatedFeesTotal(t *testing.T) {
+	t.Parallel()
+
+	mkPeer := func(fees int64) state.PeerAccountHandler {
+		p := state.NewEmptyPeerAccount()
+		p.AddToAccumulatedFees(fees)
+		return p
+	}
+	n := &Node{
+		validatorsProvider: &validatorsProviderStub{
+			peers: []state.PeerAccountHandler{mkPeer(100), mkPeer(250), mkPeer(0)},
+		},
+	}
+
+	require.Equal(t, int64(350), n.loadAccumulatedFeesTotal()) // 100 + 250 + 0
+}

--- a/node/nodeAccountTotals_test.go
+++ b/node/nodeAccountTotals_test.go
@@ -56,6 +56,38 @@ func TestNode_computeAccountTotals(t *testing.T) {
 	require.Equal(t, int64(750), totals.AllowanceTotal) // 50 + 0 + 700
 }
 
+func TestNode_GetAccountTotals(t *testing.T) {
+	t.Parallel()
+
+	marshalizer := marshal.NewProtoMarshalizer()
+	raw, err := marshalizer.Marshal(&state.UserAccountData{Address: []byte("addr-a"), Balance: 1000, Allowance: 50})
+	require.NoError(t, err)
+
+	n := &Node{
+		blkc: &mock.BlockChainMock{GetCurrentBlockHeaderCalled: func() data.HeaderHandler { return nil }},
+		accounts: &mock.AccountsStub{
+			RootHashCalled: func() ([]byte, error) { return []byte("root"), nil },
+			GetAllLeavesCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+				ch := make(chan data.KeyValueHolder, 1)
+				ch <- keyValStorage.NewKeyValStorage([]byte("addr-a"), raw)
+				close(ch)
+				return ch, nil
+			},
+		},
+		internalMarshalizer: marshalizer,
+	}
+
+	totals, err := n.GetAccountTotals()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), totals.AccountCount)
+	require.Equal(t, int64(1000), totals.BalanceTotal)
+	require.Equal(t, int64(50), totals.AllowanceTotal)
+
+	cached, err := n.GetAccountTotals()
+	require.NoError(t, err)
+	require.Same(t, totals, cached) // memoized within the block
+}
+
 func TestNode_loadAccumulatedFeesTotal(t *testing.T) {
 	t.Parallel()
 

--- a/node/nodeAccountTotals_test.go
+++ b/node/nodeAccountTotals_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/klever-io/klever-go/common/mock"
@@ -55,17 +56,6 @@ func TestNode_computeAccountTotals(t *testing.T) {
 	require.Equal(t, int64(750), totals.AllowanceTotal) // 50 + 0 + 700
 }
 
-// validatorsProviderStub is a minimal local stub (the shared heartbeat one has a wrong-field guard).
-type validatorsProviderStub struct {
-	peers []state.PeerAccountHandler
-}
-
-func (v *validatorsProviderStub) GetLatestValidators() map[string]*state.ValidatorApiResponse {
-	return nil
-}
-func (v *validatorsProviderStub) GetLatestPeers() []state.PeerAccountHandler { return v.peers }
-func (v *validatorsProviderStub) IsInterfaceNil() bool                       { return v == nil }
-
 func TestNode_loadAccumulatedFeesTotal(t *testing.T) {
 	t.Parallel()
 
@@ -74,11 +64,41 @@ func TestNode_loadAccumulatedFeesTotal(t *testing.T) {
 		p.AddToAccumulatedFees(fees)
 		return p
 	}
-	n := &Node{
-		validatorsProvider: &validatorsProviderStub{
-			peers: []state.PeerAccountHandler{mkPeer(100), mkPeer(250), mkPeer(0)},
-		},
-	}
 
-	require.Equal(t, int64(350), n.loadAccumulatedFeesTotal()) // 100 + 250 + 0
+	t.Run("sums peer accumulated fees", func(t *testing.T) {
+		t.Parallel()
+		n := &Node{validatorStatistics: &mock.ValidatorStatisticsProcessorStub{
+			LastFinalizedRootHashCalled: func() []byte { return []byte("root") },
+			ListPeerAccountsCalled: func(_ []byte) ([]state.PeerAccountHandler, error) {
+				return []state.PeerAccountHandler{mkPeer(100), mkPeer(250), mkPeer(0)}, nil
+			},
+		}}
+		total, err := n.loadAccumulatedFeesTotal()
+		require.NoError(t, err)
+		require.Equal(t, int64(350), total) // 100 + 250 + 0
+	})
+
+	t.Run("returns 0 with no error before the first finalized block", func(t *testing.T) {
+		t.Parallel()
+		n := &Node{validatorStatistics: &mock.ValidatorStatisticsProcessorStub{
+			LastFinalizedRootHashCalled: func() []byte { return nil },
+		}}
+		total, err := n.loadAccumulatedFeesTotal()
+		require.NoError(t, err)
+		require.Zero(t, total)
+	})
+
+	t.Run("propagates peer-read error", func(t *testing.T) {
+		t.Parallel()
+		expectedErr := errors.New("peer read failed")
+		n := &Node{validatorStatistics: &mock.ValidatorStatisticsProcessorStub{
+			LastFinalizedRootHashCalled: func() []byte { return []byte("root") },
+			ListPeerAccountsCalled: func(_ []byte) ([]state.PeerAccountHandler, error) {
+				return nil, expectedErr
+			},
+		}}
+		total, err := n.loadAccumulatedFeesTotal()
+		require.ErrorIs(t, err, expectedErr)
+		require.Zero(t, total)
+	})
 }

--- a/node/nodeEconomics.go
+++ b/node/nodeEconomics.go
@@ -1,0 +1,219 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/klever-io/klever-go/common"
+	kdafeespool "github.com/klever-io/klever-go/core/kapp/kdaFeesPool"
+	"github.com/klever-io/klever-go/core/process/kda/kdautils"
+	"github.com/klever-io/klever-go/data/state"
+	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/network/api/models"
+	"github.com/klever-io/klever-go/tools/check"
+)
+
+// economicsCache memoizes GetEconomics per block, capping the KApp trie scans (PREW, market
+// orders, fees pools, FPR pool) to at most once per block so a polling client can't trigger one
+// per request.
+type economicsCache struct {
+	mu     sync.Mutex
+	nonce  uint64
+	valid  bool
+	cached *models.EconomicsResponse
+}
+
+// GetEconomics returns live KLV supply figures plus node-state held aggregates, memoized per
+// block. It runs O(n) KApp trie scans, so the `/network/economics` route is opt-in (disabled by
+// default in api.yaml). The returned value is cached and shared across callers within a block,
+// so treat it as read-only. See KLC-2506.
+func (n *Node) GetEconomics() (*models.EconomicsResponse, error) {
+	// Lock spans the nonce read + compute so the cache check/update stays atomic and
+	// concurrent callers on a fresh block share one scan.
+	n.economics.mu.Lock()
+	defer n.economics.mu.Unlock()
+
+	currentNonce := uint64(0)
+	if header := n.blkc.GetCurrentBlockHeader(); !check.IfNil(header) {
+		currentNonce = header.GetNonce()
+	}
+
+	if n.economics.valid && n.economics.nonce == currentNonce && n.economics.cached != nil {
+		return n.economics.cached, nil
+	}
+
+	economics, err := n.computeEconomics()
+	if err != nil {
+		return nil, err
+	}
+
+	n.economics.cached = economics
+	n.economics.nonce = currentNonce
+	n.economics.valid = true
+
+	return economics, nil
+}
+
+// computeEconomics reads live supply plus held aggregates from node state: PREW and market escrow
+// (Validators/Market KApp scans), the KDA fees-pool KLV, the FPR staking pool, and the
+// system-account KLV. Use GetEconomics (cached) instead of calling this directly.
+func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
+	kdaData, err := n.GetAsset(string(kdautils.KLVIdentifier))
+	if err != nil {
+		return nil, err
+	}
+
+	pendingRewardsTotal := int64(0)
+	marketEscrowTotal := int64(0)
+	if !check.IfNil(n.kappController) {
+		pendingRewardsTotal, err = n.kappController.GetValidatorsKApp().GetPendingRewardsTotal()
+		if err != nil {
+			return nil, err
+		}
+		marketEscrowTotal, err = n.kappController.GetMarketKApp().GetMarketEscrowTotal()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	feesPoolKLVTotal := int64(0)
+	systemAccountKLV := int64(0)
+	fprPoolKLVTotal := int64(0)
+	if !check.IfNil(n.kapps) {
+		feesPoolKLVTotal, err = n.loadFeesPoolKLVTotal()
+		if err != nil {
+			return nil, err
+		}
+		systemAccountKLV, err = n.loadSystemAccountKLV()
+		if err != nil {
+			return nil, err
+		}
+		fprPoolKLVTotal, err = n.loadFPRPoolKLVTotal()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// A missing KLV StakingData record (fresh/test networks) means no stake, not an error.
+	staking, err := n.loadStakingData(string(kdautils.KLVIdentifier))
+	if err != nil && !errors.Is(err, common.ErrStakingNotFound) {
+		return nil, err
+	}
+
+	totalStaked := int64(0)
+	if staking != nil {
+		totalStaked = staking.GetTotalStaked()
+	}
+
+	return &models.EconomicsResponse{
+		InitialSupply:           kdaData.GetInitialSupply(),
+		MaxSupply:               kdaData.GetMaxSupply(),
+		MintedValue:             kdaData.GetMintedValue(),
+		BurnedValue:             kdaData.GetBurnedValue(),
+		CirculatingSupply:       kdaData.GetCirculatingSupply(),
+		TotalStaked:             totalStaked,
+		PendingRewardsTotal:     pendingRewardsTotal,
+		MarketEscrowTotal:       marketEscrowTotal,
+		FeesPoolKLVTotal:        feesPoolKLVTotal,
+		FPRPoolTotal:            fprPoolKLVTotal,
+		SystemAccountKLVBalance: systemAccountKLV,
+	}, nil
+}
+
+// scanKAppDataTrie loads the KApp at address and invokes accumulate with each stored value (the
+// trie tail is trimmed by GetStorage). Keys are collected first so the scan goroutine finishes
+// before the values are read back.
+func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte)) error {
+	app, err := n.loadKAppAccount(address)
+	if err != nil {
+		return err
+	}
+
+	dataTrie := app.DataTrie()
+	if check.IfNil(dataTrie) {
+		return nil
+	}
+	leavesChannel, err := dataTrie.GetAllLeavesOnChannel(app.GetRootHash(), context.Background())
+	if err != nil {
+		return err
+	}
+
+	keys := make([][]byte, 0)
+	for leaf := range leavesChannel {
+		key := make([]byte, len(leaf.Key()))
+		copy(key, leaf.Key())
+		keys = append(keys, key)
+	}
+
+	for _, key := range keys {
+		if raw := app.GetStorage(key); len(raw) > 0 {
+			accumulate(raw)
+		}
+	}
+	return nil
+}
+
+// loadFeesPoolKLVTotal sums KLVBalance across every KDA fees-pool record (KLV is held as that
+// field, not the account balance — see kdaFeesPool deposit).
+func (n *Node) loadFeesPoolKLVTotal() (int64, error) {
+	total := int64(0)
+	err := n.scanKAppDataTrie(kapps.KDAFeesPoolKAppAddress, func(raw []byte) {
+		pool := &kdafeespool.KDAFeesPoolData{}
+		if errUnmarshal := n.internalMarshalizer.Unmarshal(pool, raw); errUnmarshal != nil {
+			log.Warn("loadFeesPoolKLVTotal: skipping undecodable fees-pool record", "error", errUnmarshal)
+			return
+		}
+		total += pool.KLVBalance
+	})
+	return total, err
+}
+
+// loadSystemAccountKLV returns the KLV held directly by the system-account KApp.
+func (n *Node) loadSystemAccountKLV() (int64, error) {
+	app, err := n.loadKAppAccount(kapps.SystemAccountKAppAddress)
+	if err != nil {
+		return 0, err
+	}
+	// GetUserKDA returns a zero-value (balance 0) when the asset isn't held; a non-nil error here
+	// is a real trie/unmarshal failure, so propagate it rather than report a silent zero.
+	userKDA, err := app.GetUserKDA(kdautils.KLVIdentifier, nil, false)
+	if err != nil {
+		return 0, err
+	}
+	return userKDA.GetBalance(), nil
+}
+
+// loadFPRPoolKLVTotal sums the unclaimed KLV staking rewards across every asset's StakingData in
+// the Staking KApp: CurrentFPRAmount (this epoch) + Σ FPR(TotalAmount − TotalClaimed) (past epochs).
+// TotalAmount/CurrentFPRAmount are KLV-denominated; non-KLV rewards live in the FPR KDAS map and are
+// excluded. This mints into circulatingSupply, so it must be read at the same block to cancel.
+func (n *Node) loadFPRPoolKLVTotal() (int64, error) {
+	total := int64(0)
+	err := n.scanKAppDataTrie(kapps.StakingKAppAddress, func(raw []byte) {
+		staking := &kapps.StakingData{}
+		if errUnmarshal := n.internalMarshalizer.Unmarshal(staking, raw); errUnmarshal != nil {
+			log.Warn("loadFPRPoolKLVTotal: skipping undecodable staking record", "error", errUnmarshal)
+			return
+		}
+		total += staking.GetCurrentFPRAmount()
+		for _, fpr := range staking.GetFPR() {
+			if unclaimed := fpr.GetTotalAmount() - fpr.GetTotalClaimed(); unclaimed > 0 {
+				total += unclaimed
+			}
+		}
+	})
+	return total, err
+}
+
+func (n *Node) loadKAppAccount(address []byte) (state.KAppAccountHandler, error) {
+	acnt, err := n.kapps.LoadAccount(address)
+	if err != nil {
+		return nil, err
+	}
+	app, ok := acnt.(state.KAppAccountHandler)
+	if !ok {
+		return nil, common.ErrWrongTypeAssertion
+	}
+	return app, nil
+}

--- a/node/nodeEconomics.go
+++ b/node/nodeEconomics.go
@@ -28,54 +28,24 @@ func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 		return nil, err
 	}
 
-	pendingRewardsTotal := int64(0)
-	marketEscrowTotal := int64(0)
-	if !check.IfNil(n.kappController) {
-		pendingRewardsTotal, err = n.kappController.GetValidatorsKApp().GetPendingRewardsTotal()
-		if err != nil {
-			return nil, err
-		}
-		marketEscrowTotal, err = n.kappController.GetMarketKApp().GetMarketEscrowTotal()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	feesPoolKLVTotal := int64(0)
-	systemAccountKLV := int64(0)
-	fprPoolKLVTotal := int64(0)
-	if !check.IfNil(n.kapps) {
-		feesPoolKLVTotal, err = n.loadFeesPoolKLVTotal()
-		if err != nil {
-			return nil, err
-		}
-		systemAccountKLV, err = n.loadSystemAccountKLV()
-		if err != nil {
-			return nil, err
-		}
-		fprPoolKLVTotal, err = n.loadFPRPoolKLVTotal()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	accumulatedFeesTotal := int64(0)
-	if !check.IfNil(n.validatorStatistics) {
-		accumulatedFeesTotal, err = n.loadAccumulatedFeesTotal()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// A missing KLV StakingData record (fresh/test networks) means no stake, not an error.
-	staking, err := n.loadStakingData(string(kdautils.KLVIdentifier))
-	if err != nil && !errors.Is(err, common.ErrStakingNotFound) {
+	pendingRewardsTotal, marketEscrowTotal, err := n.loadKAppHeldTotals()
+	if err != nil {
 		return nil, err
 	}
 
-	totalStaked := int64(0)
-	if staking != nil {
-		totalStaked = staking.GetTotalStaked()
+	feesPoolKLVTotal, systemAccountKLV, fprPoolKLVTotal, err := n.loadKAppKLVPools()
+	if err != nil {
+		return nil, err
+	}
+
+	accumulatedFeesTotal, err := n.loadValidatorAccumulatedFees()
+	if err != nil {
+		return nil, err
+	}
+
+	totalStaked, err := n.loadTotalStakedKLV()
+	if err != nil {
+		return nil, err
 	}
 
 	return &models.EconomicsResponse{
@@ -92,6 +62,64 @@ func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 		AccumulatedFeesTotal:    accumulatedFeesTotal,
 		SystemAccountKLVBalance: systemAccountKLV,
 	}, nil
+}
+
+// loadKAppHeldTotals returns the pending-rewards and market-escrow totals (zero without a controller).
+func (n *Node) loadKAppHeldTotals() (int64, int64, error) {
+	if check.IfNil(n.kappController) {
+		return 0, 0, nil
+	}
+	pendingRewards, err := n.kappController.GetValidatorsKApp().GetPendingRewardsTotal()
+	if err != nil {
+		return 0, 0, err
+	}
+	marketEscrow, err := n.kappController.GetMarketKApp().GetMarketEscrowTotal()
+	if err != nil {
+		return 0, 0, err
+	}
+	return pendingRewards, marketEscrow, nil
+}
+
+// loadKAppKLVPools returns the fees-pool, system-account, and FPR-pool KLV totals (zero without a
+// KApp accounts adapter).
+func (n *Node) loadKAppKLVPools() (int64, int64, int64, error) {
+	if check.IfNil(n.kapps) {
+		return 0, 0, 0, nil
+	}
+	feesPool, err := n.loadFeesPoolKLVTotal()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	systemAccount, err := n.loadSystemAccountKLV()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	fprPool, err := n.loadFPRPoolKLVTotal()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return feesPool, systemAccount, fprPool, nil
+}
+
+// loadValidatorAccumulatedFees returns the accrued validator fees (zero without peer statistics).
+func (n *Node) loadValidatorAccumulatedFees() (int64, error) {
+	if check.IfNil(n.validatorStatistics) {
+		return 0, nil
+	}
+	return n.loadAccumulatedFeesTotal()
+}
+
+// loadTotalStakedKLV returns KLV TotalStaked; a missing StakingData record (fresh/test networks)
+// means no stake, not an error.
+func (n *Node) loadTotalStakedKLV() (int64, error) {
+	staking, err := n.loadStakingData(string(kdautils.KLVIdentifier))
+	if errors.Is(err, common.ErrStakingNotFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return staking.GetTotalStaked(), nil
 }
 
 // loadAccumulatedFeesTotal sums KLV fees accrued per validator (reset at epoch end into PREW/Allowance).

--- a/node/nodeEconomics.go
+++ b/node/nodeEconomics.go
@@ -58,8 +58,11 @@ func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 	}
 
 	accumulatedFeesTotal := int64(0)
-	if !check.IfNil(n.validatorsProvider) {
-		accumulatedFeesTotal = n.loadAccumulatedFeesTotal()
+	if !check.IfNil(n.validatorStatistics) {
+		accumulatedFeesTotal, err = n.loadAccumulatedFeesTotal()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// A missing KLV StakingData record (fresh/test networks) means no stake, not an error.
@@ -90,16 +93,24 @@ func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 }
 
 // loadAccumulatedFeesTotal sums KLV fees accrued per validator (reset at epoch end into PREW/Allowance).
-// GetLatestPeers returns nil during early sync or on a peer-read error, so this reads 0 there, not an error.
-func (n *Node) loadAccumulatedFeesTotal() int64 {
+// Returns 0 before the first finalized block (no peers yet); a peer-read error is propagated, not hidden.
+func (n *Node) loadAccumulatedFeesTotal() (int64, error) {
+	rootHash := n.validatorStatistics.LastFinalizedRootHash()
+	if len(rootHash) == 0 {
+		return 0, nil
+	}
+	peers, err := n.validatorStatistics.ListPeerAccounts(rootHash)
+	if err != nil {
+		return 0, err
+	}
 	total := int64(0)
-	for _, peer := range n.validatorsProvider.GetLatestPeers() {
+	for _, peer := range peers {
 		if check.IfNil(peer) {
 			continue
 		}
 		total += peer.GetAccumulatedFees()
 	}
-	return total
+	return total, nil
 }
 
 // scanKAppDataTrie invokes accumulate with each stored value (GetStorage trims the trie tail). Keys are

--- a/node/nodeEconomics.go
+++ b/node/nodeEconomics.go
@@ -1,8 +1,10 @@
 package node
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"math"
 
 	"github.com/klever-io/klever-go/common"
 	kdafeespool "github.com/klever-io/klever-go/core/kapp/kdaFeesPool"
@@ -108,14 +110,30 @@ func (n *Node) loadAccumulatedFeesTotal() (int64, error) {
 		if check.IfNil(peer) {
 			continue
 		}
-		total += peer.GetAccumulatedFees()
+		addGuarded(&total, peer.GetAccumulatedFees(), "loadAccumulatedFeesTotal")
 	}
 	return total, nil
 }
 
-// scanKAppDataTrie invokes accumulate with each stored value (GetStorage trims the trie tail). Keys are
-// collected before reading values so the scan goroutine finishes first.
-func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte) error) error {
+// addGuarded adds amount into total, skipping negative or overflowing values so a corrupt stored
+// entry cannot poison an authoritative supply figure.
+func addGuarded(total *int64, amount int64, context string) {
+	if amount < 0 {
+		log.Warn(context + ": negative amount, skipping entry")
+		return
+	}
+	if *total > math.MaxInt64-amount {
+		log.Warn(context + ": sum would overflow int64, skipping entry")
+		return
+	}
+	*total += amount
+}
+
+// scanKAppDataTrie invokes accumulate with each stored value whose key matches prefix (nil scans all;
+// GetStorage trims the trie tail). Keys are collected before reading values so the scan goroutine
+// finishes first. Mid-walk trie errors are swallowed upstream, so a truncated walk yields a silently
+// undercounted total (KLC-2509).
+func (n *Node) scanKAppDataTrie(address []byte, prefix []byte, accumulate func(value []byte) error) error {
 	app, err := n.loadKAppAccount(address)
 	if err != nil {
 		return err
@@ -132,6 +150,9 @@ func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte) er
 
 	keys := make([][]byte, 0)
 	for leaf := range leavesChannel {
+		if len(prefix) > 0 && !bytes.HasPrefix(leaf.Key(), prefix) {
+			continue
+		}
 		key := make([]byte, len(leaf.Key()))
 		copy(key, leaf.Key())
 		keys = append(keys, key)
@@ -150,14 +171,15 @@ func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte) er
 }
 
 // loadFeesPoolKLVTotal sums KLVBalance across every KDA fees-pool record (KLV sits in that field).
+// Fees-pool records are keyed by raw asset ID with no shared prefix, so the scan takes every leaf.
 func (n *Node) loadFeesPoolKLVTotal() (int64, error) {
 	total := int64(0)
-	err := n.scanKAppDataTrie(kapps.KDAFeesPoolKAppAddress, func(raw []byte) error {
+	err := n.scanKAppDataTrie(kapps.KDAFeesPoolKAppAddress, nil, func(raw []byte) error {
 		pool := &kdafeespool.KDAFeesPoolData{}
 		if err := n.internalMarshalizer.Unmarshal(pool, raw); err != nil {
 			return err
 		}
-		total += pool.KLVBalance
+		addGuarded(&total, pool.KLVBalance, "loadFeesPoolKLVTotal")
 		return nil
 	})
 	return total, err
@@ -181,15 +203,17 @@ func (n *Node) loadSystemAccountKLV() (int64, error) {
 // Σ FPR(TotalAmount − TotalClaimed). KLV-denominated only; non-KLV rewards (the KDAS map) are excluded.
 func (n *Node) loadFPRPoolKLVTotal() (int64, error) {
 	total := int64(0)
-	err := n.scanKAppDataTrie(kapps.StakingKAppAddress, func(raw []byte) error {
+	// StakingData records are keyed via ToKDAKey, so only KDA-prefixed leaves are decoded.
+	prefix := []byte(kapps.KDAPrefix + kapps.Sp)
+	err := n.scanKAppDataTrie(kapps.StakingKAppAddress, prefix, func(raw []byte) error {
 		staking := &kapps.StakingData{}
 		if err := n.internalMarshalizer.Unmarshal(staking, raw); err != nil {
 			return err
 		}
-		total += staking.GetCurrentFPRAmount()
+		addGuarded(&total, staking.GetCurrentFPRAmount(), "loadFPRPoolKLVTotal")
 		for _, fpr := range staking.GetFPR() {
 			if unclaimed := fpr.GetTotalAmount() - fpr.GetTotalClaimed(); unclaimed > 0 {
-				total += unclaimed
+				addGuarded(&total, unclaimed, "loadFPRPoolKLVTotal")
 			}
 		}
 		return nil

--- a/node/nodeEconomics.go
+++ b/node/nodeEconomics.go
@@ -124,7 +124,7 @@ func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 // scanKAppDataTrie loads the KApp at address and invokes accumulate with each stored value (the
 // trie tail is trimmed by GetStorage). Keys are collected first so the scan goroutine finishes
 // before the values are read back.
-func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte)) error {
+func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte) error) error {
 	app, err := n.loadKAppAccount(address)
 	if err != nil {
 		return err
@@ -147,8 +147,12 @@ func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte)) e
 	}
 
 	for _, key := range keys {
-		if raw := app.GetStorage(key); len(raw) > 0 {
-			accumulate(raw)
+		raw := app.GetStorage(key)
+		if len(raw) == 0 {
+			continue
+		}
+		if err := accumulate(raw); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -158,13 +162,13 @@ func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte)) e
 // field, not the account balance — see kdaFeesPool deposit).
 func (n *Node) loadFeesPoolKLVTotal() (int64, error) {
 	total := int64(0)
-	err := n.scanKAppDataTrie(kapps.KDAFeesPoolKAppAddress, func(raw []byte) {
+	err := n.scanKAppDataTrie(kapps.KDAFeesPoolKAppAddress, func(raw []byte) error {
 		pool := &kdafeespool.KDAFeesPoolData{}
-		if errUnmarshal := n.internalMarshalizer.Unmarshal(pool, raw); errUnmarshal != nil {
-			log.Warn("loadFeesPoolKLVTotal: skipping undecodable fees-pool record", "error", errUnmarshal)
-			return
+		if err := n.internalMarshalizer.Unmarshal(pool, raw); err != nil {
+			return err
 		}
 		total += pool.KLVBalance
+		return nil
 	})
 	return total, err
 }
@@ -190,11 +194,10 @@ func (n *Node) loadSystemAccountKLV() (int64, error) {
 // excluded. This mints into circulatingSupply, so it must be read at the same block to cancel.
 func (n *Node) loadFPRPoolKLVTotal() (int64, error) {
 	total := int64(0)
-	err := n.scanKAppDataTrie(kapps.StakingKAppAddress, func(raw []byte) {
+	err := n.scanKAppDataTrie(kapps.StakingKAppAddress, func(raw []byte) error {
 		staking := &kapps.StakingData{}
-		if errUnmarshal := n.internalMarshalizer.Unmarshal(staking, raw); errUnmarshal != nil {
-			log.Warn("loadFPRPoolKLVTotal: skipping undecodable staking record", "error", errUnmarshal)
-			return
+		if err := n.internalMarshalizer.Unmarshal(staking, raw); err != nil {
+			return err
 		}
 		total += staking.GetCurrentFPRAmount()
 		for _, fpr := range staking.GetFPR() {
@@ -202,6 +205,7 @@ func (n *Node) loadFPRPoolKLVTotal() (int64, error) {
 				total += unclaimed
 			}
 		}
+		return nil
 	})
 	return total, err
 }

--- a/node/nodeEconomics.go
+++ b/node/nodeEconomics.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"errors"
-	"sync"
 
 	"github.com/klever-io/klever-go/common"
 	kdafeespool "github.com/klever-io/klever-go/core/kapp/kdaFeesPool"
@@ -14,50 +13,13 @@ import (
 	"github.com/klever-io/klever-go/tools/check"
 )
 
-// economicsCache memoizes GetEconomics per block, capping the KApp trie scans (PREW, market
-// orders, fees pools, FPR pool) to at most once per block so a polling client can't trigger one
-// per request.
-type economicsCache struct {
-	mu     sync.Mutex
-	nonce  uint64
-	valid  bool
-	cached *models.EconomicsResponse
-}
-
-// GetEconomics returns live KLV supply figures plus node-state held aggregates, memoized per
-// block. It runs O(n) KApp trie scans, so the `/network/economics` route is opt-in (disabled by
-// default in api.yaml). The returned value is cached and shared across callers within a block,
-// so treat it as read-only. See KLC-2506.
+// GetEconomics returns live KLV supply figures plus node-state held aggregates, memoized per block.
+// The `/network/economics` route is opt-in (disabled by default in api.yaml). See KLC-2506.
 func (n *Node) GetEconomics() (*models.EconomicsResponse, error) {
-	// Lock spans the nonce read + compute so the cache check/update stays atomic and
-	// concurrent callers on a fresh block share one scan.
-	n.economics.mu.Lock()
-	defer n.economics.mu.Unlock()
-
-	currentNonce := uint64(0)
-	if header := n.blkc.GetCurrentBlockHeader(); !check.IfNil(header) {
-		currentNonce = header.GetNonce()
-	}
-
-	if n.economics.valid && n.economics.nonce == currentNonce && n.economics.cached != nil {
-		return n.economics.cached, nil
-	}
-
-	economics, err := n.computeEconomics()
-	if err != nil {
-		return nil, err
-	}
-
-	n.economics.cached = economics
-	n.economics.nonce = currentNonce
-	n.economics.valid = true
-
-	return economics, nil
+	return n.economics.get(n.blkc, n.computeEconomics)
 }
 
-// computeEconomics reads live supply plus held aggregates from node state: PREW and market escrow
-// (Validators/Market KApp scans), the KDA fees-pool KLV, the FPR staking pool, and the
-// system-account KLV. Use GetEconomics (cached) instead of calling this directly.
+// computeEconomics reads live supply plus held aggregates from node state. Use GetEconomics (cached).
 func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 	kdaData, err := n.GetAsset(string(kdautils.KLVIdentifier))
 	if err != nil {
@@ -95,6 +57,11 @@ func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 		}
 	}
 
+	accumulatedFeesTotal := int64(0)
+	if !check.IfNil(n.validatorsProvider) {
+		accumulatedFeesTotal = n.loadAccumulatedFeesTotal()
+	}
+
 	// A missing KLV StakingData record (fresh/test networks) means no stake, not an error.
 	staking, err := n.loadStakingData(string(kdautils.KLVIdentifier))
 	if err != nil && !errors.Is(err, common.ErrStakingNotFound) {
@@ -117,13 +84,26 @@ func (n *Node) computeEconomics() (*models.EconomicsResponse, error) {
 		MarketEscrowTotal:       marketEscrowTotal,
 		FeesPoolKLVTotal:        feesPoolKLVTotal,
 		FPRPoolTotal:            fprPoolKLVTotal,
+		AccumulatedFeesTotal:    accumulatedFeesTotal,
 		SystemAccountKLVBalance: systemAccountKLV,
 	}, nil
 }
 
-// scanKAppDataTrie loads the KApp at address and invokes accumulate with each stored value (the
-// trie tail is trimmed by GetStorage). Keys are collected first so the scan goroutine finishes
-// before the values are read back.
+// loadAccumulatedFeesTotal sums KLV fees accrued per validator (reset at epoch end into PREW/Allowance).
+// GetLatestPeers returns nil during early sync or on a peer-read error, so this reads 0 there, not an error.
+func (n *Node) loadAccumulatedFeesTotal() int64 {
+	total := int64(0)
+	for _, peer := range n.validatorsProvider.GetLatestPeers() {
+		if check.IfNil(peer) {
+			continue
+		}
+		total += peer.GetAccumulatedFees()
+	}
+	return total
+}
+
+// scanKAppDataTrie invokes accumulate with each stored value (GetStorage trims the trie tail). Keys are
+// collected before reading values so the scan goroutine finishes first.
 func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte) error) error {
 	app, err := n.loadKAppAccount(address)
 	if err != nil {
@@ -158,8 +138,7 @@ func (n *Node) scanKAppDataTrie(address []byte, accumulate func(value []byte) er
 	return nil
 }
 
-// loadFeesPoolKLVTotal sums KLVBalance across every KDA fees-pool record (KLV is held as that
-// field, not the account balance — see kdaFeesPool deposit).
+// loadFeesPoolKLVTotal sums KLVBalance across every KDA fees-pool record (KLV sits in that field).
 func (n *Node) loadFeesPoolKLVTotal() (int64, error) {
 	total := int64(0)
 	err := n.scanKAppDataTrie(kapps.KDAFeesPoolKAppAddress, func(raw []byte) error {
@@ -179,8 +158,7 @@ func (n *Node) loadSystemAccountKLV() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// GetUserKDA returns a zero-value (balance 0) when the asset isn't held; a non-nil error here
-	// is a real trie/unmarshal failure, so propagate it rather than report a silent zero.
+	// GetUserKDA returns zero (not error) when KLV isn't held, so a real error must propagate.
 	userKDA, err := app.GetUserKDA(kdautils.KLVIdentifier, nil, false)
 	if err != nil {
 		return 0, err
@@ -188,10 +166,8 @@ func (n *Node) loadSystemAccountKLV() (int64, error) {
 	return userKDA.GetBalance(), nil
 }
 
-// loadFPRPoolKLVTotal sums the unclaimed KLV staking rewards across every asset's StakingData in
-// the Staking KApp: CurrentFPRAmount (this epoch) + Σ FPR(TotalAmount − TotalClaimed) (past epochs).
-// TotalAmount/CurrentFPRAmount are KLV-denominated; non-KLV rewards live in the FPR KDAS map and are
-// excluded. This mints into circulatingSupply, so it must be read at the same block to cancel.
+// loadFPRPoolKLVTotal sums unclaimed KLV staking rewards across every StakingData: CurrentFPRAmount +
+// Σ FPR(TotalAmount − TotalClaimed). KLV-denominated only; non-KLV rewards (the KDAS map) are excluded.
 func (n *Node) loadFPRPoolKLVTotal() (int64, error) {
 	total := int64(0)
 	err := n.scanKAppDataTrie(kapps.StakingKAppAddress, func(raw []byte) error {

--- a/node/nodeEconomics_test.go
+++ b/node/nodeEconomics_test.go
@@ -1,0 +1,112 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/common/mock"
+	kdafeespool "github.com/klever-io/klever-go/core/kapp/kdaFeesPool"
+	"github.com/klever-io/klever-go/core/keyValStorage"
+	"github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/data/state"
+	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/tools/marshal"
+	"github.com/stretchr/testify/require"
+)
+
+// newEconomicsTestNode builds a minimal Node whose KApp adapter returns an account whose data
+// trie yields the given key->value records (values delivered via GetStorage, already trimmed).
+func newEconomicsTestNode(records map[string][]byte) *Node {
+	leaves := make([]data.KeyValueHolder, 0, len(records))
+	for key := range records {
+		leaves = append(leaves, keyValStorage.NewKeyValStorage([]byte(key), nil))
+	}
+	trieStub := &mock.TrieStub{
+		GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+			ch := make(chan data.KeyValueHolder, len(leaves))
+			for _, l := range leaves {
+				ch <- l
+			}
+			close(ch)
+			return ch, nil
+		},
+	}
+	app := &mock.KAppAccountHandlerStub{
+		DataTrieCalled:    func() data.Trie { return trieStub },
+		GetRootHashCalled: func() []byte { return []byte("root") },
+		GetStorageCalled:  func(key []byte) []byte { return records[string(key)] },
+	}
+	return &Node{
+		kapps: &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return app, nil },
+		},
+		internalMarshalizer: marshal.NewProtoMarshalizer(),
+	}
+}
+
+func TestNode_loadFeesPoolKLVTotal(t *testing.T) {
+	t.Parallel()
+
+	marshalizer := marshal.NewProtoMarshalizer()
+	records := make(map[string][]byte)
+	for id, klv := range map[string]int64{"KLV": 1000, "ABC-1q2w": 2500, "ZERO": 0} {
+		raw, err := marshalizer.Marshal(&kdafeespool.KDAFeesPoolData{KLVBalance: klv})
+		require.NoError(t, err)
+		records[id] = raw
+	}
+
+	n := newEconomicsTestNode(records)
+	total, err := n.loadFeesPoolKLVTotal()
+	require.NoError(t, err)
+	require.Equal(t, int64(3500), total) // 1000 + 2500 + 0
+}
+
+func TestNode_loadFPRPoolKLVTotal(t *testing.T) {
+	t.Parallel()
+
+	marshalizer := marshal.NewProtoMarshalizer()
+	// total per asset = CurrentFPRAmount + Σ(TotalAmount-TotalClaimed) where the diff is > 0.
+	// TotalAmount/CurrentFPRAmount are KLV; the KDAS map (non-KLV rewards) must be excluded.
+	stakings := map[string]*kapps.StakingData{
+		"A": {CurrentFPRAmount: 100, FPR: []*kapps.FPRData{{
+			TotalAmount: 500, TotalClaimed: 200,
+			// non-KLV reward (9999) must NOT be added to the KLV total.
+			KDAS: map[string]*kapps.KDAFPRData{"OTHER-1q2w": {TotalAmount: 9999, TotalClaimed: 0}},
+		}}}, // 100 + 300 = 400 (KDAS excluded)
+		"B": {CurrentFPRAmount: 50, FPR: []*kapps.FPRData{{TotalAmount: 1000, TotalClaimed: 1000}}}, // 50 + 0 = 50
+		"C": {CurrentFPRAmount: 0, FPR: []*kapps.FPRData{{TotalAmount: 100, TotalClaimed: 150}}},    // 0 + skip(neg) = 0
+		"D": {CurrentFPRAmount: 25, FPR: []*kapps.FPRData{
+			{TotalAmount: 300, TotalClaimed: 100},
+			{TotalAmount: 200, TotalClaimed: 200},
+		}}, // 25 + 200 + 0 = 225
+	}
+	records := make(map[string][]byte)
+	for id, s := range stakings {
+		raw, err := marshalizer.Marshal(s)
+		require.NoError(t, err)
+		records[id] = raw
+	}
+
+	n := newEconomicsTestNode(records)
+	total, err := n.loadFPRPoolKLVTotal()
+	require.NoError(t, err)
+	require.Equal(t, int64(675), total) // 400 + 50 + 0 + 225
+}
+
+func TestNode_scanKAppDataTrie_nilTrie(t *testing.T) {
+	t.Parallel()
+
+	app := &mock.KAppAccountHandlerStub{
+		DataTrieCalled: func() data.Trie { return nil },
+	}
+	n := &Node{
+		kapps: &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return app, nil },
+		},
+		internalMarshalizer: marshal.NewProtoMarshalizer(),
+	}
+
+	called := false
+	err := n.scanKAppDataTrie([]byte("addr"), func(_ []byte) { called = true })
+	require.NoError(t, err)
+	require.False(t, called)
+}

--- a/node/nodeEconomics_test.go
+++ b/node/nodeEconomics_test.go
@@ -106,7 +106,7 @@ func TestNode_scanKAppDataTrie_nilTrie(t *testing.T) {
 	}
 
 	called := false
-	err := n.scanKAppDataTrie([]byte("addr"), func(_ []byte) { called = true })
+	err := n.scanKAppDataTrie([]byte("addr"), func(_ []byte) error { called = true; return nil })
 	require.NoError(t, err)
 	require.False(t, called)
 }

--- a/node/nodeEconomics_test.go
+++ b/node/nodeEconomics_test.go
@@ -1,36 +1,55 @@
 package node
 
 import (
+	"errors"
+	"math"
 	"testing"
 
+	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core/kapp"
 	kdafeespool "github.com/klever-io/klever-go/core/kapp/kdaFeesPool"
 	"github.com/klever-io/klever-go/core/keyValStorage"
 	"github.com/klever-io/klever-go/core/process/kda/kdautils"
 	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/kapps"
+	"github.com/klever-io/klever-go/network/api/models"
 	"github.com/klever-io/klever-go/tools/marshal"
 	"github.com/stretchr/testify/require"
 )
 
-// newEconomicsTestNode builds a minimal Node whose KApp adapter returns an account whose data
-// trie yields the given key->value records (values delivered via GetStorage, already trimmed).
-func newEconomicsTestNode(records map[string][]byte) *Node {
-	leaves := make([]data.KeyValueHolder, 0, len(records))
-	for key := range records {
-		leaves = append(leaves, keyValStorage.NewKeyValStorage([]byte(key), nil))
-	}
-	trieStub := &mock.TrieStub{
+// marketKappEscrowStub stubs only GetMarketEscrowTotal; other MarketKapp calls are not expected.
+type marketKappEscrowStub struct {
+	kapp.MarketKapp
+	total int64
+	err   error
+}
+
+func (m *marketKappEscrowStub) GetMarketEscrowTotal() (int64, error) { return m.total, m.err }
+
+// trieWithKeys returns a trie stub whose leaves channel yields the given keys (values via GetStorage).
+func trieWithKeys(keys ...string) *mock.TrieStub {
+	return &mock.TrieStub{
 		GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
-			ch := make(chan data.KeyValueHolder, len(leaves))
-			for _, l := range leaves {
-				ch <- l
+			ch := make(chan data.KeyValueHolder, len(keys))
+			for _, k := range keys {
+				ch <- keyValStorage.NewKeyValStorage([]byte(k), nil)
 			}
 			close(ch)
 			return ch, nil
 		},
 	}
+}
+
+// newEconomicsTestNode builds a minimal Node whose KApp adapter returns an account whose data
+// trie yields the given key->value records (values delivered via GetStorage, already trimmed).
+func newEconomicsTestNode(records map[string][]byte) *Node {
+	keys := make([]string, 0, len(records))
+	for key := range records {
+		keys = append(keys, key)
+	}
+	trieStub := trieWithKeys(keys...)
 	app := &mock.KAppAccountHandlerStub{
 		DataTrieCalled:    func() data.Trie { return trieStub },
 		GetRootHashCalled: func() []byte { return []byte("root") },
@@ -113,4 +132,359 @@ func TestNode_scanKAppDataTrie_nilTrie(t *testing.T) {
 	err := n.scanKAppDataTrie([]byte("addr"), nil, func(_ []byte) error { called = true; return nil })
 	require.NoError(t, err)
 	require.False(t, called)
+}
+
+func TestNode_scanKAppDataTrie_channelError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("walk failed")
+	app := &mock.KAppAccountHandlerStub{
+		DataTrieCalled: func() data.Trie {
+			return &mock.TrieStub{GetAllLeavesOnChannelCalled: func(_ []byte) (chan data.KeyValueHolder, error) {
+				return nil, expectedErr
+			}}
+		},
+		GetRootHashCalled: func() []byte { return []byte("root") },
+	}
+	n := &Node{
+		kapps: &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return app, nil },
+		},
+		internalMarshalizer: marshal.NewProtoMarshalizer(),
+	}
+
+	err := n.scanKAppDataTrie([]byte("addr"), nil, func(_ []byte) error { return nil })
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestNode_loadKAppAccount_errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("load error propagates", func(t *testing.T) {
+		t.Parallel()
+		expectedErr := errors.New("load failed")
+		n := &Node{kapps: &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return nil, expectedErr },
+		}}
+		app, err := n.loadKAppAccount([]byte("addr"))
+		require.ErrorIs(t, err, expectedErr)
+		require.Nil(t, app)
+	})
+
+	t.Run("non-KApp account is a wrong type assertion", func(t *testing.T) {
+		t.Parallel()
+		n := &Node{kapps: &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return state.NewEmptyPeerAccount(), nil },
+		}}
+		app, err := n.loadKAppAccount([]byte("addr"))
+		require.ErrorIs(t, err, common.ErrWrongTypeAssertion)
+		require.Nil(t, app)
+	})
+}
+
+func TestNode_loadSystemAccountKLV(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the system-account KLV balance", func(t *testing.T) {
+		t.Parallel()
+		app := &mock.KAppAccountHandlerStub{
+			GetUserKDACalled: func(_ []byte, _ []byte) (*kapps.UserKDA, error) {
+				return &kapps.UserKDA{Balance: 77}, nil
+			},
+		}
+		n := &Node{kapps: &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return app, nil },
+		}}
+		balance, err := n.loadSystemAccountKLV()
+		require.NoError(t, err)
+		require.Equal(t, int64(77), balance)
+	})
+
+	t.Run("propagates GetUserKDA error", func(t *testing.T) {
+		t.Parallel()
+		expectedErr := errors.New("kda read failed")
+		app := &mock.KAppAccountHandlerStub{
+			GetUserKDACalled: func(_ []byte, _ []byte) (*kapps.UserKDA, error) { return nil, expectedErr },
+		}
+		n := &Node{kapps: &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return app, nil },
+		}}
+		balance, err := n.loadSystemAccountKLV()
+		require.ErrorIs(t, err, expectedErr)
+		require.Zero(t, balance)
+	})
+}
+
+func TestNode_loadKAppHeldTotals_errors(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("kapp read failed")
+
+	t.Run("pending rewards error propagates", func(t *testing.T) {
+		t.Parallel()
+		n := &Node{kappController: &mock.KappsControllerMock{
+			ValidatorsKapp: &mock.ValidatorsKAppStub{
+				GetPendingRewardsTotalCalled: func() (int64, error) { return 0, expectedErr },
+			},
+		}}
+		_, _, err := n.loadKAppHeldTotals()
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("market escrow error propagates", func(t *testing.T) {
+		t.Parallel()
+		n := &Node{kappController: &mock.KappsControllerMock{
+			ValidatorsKapp: &mock.ValidatorsKAppStub{
+				GetPendingRewardsTotalCalled: func() (int64, error) { return 1, nil },
+			},
+			MarketKapp: &marketKappEscrowStub{err: expectedErr},
+		}}
+		_, _, err := n.loadKAppHeldTotals()
+		require.ErrorIs(t, err, expectedErr)
+	})
+}
+
+func TestAddGuarded(t *testing.T) {
+	t.Parallel()
+
+	total := int64(math.MaxInt64 - 1)
+	addGuarded(&total, 5, "test") // would overflow, skipped
+	require.Equal(t, int64(math.MaxInt64-1), total)
+	addGuarded(&total, -1, "test") // negative, skipped
+	require.Equal(t, int64(math.MaxInt64-1), total)
+	addGuarded(&total, 1, "test")
+	require.Equal(t, int64(math.MaxInt64), total)
+}
+
+// newFullEconomicsNode builds a Node where every economics dependency succeeds. The returned apps
+// map is captured by the KApp adapter, so tests can swap per-address behavior before calling.
+func newFullEconomicsNode(t *testing.T) (*Node, map[string]state.AccountHandler) {
+	marshalizer := marshal.NewProtoMarshalizer()
+	klvKey := string(kdautils.ToKDAKey(kdautils.KLVIdentifier, nil))
+
+	kdaRaw, err := marshalizer.Marshal(&kapps.KDAData{
+		InitialSupply:     10_000,
+		MaxSupply:         100_000,
+		MintedValue:       500,
+		BurnedValue:       200,
+		CirculatingSupply: 9_000,
+	})
+	require.NoError(t, err)
+	kdaApp := &mock.KAppAccountHandlerStub{
+		DataTrieTrackerCalled: func() state.DataTrieTracker {
+			return &mock.DataTrieTrackerStub{RetrieveValueCalled: func(key []byte) ([]byte, error) {
+				require.Equal(t, klvKey, string(key))
+				return kdaRaw, nil
+			}}
+		},
+	}
+
+	feesRaw, err := marshalizer.Marshal(&kdafeespool.KDAFeesPoolData{KLVBalance: 300})
+	require.NoError(t, err)
+	feesApp := &mock.KAppAccountHandlerStub{
+		DataTrieCalled:    func() data.Trie { return trieWithKeys("KLV") },
+		GetRootHashCalled: func() []byte { return []byte("root") },
+		GetStorageCalled:  func(_ []byte) []byte { return feesRaw },
+	}
+
+	sysApp := &mock.KAppAccountHandlerStub{
+		GetUserKDACalled: func(_ []byte, _ []byte) (*kapps.UserKDA, error) {
+			return &kapps.UserKDA{Balance: 77}, nil
+		},
+	}
+
+	// one record serves both the FPR-pool scan (leaf) and loadStakingData (tracker retrieve)
+	stakingRaw, err := marshalizer.Marshal(&kapps.StakingData{
+		TotalStaked:      5_000,
+		CurrentFPRAmount: 40,
+		FPR:              []*kapps.FPRData{{TotalAmount: 100, TotalClaimed: 60}},
+	})
+	require.NoError(t, err)
+	stakingApp := &mock.KAppAccountHandlerStub{
+		DataTrieCalled:    func() data.Trie { return trieWithKeys(klvKey) },
+		GetRootHashCalled: func() []byte { return []byte("root") },
+		GetStorageCalled:  func(_ []byte) []byte { return stakingRaw },
+		DataTrieTrackerCalled: func() state.DataTrieTracker {
+			return &mock.DataTrieTrackerStub{RetrieveValueCalled: func(_ []byte) ([]byte, error) {
+				return stakingRaw, nil
+			}}
+		},
+	}
+
+	apps := map[string]state.AccountHandler{
+		string(kapps.KDAKAppAddress):           kdaApp,
+		string(kapps.KDAFeesPoolKAppAddress):   feesApp,
+		string(kapps.SystemAccountKAppAddress): sysApp,
+		string(kapps.StakingKAppAddress):       stakingApp,
+	}
+
+	mkPeer := func(fees int64) state.PeerAccountHandler {
+		p := state.NewEmptyPeerAccount()
+		p.AddToAccumulatedFees(fees)
+		return p
+	}
+
+	n := &Node{
+		blkc: &mock.BlockChainMock{GetCurrentBlockHeaderCalled: func() data.HeaderHandler { return nil }},
+		kapps: &mock.AccountsStub{LoadAccountCalled: func(address []byte) (state.AccountHandler, error) {
+			app, ok := apps[string(address)]
+			require.True(t, ok, "unexpected KApp address")
+			return app, nil
+		}},
+		kappController: &mock.KappsControllerMock{
+			ValidatorsKapp: &mock.ValidatorsKAppStub{
+				GetPendingRewardsTotalCalled: func() (int64, error) { return 111, nil },
+			},
+			MarketKapp: &marketKappEscrowStub{total: 222},
+		},
+		validatorStatistics: &mock.ValidatorStatisticsProcessorStub{
+			LastFinalizedRootHashCalled: func() []byte { return []byte("root") },
+			ListPeerAccountsCalled: func(_ []byte) ([]state.PeerAccountHandler, error) {
+				return []state.PeerAccountHandler{mkPeer(25), mkPeer(15)}, nil
+			},
+		},
+		internalMarshalizer: marshalizer,
+	}
+	return n, apps
+}
+
+func TestNode_GetEconomics(t *testing.T) {
+	t.Parallel()
+
+	n, _ := newFullEconomicsNode(t)
+
+	resp, err := n.GetEconomics()
+	require.NoError(t, err)
+	require.Equal(t, &models.EconomicsResponse{
+		InitialSupply:           10_000,
+		MaxSupply:               100_000,
+		MintedValue:             500,
+		BurnedValue:             200,
+		CirculatingSupply:       9_000,
+		TotalStaked:             5_000,
+		PendingRewardsTotal:     111,
+		MarketEscrowTotal:       222,
+		FeesPoolKLVTotal:        300,
+		FPRPoolTotal:            80, // 40 current + (100-60) unclaimed
+		AccumulatedFeesTotal:    40, // 25 + 15
+		SystemAccountKLVBalance: 77,
+	}, resp)
+
+	cached, err := n.GetEconomics()
+	require.NoError(t, err)
+	require.Same(t, resp, cached) // memoized within the block
+}
+
+func TestNode_computeEconomics_paths(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("dependency failed")
+	klvKey := string(kdautils.ToKDAKey(kdautils.KLVIdentifier, nil))
+
+	t.Run("asset load error propagates", func(t *testing.T) {
+		t.Parallel()
+		n, _ := newFullEconomicsNode(t)
+		n.kapps = &mock.AccountsStub{
+			LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) { return nil, expectedErr },
+		}
+		_, err := n.computeEconomics()
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("held totals error propagates", func(t *testing.T) {
+		t.Parallel()
+		n, _ := newFullEconomicsNode(t)
+		n.kappController = &mock.KappsControllerMock{
+			ValidatorsKapp: &mock.ValidatorsKAppStub{
+				GetPendingRewardsTotalCalled: func() (int64, error) { return 0, expectedErr },
+			},
+		}
+		_, err := n.computeEconomics()
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("fees pool decode error propagates", func(t *testing.T) {
+		t.Parallel()
+		n, apps := newFullEconomicsNode(t)
+		apps[string(kapps.KDAFeesPoolKAppAddress)] = &mock.KAppAccountHandlerStub{
+			DataTrieCalled:    func() data.Trie { return trieWithKeys("KLV") },
+			GetRootHashCalled: func() []byte { return []byte("root") },
+			GetStorageCalled:  func(_ []byte) []byte { return []byte{0xff, 0xfe, 0xfd} },
+		}
+		_, err := n.computeEconomics()
+		require.Error(t, err)
+	})
+
+	t.Run("system account error propagates", func(t *testing.T) {
+		t.Parallel()
+		n, apps := newFullEconomicsNode(t)
+		apps[string(kapps.SystemAccountKAppAddress)] = &mock.KAppAccountHandlerStub{
+			GetUserKDACalled: func(_ []byte, _ []byte) (*kapps.UserKDA, error) { return nil, expectedErr },
+		}
+		_, err := n.computeEconomics()
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("accumulated fees error propagates", func(t *testing.T) {
+		t.Parallel()
+		n, _ := newFullEconomicsNode(t)
+		n.validatorStatistics = &mock.ValidatorStatisticsProcessorStub{
+			LastFinalizedRootHashCalled: func() []byte { return []byte("root") },
+			ListPeerAccountsCalled: func(_ []byte) ([]state.PeerAccountHandler, error) {
+				return nil, expectedErr
+			},
+		}
+		_, err := n.computeEconomics()
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("staking read error propagates", func(t *testing.T) {
+		t.Parallel()
+		n, apps := newFullEconomicsNode(t)
+		marshalizer := marshal.NewProtoMarshalizer()
+		stakingRaw, err := marshalizer.Marshal(&kapps.StakingData{CurrentFPRAmount: 40})
+		require.NoError(t, err)
+		apps[string(kapps.StakingKAppAddress)] = &mock.KAppAccountHandlerStub{
+			DataTrieCalled:    func() data.Trie { return trieWithKeys(klvKey) },
+			GetRootHashCalled: func() []byte { return []byte("root") },
+			GetStorageCalled:  func(_ []byte) []byte { return stakingRaw },
+			DataTrieTrackerCalled: func() state.DataTrieTracker {
+				return &mock.DataTrieTrackerStub{RetrieveValueCalled: func(_ []byte) ([]byte, error) {
+					return nil, expectedErr
+				}}
+			},
+		}
+		_, err = n.computeEconomics()
+		require.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("missing staking record means zero staked, not an error", func(t *testing.T) {
+		t.Parallel()
+		n, apps := newFullEconomicsNode(t)
+		marshalizer := marshal.NewProtoMarshalizer()
+		stakingRaw, err := marshalizer.Marshal(&kapps.StakingData{CurrentFPRAmount: 40})
+		require.NoError(t, err)
+		apps[string(kapps.StakingKAppAddress)] = &mock.KAppAccountHandlerStub{
+			DataTrieCalled:    func() data.Trie { return trieWithKeys(klvKey) },
+			GetRootHashCalled: func() []byte { return []byte("root") },
+			GetStorageCalled:  func(_ []byte) []byte { return stakingRaw },
+			DataTrieTrackerCalled: func() state.DataTrieTracker {
+				return &mock.DataTrieTrackerStub{RetrieveValueCalled: func(_ []byte) ([]byte, error) {
+					return nil, nil // no record stored
+				}}
+			},
+		}
+		resp, err := n.computeEconomics()
+		require.NoError(t, err)
+		require.Zero(t, resp.TotalStaked)
+	})
+
+	t.Run("nil validator statistics yields zero accumulated fees", func(t *testing.T) {
+		t.Parallel()
+		n, _ := newFullEconomicsNode(t)
+		n.validatorStatistics = nil
+		resp, err := n.computeEconomics()
+		require.NoError(t, err)
+		require.Zero(t, resp.AccumulatedFeesTotal)
+	})
 }

--- a/node/nodeEconomics_test.go
+++ b/node/nodeEconomics_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/klever-io/klever-go/common/mock"
 	kdafeespool "github.com/klever-io/klever-go/core/kapp/kdaFeesPool"
 	"github.com/klever-io/klever-go/core/keyValStorage"
+	"github.com/klever-io/klever-go/core/process/kda/kdautils"
 	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/kapps"
@@ -48,7 +49,8 @@ func TestNode_loadFeesPoolKLVTotal(t *testing.T) {
 
 	marshalizer := marshal.NewProtoMarshalizer()
 	records := make(map[string][]byte)
-	for id, klv := range map[string]int64{"KLV": 1000, "ABC-1q2w": 2500, "ZERO": 0} {
+	// NEG exercises the negative guard: a corrupt balance is skipped, not summed.
+	for id, klv := range map[string]int64{"KLV": 1000, "ABC-1q2w": 2500, "ZERO": 0, "NEG": -50} {
 		raw, err := marshalizer.Marshal(&kdafeespool.KDAFeesPoolData{KLVBalance: klv})
 		require.NoError(t, err)
 		records[id] = raw
@@ -57,7 +59,7 @@ func TestNode_loadFeesPoolKLVTotal(t *testing.T) {
 	n := newEconomicsTestNode(records)
 	total, err := n.loadFeesPoolKLVTotal()
 	require.NoError(t, err)
-	require.Equal(t, int64(3500), total) // 1000 + 2500 + 0
+	require.Equal(t, int64(3500), total) // 1000 + 2500 + 0, NEG skipped
 }
 
 func TestNode_loadFPRPoolKLVTotal(t *testing.T) {
@@ -83,8 +85,10 @@ func TestNode_loadFPRPoolKLVTotal(t *testing.T) {
 	for id, s := range stakings {
 		raw, err := marshalizer.Marshal(s)
 		require.NoError(t, err)
-		records[id] = raw
+		records[string(kdautils.ToKDAKey([]byte(id), nil))] = raw
 	}
+	// a non-KDA-prefixed leaf must be filtered out, not decoded into the total
+	records["garbage-key"] = []byte{0xff, 0xfe, 0xfd}
 
 	n := newEconomicsTestNode(records)
 	total, err := n.loadFPRPoolKLVTotal()
@@ -106,7 +110,7 @@ func TestNode_scanKAppDataTrie_nilTrie(t *testing.T) {
 	}
 
 	called := false
-	err := n.scanKAppDataTrie([]byte("addr"), func(_ []byte) error { called = true; return nil })
+	err := n.scanKAppDataTrie([]byte("addr"), nil, func(_ []byte) error { called = true; return nil })
 	require.NoError(t, err)
 	require.False(t, called)
 }


### PR DESCRIPTION
## Summary

Adds two read-only, opt-in node endpoints exposing live KLV held-balance aggregates for supply reconciliation, plus a KFI/KLV circulating-supply transposition fix in the indexer. Every held aggregate is KLV already inside `circulatingSupply`, so summing them against `circulatingSupply` recovers the full physical KLV total.

## `GET /network/economics`

Disabled by default (`open: false`); memoized per block. Returns supply figures (`initialSupply`, `maxSupply`, `mintedValue`, `burnedValue`, `circulatingSupply`, `totalStaked`) plus held aggregates from KApp/peer state:

- `pendingRewardsTotal` — unclaimed PREW (Validators KApp)
- `marketEscrowTotal` — open-order escrow (`CurrentBid` in KLV + `RoyaltiesFixedDeposit`)
- `feesPoolKlvTotal` — Σ `KLVBalance` across KDA fee pools
- `fprPoolTotal` — KLV staking-reward pool (`CurrentFPRAmount` + unclaimed `FPRData`; non-KLV `KDAS` excluded)
- `accumulatedFeesTotal` — Σ validator `AccumulatedFees` (accrued, pre-distribution)
- `systemAccountKlvBalance` — KLV held by the system-account KApp

## `GET /network/account-totals`

Disabled by default; memoized per block. A full walk of the user-accounts trie returning `accountCount`, `balanceTotal`, and `allowanceTotal` (inline KLV `Balance` + `Allowance`). Accounts are identified by `Address == leaf key`, so smart-contract code leaves — which can decode cleanly into a `UserAccountData` — are excluded. Frozen/unfrozen are out of scope (sub-trie; `totalStaked` covers frozen).

Both endpoints share a generic per-block `blockCache[T]` helper.

## Indexer fix

Corrects `SaveEpochInfo` where `KFICirculatingSupply`/`KLVCirculatingSupply` were assigned from the swapped KDA structs, `KFITotalStaked` was never set, and a copy-paste guard checked the wrong staking-bytes variable.

**Downstream impact**: epoch documents indexed before this fix carry swapped `kfiCirculationSupply`/`klvCirculationSupply` values and `kfiTotalStaked: 0`; documents are correct from the first epoch indexed with this build. Consumers reading historical epoch docs should account for this (or reindex). No ES mapping change — the epoch index uses dynamic mapping and all four fields already exist in every document.

## Tests

Unit tests for the KApp scan aggregates (market escrow, pending rewards), the node-level FPR / fees / balance / allowance summing — including FPR `KDAS` exclusion and the account-vs-code-leaf discrimination — and the new route handlers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added two opt-in, read-only network API endpoints for live supply/account aggregation: `GET /network/economics` and `GET /network/account-totals` (both disabled by default in `config/node/api.yaml`). Both handlers are memoized per block and backed by new facade/node methods (`GetEconomics`, `GetAccountTotals`) that derive totals from on-chain state (KApps/trie data and user-accounts trie) rather than affecting transaction processing or consensus.

**Blockchain-critical impact (stability/data integrity)**
- **Networking/API**: Introduces new Gin route handlers and response models (`EconomicsResponse`, `AccountTotalsResponse`) with explicit internal error propagation (`ErrGetEconomics`, `ErrGetAccountTotals`). Adds tests for nil app/facade context and facade handler failures.
- **State management (node, read-only)**:
  - Adds a mutex-protected generic `blockCache[T]` keyed by the current block header nonce to ensure per-block memoization and safe concurrent access.
  - Hardens caching semantics by rejecting `(nil, nil)` compute results (`errNilComputeResult`), and adds tests covering per-block invalidation and concurrent callers sharing a single computation.
  - Economics aggregation scans relevant KApp data tries and computes held aggregates (fees-pool KLV total, FPR pool KLV total with KLV-only logic and positive-delta handling, system-account KLV balance, plus pending rewards and market escrow totals from KApp interfaces) alongside base supply figures from the asset interface.
  - Account totals traverse the user-accounts trie, decode `UserAccountData`, and **exclude smart-contract code leaves** by requiring the embedded/stored address to match the leaf key.

**Cross-cutting correctness fixes**
- **Indexer/data integrity**: Fixes `SaveEpochInfo` to correct swapped KDA circulating-supply assignments (KFI vs KLV) and fixes a copy-paste staking-bytes guard so the correct byte slice is validated.

**KApp/trie interface expansion**
- Extends KApp interfaces and implementations to expose trie-derived aggregates used by economics:
  - `ValidatorsKapp.GetPendingRewardsTotal`
  - `MarketKapp.GetMarketEscrowTotal`
- Adds unit tests for prefix filtering, claimed vs unclaimed handling, and nil/edge paths in trie scanning.

**Concurrency/error handling**
- Concurrency changes are confined to the new per-block cache (lock-protected compute + nonce-based invalidation), with additional error-path tests for aggregation helpers and route handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
