### PR TITLE
[KLC-2448] Check HTTP status in operator GetURL and PostURL

### DIFF
--- a/cmd/operator/utils/http.go
+++ b/cmd/operator/utils/http.go
@@ -2,11 +2,14 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 )
+
+const maxErrorBodySnippet = 512
 
 var httpClient *http.Client
 
@@ -21,6 +24,10 @@ func GetURL(url string, target interface{}) error {
 		return err
 	}
 	defer func() { _ = r.Body.Close() }()
+
+	if err := checkStatus(http.MethodGet, url, r); err != nil {
+		return err
+	}
 
 	return json.NewDecoder(r.Body).Decode(target)
 }
@@ -43,6 +50,10 @@ func PostURL(url, body string, headers []string, target interface{}) error {
 	}
 	defer func() { _ = r.Body.Close() }()
 
+	if err := checkStatus(http.MethodPost, url, r); err != nil {
+		return err
+	}
+
 	if target != nil {
 		data, errRead := io.ReadAll(r.Body)
 		if errRead != nil {
@@ -54,4 +65,18 @@ func PostURL(url, body string, headers []string, target interface{}) error {
 		}
 	}
 	return nil
+}
+
+func checkStatus(method, url string, r *http.Response) error {
+	if r.StatusCode >= http.StatusOK && r.StatusCode < http.StatusMultipleChoices {
+		return nil
+	}
+
+	snippet, _ := io.ReadAll(io.LimitReader(r.Body, maxErrorBodySnippet))
+	body := strings.TrimSpace(string(snippet))
+	if body == "" {
+		return fmt.Errorf("%s %s: unexpected HTTP status %s", method, url, r.Status)
+	}
+
+	return fmt.Errorf("%s %s: unexpected HTTP status %s: %s", method, url, r.Status, body)
 }

--- a/cmd/operator/utils/http.go
+++ b/cmd/operator/utils/http.go
@@ -7,9 +7,13 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode"
 )
 
-const maxErrorBodySnippet = 512
+const (
+	maxErrorBodySnippet = 512
+	maxResponseBody     = 32 << 20
+)
 
 var httpClient *http.Client
 
@@ -29,7 +33,7 @@ func GetURL(url string, target interface{}) error {
 		return err
 	}
 
-	return json.NewDecoder(r.Body).Decode(target)
+	return json.NewDecoder(io.LimitReader(r.Body, maxResponseBody)).Decode(target)
 }
 
 // PostURL provides a post using a json string
