### PR TITLE
fix: refresh peer type cache after storage bootstrap restores coordinator state

### DIFF
--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -10,22 +10,23 @@ import (
 
 // NodesCoordinatorMock defines the behaviour of a struct able to do validator group selection
 type NodesCoordinatorMock struct {
-	Validators                              []sharding.Validator
-	ConsensusSize                           uint32
-	GetSelectedPublicKeysCalled             func(selection []byte, epoch uint32) (publicKeys []string, err error)
-	GetValidatorsPublicKeysCalled           func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	GetValidatorsRewardsAddressesCalled     func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	SetNodesCalled                          func(nodes []sharding.Validator, epoch uint32) error
-	ComputeValidatorsGroupCalled            func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
-	GetValidatorWithPublicKeyCalled         func(publicKey []byte) (validator sharding.Validator, err error)
-	GetAllElectedValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllEligibleValidatorsKeysCalled      func() ([][]byte, error)
-	GetAllWaitingValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllLeavingValidatorsPublicKeysCalled func() ([][]byte, error)
-	CheckValidatorSlotCalled                func(epoch uint32, slotIndex int64, pubkey []byte) bool
-	ConsensusGroupSizeCalled                func() int
-	LoadValidatorsCalled                    func(validators []*state.ValidatorInfo) error
-	SetEpochValidatorsInfoCalled            func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
+	Validators                                 []sharding.Validator
+	ConsensusSize                              uint32
+	GetSelectedPublicKeysCalled                func(selection []byte, epoch uint32) (publicKeys []string, err error)
+	GetValidatorsPublicKeysCalled              func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	GetValidatorsRewardsAddressesCalled        func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	SetNodesCalled                             func(nodes []sharding.Validator, epoch uint32) error
+	ComputeValidatorsGroupCalled               func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
+	GetValidatorWithPublicKeyCalled            func(publicKey []byte) (validator sharding.Validator, err error)
+	GetAllElectedValidatorsKeysCalled          func() ([][]byte, error)
+	GetAllElectedValidatorsKeysWithEpochCalled func(epoch uint32) ([][]byte, error)
+	GetAllEligibleValidatorsKeysCalled         func() ([][]byte, error)
+	GetAllWaitingValidatorsKeysCalled          func() ([][]byte, error)
+	GetAllLeavingValidatorsPublicKeysCalled    func() ([][]byte, error)
+	CheckValidatorSlotCalled                   func(epoch uint32, slotIndex int64, pubkey []byte) bool
+	ConsensusGroupSizeCalled                   func() int
+	LoadValidatorsCalled                       func(validators []*state.ValidatorInfo) error
+	SetEpochValidatorsInfoCalled               func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
 }
 
 // NewNodesCoordinatorMock -
@@ -59,7 +60,10 @@ func (ncm *NodesCoordinatorMock) GetNumTotalEligible() uint64 {
 }
 
 // GetAllElectedValidatorsKeys -
-func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(epoch uint32, _ bool) ([][]byte, error) {
+	if ncm.GetAllElectedValidatorsKeysWithEpochCalled != nil {
+		return ncm.GetAllElectedValidatorsKeysWithEpochCalled(epoch)
+	}
 	if ncm.GetAllElectedValidatorsKeysCalled != nil {
 		return ncm.GetAllElectedValidatorsKeysCalled()
 	}

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -93,39 +93,64 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 				"epoch", hdr.GetEpoch())
 			ptp.updateCache(hdr.GetEpoch())
 		},
-		func(_ data.HeaderHandler) {},
+		func(_ data.HeaderHandler) {
+			// nothing to do on epoch start prepare; the cache refresh happens on the action event above
+		},
 		core.IndexerOrder,
 	)
 
 	return subscribeHandler
 }
 
+// RefreshCache rebuilds the peer type cache from the nodes coordinator for the
+// given epoch; used after the storage bootstrap restores the coordinator state,
+// before block processing starts (concurrent refreshes carry no epoch ordering)
+func (ptp *PeerTypeProvider) RefreshCache(epoch uint32) {
+	ptp.updateCache(epoch)
+}
+
 func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
