### PR TITLE
[KLC-2513] Count KDA transfers only for transfer builtin functions

### DIFF
--- a/core/process/smartContract/hooks/counters/usageCounter.go
+++ b/core/process/smartContract/hooks/counters/usageCounter.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	logger "github.com/klever-io/klever-go-logger"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/klever-io/klever-go/vmcommon"
@@ -69,6 +70,10 @@ func (counter *usageCounter) ProcessMaxBuiltInCounters(input *vmcommon.ContractC
 		return fmt.Errorf("%w: too many built-in functions calls", process.ErrMaxCallsReached)
 	}
 
+	if !isTransferBuiltinFunction(input.Function) {
+		return nil
+	}
+
 	parsedTransfer, errKDATransfer := counter.kdaTransferParser.ParseKDATransfers(input.RecipientAddr, input.Arguments)
 	if errKDATransfer != nil {
 		// not a transfer - no need to count max transfers
@@ -81,6 +86,10 @@ func (counter *usageCounter) ProcessMaxBuiltInCounters(input *vmcommon.ContractC
 	}
 
 	return nil
+}
+
+func isTransferBuiltinFunction(function string) bool {
+	return function == core.BuiltInFunctionTransfer
 }
 
 // ResetCounters resets the state counters for the blockchain hook

--- a/core/process/smartContract/hooks/counters/usageCounter_test.go
+++ b/core/process/smartContract/hooks/counters/usageCounter_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/core/process/smartContract/hooks/counters"
 	"github.com/klever-io/klever-go/tools/check"
@@ -137,7 +138,7 @@ func TestUsageCounter_ProcessMaxBuiltInCounters(t *testing.T) {
 		values[maxBuiltinCalls] = 1000
 		counter.SetMaximumValues(values)
 
-		vmInput := &vmcommon.ContractCallInput{}
+		vmInput := &vmcommon.ContractCallInput{Function: core.BuiltInFunctionTransfer}
 
 		assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))                                 // counter is now 2
 		assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))                                 // counter is now 4
@@ -168,6 +169,62 @@ func TestUsageCounter_ProcessMaxBuiltInCounters(t *testing.T) {
 		}
 		assert.Equal(t, expectedMap, countersMap)
 	})
+}
+
+func TestNonTransferBuiltinNotCountedAsTransfer(t *testing.T) {
+	t.Parallel()
+
+	counter, _ := counters.NewUsageCounter(&KDATransferParserStub{
+		ParseKDATransfersCalled: func(rcvAddr []byte, args [][]byte) (*vmcommon.ParsedKDATransfers, error) {
+			return &vmcommon.ParsedKDATransfers{
+				KDATransfers: make([]*vmcommon.KDATransfer, 2),
+			}, nil
+		},
+	})
+	counter.SetMaximumValues(generateMapsOfValues(100))
+
+	vmInput := &vmcommon.ContractCallInput{Function: core.BuiltInFunctionFreeze}
+
+	assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))
+	assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))
+
+	countersMap := counter.GetCounterValues()
+	expectedMap := map[string]uint64{
+		crtBuiltinCalls: 2,
+		crtTransfers:    0,
+		crtTrieReads:    0,
+	}
+	assert.Equal(t, expectedMap, countersMap)
+}
+
+func TestMultiTransferStillCounted(t *testing.T) {
+	t.Parallel()
+
+	counter, _ := counters.NewUsageCounter(&KDATransferParserStub{
+		ParseKDATransfersCalled: func(rcvAddr []byte, args [][]byte) (*vmcommon.ParsedKDATransfers, error) {
+			return &vmcommon.ParsedKDATransfers{
+				KDATransfers: make([]*vmcommon.KDATransfer, 2),
+			}, nil
+		},
+	})
+	values := generateMapsOfValues(6)
+	values[maxBuiltinCalls] = 1000
+	counter.SetMaximumValues(values)
+
+	vmInput := &vmcommon.ContractCallInput{Function: core.BuiltInFunctionTransfer}
+
+	assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))                                 // transfers now 2
+	assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))                                 // transfers now 4
+	assert.Nil(t, counter.ProcessMaxBuiltInCounters(vmInput))                                 // transfers now 6
+	assert.ErrorIs(t, counter.ProcessMaxBuiltInCounters(vmInput), process.ErrMaxCallsReached) // transfers now 8, over cap
+
+	countersMap := counter.GetCounterValues()
+	expectedMap := map[string]uint64{
+		crtBuiltinCalls: 4,
+		crtTransfers:    8,
+		crtTrieReads:    0,
+	}
+	assert.Equal(t, expectedMap, countersMap)
 }
 
 // KDATransferParserStub -


### PR DESCRIPTION
The smart-contract usage counter ran the multi-transfer parser on every built-in call and added any successful parse result to the per-transaction KDA-transfer count, without checking the function name. A non-transfer built-in whose arguments coincidentally match the multi-transfer shape was miscounted as transfers, so a transaction mixing real transfers with such calls could hit the 250-transfer cap early and revert. This guards the transfer count so it only applies when the built-in is actually a transfer.

## What changed
- In `ProcessMaxBuiltInCounters` (`usageCounter.go`), return early after the built-in-call count when `input.Function` is not a transfer built-in — so non-transfer built-ins still count as a call but are never parsed or counted as transfers.
- The whitelist is `core.BuiltInFunctionTransfer` (`"KleverTransfer"`), the sole entry in the codebase's own `listOfTransferFunc`. The shared parser is left untouched (`input.Function` is already in scope at the counter, so no signature change).

## Why
The parser validates the argument shape, not the function name, so it treats any shape-matching input as a transfer. Checking `input.Function` is the minimal correct gate and mirrors the codebase's own transfer whitelist. The miscount was per-transaction (counters reset at the start of each top-level SC execution) and failed closed (the offending transaction simply reverts), so this is a correctness fix.

## Tests
- Added `TestNonTransferBuiltinNotCountedAsTransfer` (a transfer-shaped non-transfer built-in is not counted) and `TestMultiTransferStillCounted` (real transfers still count and still enforce the cap) to the existing `usageCounter_test.go`.
- Updated the pre-existing "number of transfers exceeded" subtest to set `Function = core.BuiltInFunctionTransfer`, since an empty `Function` is now correctly excluded by the guard. `go test -race` passes.

## Compatibility / risk
No API or protocol change. The behavior change is limited to counting: non-transfer built-ins no longer inflate the transfer counter, while real transfers and the 250 cap are unchanged. The fail-closed behavior is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated smart-contract usage counting to only classify KDA transfers when the built-in call is actually `KleverTransfer`, reducing the risk of miscounting non-transfer built-ins as transfers in transaction-processing logic.

- `ProcessMaxBuiltInCounters` now short-circuits for non-transfer built-ins after recording the built-in call, preventing transfer parsing and transfer-limit enforcement from running on unrelated calls.
- Transfer counting and max-transfer error handling remain unchanged for real transfer built-ins.
- Tests were expanded to cover:
  - non-transfer built-ins with transfer-shaped arguments are not counted as transfers
  - multi-transfer calls still accumulate correctly and still trip the transfer cap
- One existing test was updated to explicitly set the transfer built-in function to match the new guard.

This change is scoped to smart-contract execution/accounting and improves correctness of usage counters without altering consensus, networking, or state layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->