@@ -55,9 +59,12 @@ func PostURL(url, body string, headers []string, target interface{}) error {
 	}
 
 	if target != nil {
-		data, errRead := io.ReadAll(r.Body)
+		data, errRead := io.ReadAll(io.LimitReader(r.Body, maxResponseBody+1))
 		if errRead != nil {
 			return errRead
+		}
+		if int64(len(data)) > maxResponseBody {
+			return fmt.Errorf("%s %s: response body exceeds %d bytes", http.MethodPost, url, maxResponseBody)
 		}
 
 		if err := json.Unmarshal(data, &target); err != nil {
@@ -73,10 +80,23 @@ func checkStatus(method, url string, r *http.Response) error {
 	}
 
 	snippet, _ := io.ReadAll(io.LimitReader(r.Body, maxErrorBodySnippet))
-	body := strings.TrimSpace(string(snippet))
+	status := sanitizeServerText(r.Status)
+	body := strings.TrimSpace(sanitizeServerText(string(snippet)))
 	if body == "" {
-		return fmt.Errorf("%s %s: unexpected HTTP status %s", method, url, r.Status)
+		return fmt.Errorf("%s %s: unexpected HTTP status %s", method, url, status)
 	}
 
-	return fmt.Errorf("%s %s: unexpected HTTP status %s: %s", method, url, r.Status, body)
+	return fmt.Errorf("%s %s: unexpected HTTP status %s: %s", method, url, status, body)
+}
+
+func sanitizeServerText(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/cmd/operator/utils/http_test.go
+++ b/cmd/operator/utils/http_test.go
@@ -1,0 +1,147 @@
+package utils_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/klever-io/klever-go/cmd/operator/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sampleResult struct {
+	Name string `json:"name"`
+}
+
+func TestGetURLDecodesSuccessBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"klever"}`))
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.GetURL(srv.URL, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, "klever", got.Name)
+}
+
+func TestGetURLReturnsErrorOnServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"name":"boom"}`))
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.GetURL(srv.URL, &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "boom")
+	assert.Empty(t, got.Name)
+}
+
+func TestGetURLReturnsErrorOnNotFoundStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.GetURL(srv.URL, &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestGetURLReturnsErrorOnMultipleChoicesStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMultipleChoices)
+		_, _ = w.Write([]byte("choices"))
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.GetURL(srv.URL, &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "300")
+}
+
+func TestGetURLSurfacesEOFOnEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.GetURL(srv.URL, &got)
+	assert.True(t, errors.Is(err, io.EOF), "empty 2xx body must still surface io.EOF for not-found callers")
+}
+
+func TestGetURLTruncatesBodyInError(t *testing.T) {
+	longBody := strings.Repeat("Z", 2000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(longBody))
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.GetURL(srv.URL, &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+	assert.Equal(t, 512, strings.Count(err.Error(), "Z"), "body snippet must be capped at 512 bytes")
+}
+
+func TestPostURLDecodesSuccessBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"klever"}`))
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.PostURL(srv.URL, `{}`, nil, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, "klever", got.Name)
+}
+
+func TestPostURLReturnsErrorOnServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"name":"boom"}`))
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.PostURL(srv.URL, `{}`, nil, &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "boom")
+	assert.Empty(t, got.Name)
+}
+
+func TestPostURLReturnsErrorOnEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.PostURL(srv.URL, `{}`, nil, &got)
+	require.Error(t, err)
+}
+
+func TestPostURLNilTargetReturnsNilOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"ignored"}`))
+	}))
+	defer srv.Close()
+
+	err := utils.PostURL(srv.URL, `{}`, nil, nil)
+	assert.NoError(t, err)
+}

--- a/cmd/operator/utils/http_test.go
+++ b/cmd/operator/utils/http_test.go
@@ -17,57 +17,93 @@ type sampleResult struct {
 	Name string `json:"name"`
 }
 
-func TestGetURLDecodesSuccessBody(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"name":"klever"}`))
-	}))
-	defer srv.Close()
+func TestURLHandlesHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		status     int
+		body       string
+		wantErr    bool
+		wantName   string
+		wantSubstr []string
+	}{
+		{
+			name:     "GET decodes success body",
+			method:   http.MethodGet,
+			status:   http.StatusOK,
+			body:     `{"name":"klever"}`,
+			wantName: "klever",
+		},
+		{
+			name:       "GET surfaces server error",
+			method:     http.MethodGet,
+			status:     http.StatusInternalServerError,
+			body:       `{"name":"boom"}`,
+			wantErr:    true,
+			wantSubstr: []string{"500", "boom"},
+		},
+		{
+			name:       "GET rejects not found",
+			method:     http.MethodGet,
+			status:     http.StatusNotFound,
+			body:       "not found",
+			wantErr:    true,
+			wantSubstr: []string{"404"},
+		},
+		{
+			name:       "GET rejects multiple choices",
+			method:     http.MethodGet,
+			status:     http.StatusMultipleChoices,
+			body:       "choices",
+			wantErr:    true,
+			wantSubstr: []string{"300"},
+		},
+		{
+			name:     "POST decodes success body",
+			method:   http.MethodPost,
+			status:   http.StatusOK,
+			body:     `{"name":"klever"}`,
+			wantName: "klever",
+		},
+		{
+			name:       "POST surfaces server error",
+			method:     http.MethodPost,
+			status:     http.StatusInternalServerError,
+			body:       `{"name":"boom"}`,
+			wantErr:    true,
+			wantSubstr: []string{"500", "boom"},
+		},
+	}
 
-	var got sampleResult
-	err := utils.GetURL(srv.URL, &got)
-	assert.NoError(t, err)
-	assert.Equal(t, "klever", got.Name)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
 
