### PR TITLE
fix: rebuild publicKeyToValidatorMap in nodesCoordinator LoadState

### DIFF
--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -127,10 +127,12 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		indexHashedNodesCoordinator: ihgs,
 	}
 
-	err = ihgs.saveState(ihgs.savedStateKey)
-	if err != nil {
-		log.Error("saving initial nodes coordinator config failed",
-			"error", err.Error())
+	if arguments.StartEpoch == 0 {
+		err = ihgs.saveState(ihgs.savedStateKey)
+		if err != nil {
+			log.Error("saving initial nodes coordinator config failed",
+				"error", err.Error())
+		}
 	}
 
 	log.Info("new nodes config is set for epoch", "epoch", arguments.Epoch)

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -284,11 +284,7 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 
 	displayNodesConfigInfo(nodesConfig)
 
-	// the constructor seeds publicKeyToValidatorMap only from its startup
-	// arguments (the genesis nodes file on a plain restart); publish the
-	// restored configs together with a lookup map rebuilt from them, under
-	// one write lock, so current-epoch validators resolve as soon as the
-	// restored configs are visible
+	// rebuild the validator lookup from restored configs and publish both atomically
 	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
 
 	ihgs.mutNodesConfig.Lock()

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -281,14 +281,18 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	}
 
 	displayNodesConfigInfo(nodesConfig)
-	ihgs.mutNodesConfig.Lock()
-	ihgs.nodesConfig = nodesConfig
-	ihgs.mutNodesConfig.Unlock()
 
 	// the constructor seeds publicKeyToValidatorMap only from its startup
-	// arguments (the genesis nodes file on a plain restart); rebuild it from
-	// the restored per-epoch configs so current-epoch validators resolve again
-	ihgs.fillPublicKeyToValidatorMap()
+	// arguments (the genesis nodes file on a plain restart); publish the
+	// restored configs together with a lookup map rebuilt from them, under
+	// one write lock, so current-epoch validators resolve as soon as the
+	// restored configs are visible
+	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
+
+	ihgs.mutNodesConfig.Lock()
+	ihgs.nodesConfig = nodesConfig
+	ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
+	ihgs.mutNodesConfig.Unlock()
 
 	ihgs.stateReady.Store(true)
 
@@ -377,10 +381,18 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 	ihgs.mutNodesConfig.Lock()
 	defer ihgs.mutNodesConfig.Unlock()
 