-	newCache := ptp.createNewCache(epoch)
+	newCache, ok := ptp.createNewCache(epoch)
+	if !ok {
+		log.Warn("peerTypeProvider - no validator list available, keeping previous cache", "epoch", epoch)
+		return
+	}
 
 	ptp.mutCache.Lock()
 	ptp.cache = newCache
 	ptp.mutCache.Unlock()
 }
 
+// createNewCache returns false when no validator list could be fetched at all,
+// so a stale-but-valid cache is not replaced by an empty one
 func (ptp *PeerTypeProvider) createNewCache(
 	epoch uint32,
-) map[string]*peerListAndShard {
+) (map[string]*peerListAndShard, bool) {
 	newCache := make(map[string]*peerListAndShard)
 
-	nodesMapElected, err := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch)
+	// the coordinator produces disjoint lists; if they ever overlap, the last
+	// list merged below wins
+	nodesMapElected, electedErr := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
+	if electedErr != nil {
+		log.Debug("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch, "error", electedErr)
 	}
 	computePeerType(newCache, nodesMapElected, core.ElectedList)
 
-	nodesMapEligible, err := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch)
+	nodesMapEligible, eligibleErr := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
+	if eligibleErr != nil {
+		log.Debug("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch, "error", eligibleErr)
 	}
 	computePeerType(newCache, nodesMapEligible, core.EligibleList)
 
-	return newCache
+	nodesMapWaiting, waitingErr := ptp.nodesCoordinator.GetAllWaitingValidatorsKeys(epoch, false)
+	if waitingErr != nil {
+		log.Debug("peerTypeProvider - GetAllWaitingValidatorsKeys failed", "epoch", epoch, "error", waitingErr)
+	}
+	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
+
+	allListsFailed := electedErr != nil && eligibleErr != nil && waitingErr != nil
+
+	return newCache, !allListsFailed
 }
 
 func computePeerType(

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/eventNotifier"
+	"github.com/klever-io/klever-go/sharding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,7 +121,9 @@ func TestNewPeerTypeProvider_createCache(t *testing.T) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
 
 	assert.NotNil(t, cache)
 
@@ -129,6 +132,156 @@ func TestNewPeerTypeProvider_createCache(t *testing.T) {
 
 	assert.NotNil(t, cache[pkEligible])
 	assert.Equal(t, core.EligibleList, cache[pkEligible].pType)
+}
+
+func TestNewPeerTypeProvider_createCacheIncludesWaitingList(t *testing.T) {
+	pkElected := "pk1"
+	pkEligible := "pk2"
+	pkWaiting := "pk3"
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkElected)}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkEligible)}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkWaiting)}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
+
+	assert.NotNil(t, cache[pkWaiting])
+	assert.Equal(t, core.WaitingList, cache[pkWaiting].pType)
+}
+
+func TestPeerTypeProvider_RefreshCacheRebuildsFromCoordinator(t *testing.T) {
+	// mimic a restart: at construction time the coordinator only holds stale
+	// data (no validators); after LoadState restores the real configs a
+	// RefreshCache call must rebuild the cache from the coordinator, querying
+	// it with the exact epoch the caller passed
+	pk := []byte("pk1")
+	restored := false
+	restoredEpoch := uint32(5)
+	var lastQueriedEpoch uint32
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			lastQueriedEpoch = epoch
+			if restored {
+				return [][]byte{pk}, nil
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+
+	restored = true
+	ptp.RefreshCache(restoredEpoch)
+
+	require.Equal(t, restoredEpoch, lastQueriedEpoch)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheReplacesCacheWhenListsAreEmptyWithoutError(t *testing.T) {
+	pk := []byte("pk1")
+	demoted := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			if demoted {
+				return [][]byte{}, nil
+			}
+			return [][]byte{pk}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	// successful fetches returning empty lists are a genuine state (validator
+	// demoted) and must replace the cache, unlike the all-fetches-failed case
+	demoted = true
+	ptp.RefreshCache(6)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheKeepsPreviousCacheWhenAllListsFail(t *testing.T) {
+	pk := []byte("pk1")
+	failing := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{pk}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	// a refresh for an epoch the coordinator does not know must not wipe the
+	// previously valid cache
+	failing = true
+	ptp.RefreshCache(42)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
 }
 
 func TestNewPeerTypeProvider_CallsUpdateCacheOnEpochChange(t *testing.T) {
@@ -274,7 +427,9 @@ func TestPeerTypeProvider_CreateNewCacheScenarios(t *testing.T) {
 	}
 	ptp, _ := NewPeerTypeProvider(arg)
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
 	assert.Len(t, cache, 3)
 	assert.Equal(t, core.EligibleList, cache["elected1"].pType) // elected1 is also eligible as it have been updated in the eligible list
 	assert.Equal(t, core.ElectedList, cache["elected2"].pType)

--- a/node/heartbeat/componentHandler/heartbeatHandler.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler.go
@@ -266,6 +266,16 @@ func (hbh *HeartbeatHandler) Sender() *process.Sender {
 	return hbh.sender
 }
 
+// RefreshPeerTypeCache rebuilds the peer type provider's cache for the given
+// epoch; called after the storage bootstrap restores the nodes coordinator state
+func (hbh *HeartbeatHandler) RefreshPeerTypeCache(epoch uint32) {
+	if hbh == nil || hbh.peerTypeProvider == nil {
+		return
+	}
+
+	hbh.peerTypeProvider.RefreshCache(epoch)
+}
+
 // Close stops the heartbeat sender and monitor background goroutines and waits
 // for both to exit. Idempotent: each step (cancelFunc, channel receive on closed
 // channel, monitor.Close) is safe to repeat.

--- a/node/heartbeat/componentHandler/heartbeatHandler_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_test.go
@@ -142,3 +142,14 @@ func TestNewHeartbeatHandler_ShouldWork(t *testing.T) {
 	// let the sending go routine finish
 	time.Sleep(time.Second)
 }
+
+func TestHeartbeatHandler_RefreshPeerTypeCacheNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var hbh *HeartbeatHandler
+	// must not panic on a nil receiver or a handler without a provider
+	hbh.RefreshPeerTypeCache(1)
+
+	hbh = &HeartbeatHandler{}
+	hbh.RefreshPeerTypeCache(1)
+}

--- a/node/interface.go
+++ b/node/interface.go
@@ -76,6 +76,7 @@ type Accumulator interface {
 type HeartbeatHandler interface {
 	Monitor() *process.Monitor
 	Sender() *process.Sender
+	RefreshPeerTypeCache(epoch uint32)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/node/node.go
+++ b/node/node.go
@@ -332,6 +332,13 @@ func (n *Node) StartConsensus() error {
 		epoch = crtBlockHeader.GetEpoch()
 	}
 
+	// the heartbeat's peer type cache was built before LoadStorage restored the
+	// nodes coordinator state; refresh it so the node reports its real peer type
+	// without waiting for the next epoch start
+	if !check.IfNil(n.heartbeatHandler) {
+		n.heartbeatHandler.RefreshPeerTypeCache(epoch)
+	}
+
 	forkControllerSubscriber, ok := n.forkController.(core.EpochSubscriberHandler)
 	if !ok {
 		return common.ErrWrongTypeAssertion


### PR DESCRIPTION
## Problem

When a node that is elected, eligible or waiting in the current epoch restarts mid-epoch, its `klv_node_type` and `klv_peer_type` metrics report "observer" from startup until the next epoch switch, and the heartbeat monitor labels every current validator "observer" in `/node/heartbeatstatus` over the same window. Fixes #88.

## Root cause

The heartbeat sender and monitor resolve peer types through `PeerTypeProvider.ComputeForPubKey`, which reads a cache that is only built in two places: at construction and on epoch-start events. The provider is constructed inside `StartHeartbeat` during node creation, BEFORE `StartConsensus` runs `bootstrapper.LoadStorage()` and the nodes coordinator's `LoadState` restores the real per-epoch validator configs. The construction-time cache is therefore built from genesis-seeded coordinator data, and nothing refreshes it after the restore; the first epoch-start event is the first correction. Full trace in #88.

A second, independent gap: `createNewCache` merged only the elected and eligible lists. The waiting list was never added, so waiting validators always reported as "observer", restart or not.

## Fix

- `PeerTypeProvider.RefreshCache(epoch)`: exported, rebuilds the cache from the nodes coordinator. Called from `StartConsensus` right after `LoadStorage()` and the epoch determination, via a nil-safe `RefreshPeerTypeCache` method on the heartbeat handler (added to the `node.HeartbeatHandler` interface). This is the first point where both the restored coordinator state and the current epoch are available, and it runs before block syncing starts.
- `createNewCache` now merges the waiting list (`GetAllWaitingValidatorsKeys` -> `core.WaitingList`).
- Robustness: when every validator-list fetch fails (for example `ErrEpochNodesConfigDoesNotExist` for an epoch the restored registry does not hold), the previous cache is kept and a Warn is logged instead of installing an empty map that would downgrade every known validator to observer. Successful fetches returning empty lists still replace the cache, so genuine demotions keep reporting correctly. Fetch errors now log the error value.

## Validation

Unit tests (all green, including `-race` on the new tests):
- `TestPeerTypeProvider_RefreshCacheRebuildsFromCoordinator`: observer before refresh, elected after; also asserts the coordinator is queried with the exact epoch passed by the caller.
- `TestNewPeerTypeProvider_createCacheIncludesWaitingList`
- `TestPeerTypeProvider_RefreshCacheKeepsPreviousCacheWhenAllListsFail` and `TestPeerTypeProvider_RefreshCacheReplacesCacheWhenListsAreEmptyWithoutError`: pin both sides of the failure-versus-genuinely-empty boundary.
- `TestHeartbeatHandler_RefreshPeerTypeCacheNilSafe`
- `common/mock/NodesCoordinatorMock` gained an additive `GetAllElectedValidatorsKeysWithEpochCalled` hook (existing tests unaffected; all consumer packages re-tested green).

Live A/B validation on mainnet (same db, same epoch 5919, restarts minutes apart, observer node):
- Control build, synced baseline: 217 peers labeled eligible=104 elected=21 observer=92 (correct).
- Control build, after mid-epoch restart: observer=197 elected=21, unchanged after 60s. All 119 real current validators downgraded to observer; the 21 "elected" labels were the genesis-era pubkeys wrongly promoted by the stale cache (15 of them are observers today).
- Fixed build, same db, after restart: eligible=104 elected=21 observer=91 waiting=1 within ~50s of container start, identical to baseline, no epoch switch needed. The single waiting label is the network's one waiting-list validator, which the unfixed build structurally cannot report.
- Cross-check on a production validator: after a mid-epoch restart of an unfixed v1.7.20 node (staked, eligible), the node reported Peer Type/Node Type "observer" about itself while the fixed node labeled the same BLS key "eligible" at the same moment.

## Notes

- No wire or storage format changes; no consensus impact (the cache feeds only metrics, heartbeat labels, and the heartbeat status API).
- `validatorsProvider.createNewCache` has the same waiting-list omission, there masked by the trie-derived status; left out of scope.
- Pre-existing and unrelated: `go test -race ./core/process/peer/` fails on data races between `validatorsProvider`'s background refresh goroutine and its tests (reproduced identically on a clean develop checkout); worth a separate tracking issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Refreshes the peer-type cache after storage restores coordinator state and before consensus block syncing, preventing stale validator classifications after mid-epoch restarts.
- Includes elected, eligible, and waiting validators in peer classification, affecting heartbeat labels, metrics, and heartbeat status reporting.
- Preserves the existing cache when all validator-list fetches fail, while successfully fetched empty lists correctly replace it; retrieval errors now emit warnings.
- Adds nil-safe heartbeat refresh handling and unit coverage for restart recovery, waiting validators, demotion, fetch failures, and nil providers.
- No changes to consensus rules, transaction processing, wire protocols, storage formats, or data integrity. The change is limited to post-bootstrap state-derived classification and heartbeat/network observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->