-func TestGetURLReturnsErrorOnServerError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"name":"boom"}`))
-	}))
-	defer srv.Close()
+			var got sampleResult
+			var err error
+			if tt.method == http.MethodPost {
+				err = utils.PostURL(srv.URL, `{}`, nil, &got)
+			} else {
+				err = utils.GetURL(srv.URL, &got)
+			}
 
-	var got sampleResult
-	err := utils.GetURL(srv.URL, &got)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "500")
-	assert.Contains(t, err.Error(), "boom")
-	assert.Empty(t, got.Name)
-}
+			if tt.wantErr {
+				require.Error(t, err)
+				for _, substr := range tt.wantSubstr {
+					assert.Contains(t, err.Error(), substr)
+				}
+				assert.Empty(t, got.Name)
+				return
+			}
 
-func TestGetURLReturnsErrorOnNotFoundStatus(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "not found", http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	var got sampleResult
-	err := utils.GetURL(srv.URL, &got)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "404")
-}
-
-func TestGetURLReturnsErrorOnMultipleChoicesStatus(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusMultipleChoices)
-		_, _ = w.Write([]byte("choices"))
-	}))
-	defer srv.Close()
-
-	var got sampleResult
-	err := utils.GetURL(srv.URL, &got)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "300")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantName, got.Name)
+		})
+	}
 }
 
 func TestGetURLSurfacesEOFOnEmptyBody(t *testing.T) {
@@ -96,32 +132,19 @@ func TestGetURLTruncatesBodyInError(t *testing.T) {
 	assert.Equal(t, 512, strings.Count(err.Error(), "Z"), "body snippet must be capped at 512 bytes")
 }
 
-func TestPostURLDecodesSuccessBody(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"name":"klever"}`))
-	}))
-	defer srv.Close()
-
-	var got sampleResult
-	err := utils.PostURL(srv.URL, `{}`, nil, &got)
-	assert.NoError(t, err)
-	assert.Equal(t, "klever", got.Name)
-}
-
-func TestPostURLReturnsErrorOnServerError(t *testing.T) {
+func TestErrorStripsControlCharsFromServerBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"name":"boom"}`))
+		_, _ = w.Write([]byte("line1\nline2\x1b[2Kfaked-success"))
 	}))
 	defer srv.Close()
 
 	var got sampleResult
-	err := utils.PostURL(srv.URL, `{}`, nil, &got)
+	err := utils.GetURL(srv.URL, &got)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "500")
-	assert.Contains(t, err.Error(), "boom")
-	assert.Empty(t, got.Name)
+	assert.NotContains(t, err.Error(), "\n", "newlines must be stripped to prevent log line forging")
+	assert.NotContains(t, err.Error(), "\x1b", "escape sequences must be stripped to prevent terminal spoofing")
+	assert.Contains(t, err.Error(), "line1line2[2Kfaked-success")
 }
 
 func TestPostURLReturnsErrorOnEmptyBody(t *testing.T) {


### PR DESCRIPTION
The operator CLI's HTTP helpers (`utils.GetURL` / `utils.PostURL`) decoded the response body regardless of the HTTP status, so a non-2xx response carrying a JSON error body was silently decoded into the target struct as if the request had succeeded — callers moved on with a zero-value or partially-populated object and no error. This PR makes both helpers inspect the status code before decoding and return a descriptive error on any non-2xx response.

## What changed
- `GetURL` and `PostURL` now reject non-2xx responses before decoding, via a small `checkStatus` helper that reports the method, URL, status, and a 512-byte-truncated snippet of the response body.
- Only `2xx` counts as success. The 2xx decode paths are left byte-for-byte unchanged, so an empty 2xx body still surfaces `io.EOF` — the signal the existing not-found handling relies on.
- Added `cmd/operator/utils/http_test.go` (httptest-based) covering success decode, 404, 500-with-JSON-body, the 300 boundary, empty-body `io.EOF`, the 512-byte truncation cap, and the `PostURL` empty-body / nil-target paths.

## Why
The old behavior relied on incidental luck: a non-2xx JSON error body would decode into a zero/partial struct and look like success, and "not found" only surfaced when the server happened to return an empty body. Several `query.go` helpers silently proceeded with zero values on server errors. Checking the status up front makes those failures explicit while keeping the empty-body → `io.EOF` path intact, so the change stays minimal and no callers need to be touched.

## Tests
- New httptest-based suite for both helpers; `go test ./cmd/operator/...` passes; `gofmt`/`go vet` clean.

## Compatibility / risk
No API or schema changes. The only behavior change is error surfacing: operator commands that previously proceeded silently after a non-2xx response now return that error. The 2xx success path and the empty-body not-found path are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the operator CLI HTTP helpers to fail fast on non-2xx responses before attempting JSON decoding. This tightens error handling so callers no longer risk treating 4xx/5xx responses as successful, reducing the chance of incorrect operator-side state transitions.

Key changes:
- `utils.GetURL` and `utils.PostURL` now validate HTTP status codes through a shared `checkStatus` helper.
- Non-2xx errors now include method, URL, status, and a response-body snippet capped at 512 bytes.
- Successful 2xx decoding behavior remains unchanged, including existing `io.EOF` handling for empty bodies.

Added tests covering:
- successful GET/POST decoding
- 300/404/500 status handling
- empty-body `io.EOF`
- error-body truncation
- `PostURL` with nil target
<!-- end of auto-generated comment: release notes by coderabbit.ai -->