+	ihgs.publicKeyToValidatorMap = ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
+}
+
+// computePublicKeyToValidatorMap merges the elected and eligible validators of
+// all given epoch configs into one lookup map, later epochs taking precedence
+func (ihgs *indexHashedNodesCoordinator) computePublicKeyToValidatorMap(
+	nodesConfig map[uint32]*epochNodesConfig,
+) map[string]Validator {
 	index := 0
-	epochList := make([]uint32, len(ihgs.nodesConfig))
+	epochList := make([]uint32, len(nodesConfig))
 	mapAllValidators := make(map[uint32]map[string]Validator)
-	for epoch, epochConfig := range ihgs.nodesConfig {
+	for epoch, epochConfig := range nodesConfig {
 		epochConfig.mutNodesMaps.RLock()
 		mapAllValidators[epoch] = ihgs.createPublicKeyToValidatorMap(epochConfig.electedList, epochConfig.eligibleList)
 		epochConfig.mutNodesMaps.RUnlock()
@@ -393,13 +405,15 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 		return epochList[i] < epochList[j]
 	})
 
-	ihgs.publicKeyToValidatorMap = make(map[string]Validator)
+	publicKeyToValidatorMap := make(map[string]Validator)
 	for _, epoch := range epochList {
 		validatorsForEpoch := mapAllValidators[epoch]
 		for pubKey, vInfo := range validatorsForEpoch {
-			ihgs.publicKeyToValidatorMap[pubKey] = vInfo
+			publicKeyToValidatorMap[pubKey] = vInfo
 		}
 	}
+
+	return publicKeyToValidatorMap
 }
 
 func (ihgs *indexHashedNodesCoordinator) createPublicKeyToValidatorMap(

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -285,6 +285,11 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ihgs.nodesConfig = nodesConfig
 	ihgs.mutNodesConfig.Unlock()
 
+	// the constructor seeds publicKeyToValidatorMap only from its startup
+	// arguments (the genesis nodes file on a plain restart); rebuild it from
+	// the restored per-epoch configs so current-epoch validators resolve again
+	ihgs.fillPublicKeyToValidatorMap()
+
 	ihgs.stateReady.Store(true)
 
 	return nil

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -760,6 +760,73 @@ func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {
 	require.False(t, check.IfNil(ihgs3))
 }
 
+func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *testing.T) {
+	t.Parallel()
+
+	// simulate a restart within the install epoch: the first coordinator
+	// persists the real validators under hash(selfPubKey); a second
+	// coordinator (the restart) is seeded with genesis nodes and must NOT
+	// overwrite that saved state, otherwise LoadState reads genesis data back
+	realElected := createDummyNodesList(4, "realElected")
+	realEligible := createDummyNodesList(1, "realEligible")
+	bootStorer := mock.NewStorerMock()
+
+	firstArgs := createArguments()
+	firstArgs.BootStorer = bootStorer
+	firstArgs.ElectedNodes = realElected
+	firstArgs.EligibleNodes = realEligible
+	firstArgs.Epoch = 5
+	firstArgs.StartEpoch = 5
+	firstCoordinator, err := NewNodesCoordinator(firstArgs)
+	require.Nil(t, err)
+
+	// EpochStartPrepare would rotate the key, but within the install epoch
+	// the key is still hash(selfPubKey); persist under that key
+	err = firstCoordinator.saveState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	// second coordinator (the restart) uses the same bootStorer and same
+	// selfPubKey, so savedStateKey = hash(selfPubKey) is the same; it is
+	// seeded with genesis nodes and StartEpoch > 0
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	secondArgs := createArguments()
+	secondArgs.BootStorer = bootStorer
+	secondArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	secondArgs.Hasher = firstArgs.Hasher
+	secondArgs.ElectedNodes = genesisElected
+	secondArgs.EligibleNodes = genesisEligible
+	secondArgs.Epoch = 0
+	secondArgs.StartEpoch = 5
+	_, err = NewNodesCoordinator(secondArgs)
+	require.Nil(t, err)
+
+	// now LoadState with the same key must return the REAL validators, not
+	// genesis; if the constructor overwrote, this will return genesis data
+	thirdArgs := createArguments()
+	thirdArgs.BootStorer = bootStorer
+	thirdArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	thirdArgs.Hasher = firstArgs.Hasher
+	thirdArgs.ElectedNodes = genesisElected
+	thirdArgs.EligibleNodes = genesisEligible
+	thirdArgs.StartEpoch = 5
+	thirdCoordinator, err := NewNodesCoordinator(thirdArgs)
+	require.Nil(t, err)
+
+	err = thirdCoordinator.LoadState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	realPubKey := realElected[0].PubKey()
+	validator, err := thirdCoordinator.GetValidatorWithPublicKey(realPubKey)
+	require.Nil(t, err)
+	require.Equal(t, realPubKey, validator.PubKey())
+
+	genesisPubKey := genesisElected[0].PubKey()
+	_, err = thirdCoordinator.GetValidatorWithPublicKey(genesisPubKey)
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
 func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) {
 	t.Parallel()
 

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -759,3 +759,54 @@ func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {
 	require.Nil(t, err)
 	require.False(t, check.IfNil(ihgs3))
 }
+
+func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) {
+	t.Parallel()
+
+	// simulate a mid-epoch restart from storage: the persisted registry holds
+	// the current epoch's validators, while the constructor is seeded from the
+	// genesis nodes file only
+	currentElected := createDummyNodesList(4, "currentElected")
+	currentEligible := createDummyNodesList(1, "currentEligible")
+	bootStorer := mock.NewStorerMock()
+
+	argumentsBeforeRestart := createArguments()
+	argumentsBeforeRestart.BootStorer = bootStorer
+	argumentsBeforeRestart.ElectedNodes = currentElected
+	argumentsBeforeRestart.EligibleNodes = currentEligible
+	nodesCoordinatorBeforeRestart, err := NewNodesCoordinator(argumentsBeforeRestart)
+	require.Nil(t, err)
+
+	// persist the registry under a rotated key, as EpochStartPrepare does; the
+	// constructor-time save under hash(selfPubKey) must not be reused here
+	// because a subsequent constructor overwrites that key
+	savedStateKey := []byte("rotated-saved-state-key")
+	err = nodesCoordinatorBeforeRestart.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	argumentsAfterRestart := createArguments()
+	argumentsAfterRestart.BootStorer = bootStorer
+	argumentsAfterRestart.ElectedNodes = genesisElected
+	argumentsAfterRestart.EligibleNodes = genesisEligible
+	nodesCoordinatorAfterRestart, err := NewNodesCoordinator(argumentsAfterRestart)
+	require.Nil(t, err)
+
+	currentPubKey := currentElected[0].PubKey()
+	_, err = nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(currentPubKey)
+	require.Equal(t, ErrValidatorNotFound, err)
+
+	err = nodesCoordinatorAfterRestart.LoadState(savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(currentPubKey)
+	require.Nil(t, err)
+	require.Equal(t, currentPubKey, validator.PubKey())
+
+	// the map is rebuilt wholesale from the restored per-epoch configs, so the
+	// genesis-seeded entries are gone
+	_, err = nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(genesisElected[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
+}

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -797,7 +797,7 @@ func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *test
 	secondArgs.Hasher = firstArgs.Hasher
 	secondArgs.ElectedNodes = genesisElected
 	secondArgs.EligibleNodes = genesisEligible
-	secondArgs.Epoch = 0
+	secondArgs.Epoch = 5
 	secondArgs.StartEpoch = 5
 	_, err = NewNodesCoordinator(secondArgs)
 	require.Nil(t, err)
@@ -825,6 +825,42 @@ func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *test
 	genesisPubKey := genesisElected[0].PubKey()
 	_, err = thirdCoordinator.GetValidatorWithPublicKey(genesisPubKey)
 	require.Equal(t, ErrValidatorNotFound, err)
+}
+
+func TestNodesCoordinator_ConstructorSavesStateOnGenesisStart(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "genesisElected")
+	eligible := createDummyNodesList(1, "genesisEligible")
+	bootStorer := mock.NewStorerMock()
+
+	args := createArguments()
+	args.BootStorer = bootStorer
+	args.ElectedNodes = elected
+	args.EligibleNodes = eligible
+	args.Epoch = 0
+	args.StartEpoch = 0
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	// a second coordinator loading from the same key must see the saved state;
+	// StartEpoch > 0 so the second constructor does not overwrite what was saved
+	args2 := createArguments()
+	args2.BootStorer = bootStorer
+	args2.SelfPublicKey = args.SelfPublicKey
+	args2.Hasher = args.Hasher
+	args2.ElectedNodes = createDummyNodesList(4, "otherElected")
+	args2.EligibleNodes = createDummyNodesList(1, "otherEligible")
+	args2.StartEpoch = 1
+	coordinator2, err := NewNodesCoordinator(args2)
+	require.Nil(t, err)
+
+	err = coordinator2.LoadState(coordinator.savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := coordinator2.GetValidatorWithPublicKey(elected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, elected[0].PubKey(), validator.PubKey())
 }
 
 func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) {
@@ -871,6 +907,11 @@ func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) 
 	validator, err := nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(currentPubKey)
 	require.Nil(t, err)
 	require.Equal(t, currentPubKey, validator.PubKey())
+
+	eligiblePubKey := currentEligible[0].PubKey()
+	eligibleValidator, err := nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(eligiblePubKey)
+	require.Nil(t, err)
+	require.Equal(t, eligiblePubKey, eligibleValidator.PubKey())
 
 	// the map is rebuilt wholesale from the restored per-epoch configs, so the
 	// genesis-seeded entries are gone


### PR DESCRIPTION
## Problem

A validator node that is restarted with an existing database stops following the chain per slot. After the restart it commits blocks only in bursts of ~20 blocks every 20 slots (80 seconds with 4s slots), with fully silent windows in between, and every burst starts by re-committing the previous tip block. The behavior persists until the next epoch boundary, after which the node follows per slot again. This was observed in production on fallback/redundancy nodes (--redundancy-level=1) but affects any restart from local storage.

## Root cause

indexHashedNodesCoordinator.publicKeyToValidatorMap is only filled in two places: the constructor and EpochStartPrepare. LoadState (the restart-from-storage path, called by the storage bootstrapper) restores the per-epoch validator configs into nodesConfig but never rebuilds the map.

On a restart, the epoch-start bootstrap returns Parameters{NodesConfig: nil} (it is only populated on the network start-in-epoch path), so the constructor falls back to the genesis nodes file and seeds the map with genesis-era validators only. LoadState then restores the correct per-epoch configs (so header signature verification works), but the map stays genesis-only until the next EpochStartPrepare.

The headers topic is validator-gated: SingleDataInterceptor drops every non-whitelisted message whose originator does not resolve to a validator, and that resolution ends in GetValidatorWithPublicKey, which reads only publicKeyToValidatorMap. With a stale map every gossiped tip header from a current validator is dropped before it reaches the headers pool, so ProbableHighestNonce never advances and the node believes it is synchronized. Explicitly requested headers bypass the gate via the request whitelist, which is why the node still advances in periodic bursts driven by the consensus-stuck detection and the 20-slot header re-request cycle.

## Fix (two behavioral changes)

### 1. Rebuild publicKeyToValidatorMap in LoadState

computePublicKeyToValidatorMap (extracted helper) merges the elected and eligible validators of all restored epoch configs into one lookup map. LoadState computes this map from the freshly restored nodesConfig *before* acquiring the write lock, then publishes both nodesConfig and the rebuilt map atomically under one mutNodesConfig.Lock, so GetValidatorWithPublicKey can never observe a state where configs are updated but the map is stale.

### 2. Guard initial saveState behind StartEpoch == 0

The constructor's saveState call persists the genesis-seeded nodesConfig under hash(selfPubKey). On a restart within the install epoch (StartEpoch > 0), this would overwrite the previously saved real validator state with genesis data, causing LoadState to read back genesis entries. The constructor now only saves on a fresh genesis start (StartEpoch == 0).

## Validation

- Regression tests:
  - TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap: seeds a coordinator the way a restart does, verifies both elected and eligible validators resolve after LoadState, and genesis-seeded entries are gone.
  - TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart: verifies a restart within the install epoch (Epoch == StartEpoch > 0, matching production shape) does not overwrite saved state.
  - TestNodesCoordinator_ConstructorSavesStateOnGenesisStart: verifies the constructor does save state when StartEpoch == 0, protecting the genesis-start path against a future inversion.
- go test ./sharding/... green, including -race; go vet clean.
- Validated live on a testnet fallback node: three consecutive mid-epoch restarts on the fixed build all resume per-slot following immediately after catch-up, with zero silent windows. A control restart on an unfixed build reproduces the 80s burst cycle.

## Notes

- No wire or storage format changes; fixed and unfixed nodes interoperate, so no coordinated rollout is needed.
- A related pre-existing gap exists on the network start-in-epoch path (SetNodes for the previous epoch also does not refill the map). It is a much smaller window, self-healing at the next boundary, and intentionally left out of this fix; it can be tracked separately.