### PR TITLE
fix: restore validator sync across restarts and epoch transitions (#88, #90, #91)

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -294,6 +294,7 @@ func createNodesCoordinator(
 	}
 
 	currentEpoch := startEpoch
+	restoredFromRegistry := false
 	if bootstrapParameters.NodesConfig != nil {
 		nodeRegistry := bootstrapParameters.NodesConfig
 		currentEpoch = bootstrapParameters.Epoch
@@ -310,6 +311,8 @@ func createNodesCoordinator(
 			if err != nil {
 				return nil, err
 			}
+
+			restoredFromRegistry = true
 		}
 	}
 
@@ -336,6 +339,8 @@ func createNodesCoordinator(
 		ConsensusGroupCache: consensusGroupCache,
 		Epoch:               currentEpoch,
 		StartEpoch:          startEpoch,
+
+		NodesRestoredFromRegistry: restoredFromRegistry,
 	}
 
 	if len(bootstrapParameters.CurrEpochValidatorsInfo) > 0 {

--- a/common/errors.go
+++ b/common/errors.go
@@ -307,6 +307,10 @@ var ErrCacheConfigInvalidEconomics = errors.New("cache-economics parameter is no
 // ErrNilNodesCoordinator signals a nil nodes coordinator has been provided
 var ErrNilNodesCoordinator = errors.New("nil nodes coordinator")
 
+// ErrNodesCoordinatorNotReadyAfterBootstrap signals that the nodes coordinator did not
+// restore a usable state after a non-genesis restart from storage
+var ErrNodesCoordinatorNotReadyAfterBootstrap = errors.New("nodes coordinator not ready after storage bootstrap")
+
 // ErrValidatorNotFound signals that the validator has not been found
 var ErrValidatorNotFound = errors.New("validator not found")
 

--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -10,22 +10,26 @@ import (
 
 // NodesCoordinatorMock defines the behaviour of a struct able to do validator group selection
 type NodesCoordinatorMock struct {
-	Validators                              []sharding.Validator
-	ConsensusSize                           uint32
-	GetSelectedPublicKeysCalled             func(selection []byte, epoch uint32) (publicKeys []string, err error)
-	GetValidatorsPublicKeysCalled           func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	GetValidatorsRewardsAddressesCalled     func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	SetNodesCalled                          func(nodes []sharding.Validator, epoch uint32) error
-	ComputeValidatorsGroupCalled            func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
-	GetValidatorWithPublicKeyCalled         func(publicKey []byte) (validator sharding.Validator, err error)
-	GetAllElectedValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllEligibleValidatorsKeysCalled      func() ([][]byte, error)
-	GetAllWaitingValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllLeavingValidatorsPublicKeysCalled func() ([][]byte, error)
-	CheckValidatorSlotCalled                func(epoch uint32, slotIndex int64, pubkey []byte) bool
-	ConsensusGroupSizeCalled                func() int
-	LoadValidatorsCalled                    func(validators []*state.ValidatorInfo) error
-	SetEpochValidatorsInfoCalled            func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
+	Validators                          []sharding.Validator
+	ConsensusSize                       uint32
+	GetSelectedPublicKeysCalled         func(selection []byte, epoch uint32) (publicKeys []string, err error)
+	GetValidatorsPublicKeysCalled       func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	GetValidatorsRewardsAddressesCalled func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	SetNodesCalled                      func(nodes []sharding.Validator, epoch uint32) error
+	ComputeValidatorsGroupCalled        func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
+	GetValidatorWithPublicKeyCalled     func(publicKey []byte) (validator sharding.Validator, err error)
+	GetAllElectedValidatorsKeysCalled   func() ([][]byte, error)
+	// GetAllElectedValidatorsKeysWithEpochCalled takes precedence over
+	// GetAllElectedValidatorsKeysCalled when both are set
+	GetAllElectedValidatorsKeysWithEpochCalled func(epoch uint32) ([][]byte, error)
+	GetAllEligibleValidatorsKeysCalled         func() ([][]byte, error)
+	GetAllWaitingValidatorsKeysCalled          func() ([][]byte, error)
+	GetAllLeavingValidatorsPublicKeysCalled    func() ([][]byte, error)
+	CheckValidatorSlotCalled                   func(epoch uint32, slotIndex int64, pubkey []byte) bool
+	ConsensusGroupSizeCalled                   func() int
+	LoadValidatorsCalled                       func(validators []*state.ValidatorInfo) error
+	SetEpochValidatorsInfoCalled               func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
+	IsReadyCalled                              func() bool
 }
 
 // NewNodesCoordinatorMock -
@@ -59,7 +63,10 @@ func (ncm *NodesCoordinatorMock) GetNumTotalEligible() uint64 {
 }
 
 // GetAllElectedValidatorsKeys -
-func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(epoch uint32, _ bool) ([][]byte, error) {
+	if ncm.GetAllElectedValidatorsKeysWithEpochCalled != nil {
+		return ncm.GetAllElectedValidatorsKeysWithEpochCalled(epoch)
+	}
 	if ncm.GetAllElectedValidatorsKeysCalled != nil {
 		return ncm.GetAllElectedValidatorsKeysCalled()
 	}
@@ -226,6 +233,14 @@ func (ncm *NodesCoordinatorMock) GetOwnPublicKey() []byte {
 // LoadState -
 func (ncm *NodesCoordinatorMock) LoadState(_ []byte) error {
 	return nil
+}
+
+// IsReady -
+func (ncm *NodesCoordinatorMock) IsReady() bool {
+	if ncm.IsReadyCalled != nil {
+		return ncm.IsReadyCalled()
+	}
+	return true
 }
 
 // GetSavedStateKey -

--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -30,6 +30,7 @@ type NodesCoordinatorMock struct {
 	LoadValidatorsCalled                       func(validators []*state.ValidatorInfo) error
 	SetEpochValidatorsInfoCalled               func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
 	IsReadyCalled                              func() bool
+	LoadStateFailedValue                       bool
 }
 
 // NewNodesCoordinatorMock -
@@ -241,6 +242,11 @@ func (ncm *NodesCoordinatorMock) IsReady() bool {
 		return ncm.IsReadyCalled()
 	}
 	return true
+}
+
+// LoadStateFailed -
+func (ncm *NodesCoordinatorMock) LoadStateFailed() bool {
+	return ncm.LoadStateFailedValue
 }
 
 // GetSavedStateKey -

--- a/core/bootstrap/disabled/disabledNodesCoordinator.go
+++ b/core/bootstrap/disabled/disabledNodesCoordinator.go
@@ -74,6 +74,11 @@ func (n *nodesCoordinator) LoadState(_ []byte) error {
 	return nil
 }
 
+// IsReady -
+func (n *nodesCoordinator) IsReady() bool {
+	return true
+}
+
 // SetEpochValidatorsInfo -
 func (n *nodesCoordinator) SetEpochValidatorsInfo(_ uint32, _ []*state.ValidatorInfo) error {
 	return nil

--- a/core/bootstrap/disabled/disabledNodesCoordinator.go
+++ b/core/bootstrap/disabled/disabledNodesCoordinator.go
@@ -79,6 +79,11 @@ func (n *nodesCoordinator) IsReady() bool {
 	return true
 }
 
+// LoadStateFailed -
+func (n *nodesCoordinator) LoadStateFailed() bool {
+	return false
+}
+
 // SetEpochValidatorsInfo -
 func (n *nodesCoordinator) SetEpochValidatorsInfo(_ uint32, _ []*state.ValidatorInfo) error {
 	return nil

--- a/core/bootstrap/disabled/disabledNodesCoordinator_test.go
+++ b/core/bootstrap/disabled/disabledNodesCoordinator_test.go
@@ -1,0 +1,16 @@
+package disabled
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodesCoordinator_IsReady(t *testing.T) {
+	t.Parallel()
+
+	coordinator := NewNodesCoordinator()
+
+	// the disabled coordinator is always ready: it never restores state
+	require.True(t, coordinator.IsReady())
+}

--- a/core/consensus/slot/bls/subslotStartSlot.go
+++ b/core/consensus/slot/bls/subslotStartSlot.go
@@ -254,10 +254,13 @@ func (sr *subslotStartSlot) EpochStartPrepare(metaHdr data.HeaderHandler) {
 // pre-BLS membership gate and reach the fork detector, and would also cause
 // shuffled-out nodes to sign rounds they are not in. Synchronized validators
 // get the narrow consensus group from initCurrentSlot at the next slot.
+// Only an explicit NsNotSynchronized widens: GetNodeState reports
+// NsNotCalculated for a few milliseconds after every slot boundary, and a
+// synchronized validator caught in that window must not widen either.
 func (sr *subslotStartSlot) EpochStartAction(hdr data.HeaderHandler) {
 	log.Debug(fmt.Sprintf("epoch %d start action in consensus", hdr.GetEpoch()))
 
-	if sr.BootStrapper().GetNodeState() == core.NsSynchronized {
+	if sr.BootStrapper().GetNodeState() != core.NsNotSynchronized {
 		return
 	}
 

--- a/core/consensus/slot/bls/subslotStartSlot.go
+++ b/core/consensus/slot/bls/subslotStartSlot.go
@@ -254,13 +254,19 @@ func (sr *subslotStartSlot) EpochStartPrepare(metaHdr data.HeaderHandler) {
 // pre-BLS membership gate and reach the fork detector, and would also cause
 // shuffled-out nodes to sign rounds they are not in. Synchronized validators
 // get the narrow consensus group from initCurrentSlot at the next slot.
-// Only an explicit NsNotSynchronized widens: GetNodeState reports
-// NsNotCalculated for a few milliseconds after every slot boundary, and a
-// synchronized validator caught in that window must not widen either.
+// GetNodeState is a tri-state and its third value, NsNotCalculated, is treated
+// as syncing here. That is deliberate: for a syncing node NsNotCalculated is the
+// common state at this point (baseBootstrap.syncBlock clears isNodeStateCalculated
+// at the end of every iteration and block processing may span several slots), and
+// EpochStartAction fires once per epoch with no retry, so treating it as
+// synchronized would skip the refresh outright in the case this exists for. The
+// accepted cost is the inverse: a synchronized validator caught in the brief
+// post-slot-boundary window where its state is not yet recomputed widens for one
+// slot, until initCurrentSlot narrows it again.
 func (sr *subslotStartSlot) EpochStartAction(hdr data.HeaderHandler) {
 	log.Debug(fmt.Sprintf("epoch %d start action in consensus", hdr.GetEpoch()))
 
-	if sr.BootStrapper().GetNodeState() != core.NsNotSynchronized {
+	if sr.BootStrapper().GetNodeState() == core.NsSynchronized {
 		return
 	}
 

--- a/core/consensus/slot/bls/subslotStartSlot.go
+++ b/core/consensus/slot/bls/subslotStartSlot.go
@@ -34,6 +34,7 @@ func NewSubslotStartSlot(
 ) (*subslotStartSlot, error) {
 	err := checkNewSubslotStartSlotParams(
 		baseSubslot,
+		resetConsensusMessages,
 	)
 	if err != nil {
 		return nil, err
@@ -56,12 +57,17 @@ func NewSubslotStartSlot(
 
 func checkNewSubslotStartSlotParams(
 	baseSubslot *slot.Subslot,
+	resetConsensusMessages func(),
 ) error {
 	if baseSubslot == nil {
 		return slot.ErrNilSubslot
 	}
 	if baseSubslot.ConsensusState == nil {
 		return slot.ErrNilConsensusState
+	}
+	// called unconditionally by doStartSlotJob and by EpochStartAction below
+	if resetConsensusMessages == nil {
+		return slot.ErrNilResetConsensusMessages
 	}
 
 	err := slot.ValidateConsensusCore(baseSubslot.ConsensusCoreHandler)
@@ -240,9 +246,38 @@ func (sr *subslotStartSlot) EpochStartPrepare(metaHdr data.HeaderHandler) {
 }
 
 // EpochStartAction is called upon a start of epoch event.
+// It refreshes the elected nodes set from the coordinator so that
+// IsNodeInConsensusGroup accepts validators from the new epoch even while the
+// node is still syncing (initCurrentSlot is gated on NsSynchronized and would
+// leave the set stale otherwise).
+// The elected-set swap and resetConsensusMessages are not serialized with
+// ProcessReceivedMessage, which checks the set and increments the per-key
+// message budget in its own critical sections. A message landing between the
+// two therefore costs at most one extra accepted message for one key in the
+// transition slot; serializing would mean holding a lock across the full
+// validity pipeline including BLS verification, on the consensus hot path.
+// The action also re-fires when fork recovery reverts through an epoch-start
+// block (trigger.RevertStateToBlock calls SetProcessed again). On a live,
+// synchronized validator that widens the set and clears the budgets mid-slot;
+// this is bounded the same way: initCurrentSlot re-narrows the set at the next
+// slot and every state-changing path re-validates against the tight consensus
+// group (ConsensusGroupIndex, SetJobDone).
 func (sr *subslotStartSlot) EpochStartAction(hdr data.HeaderHandler) {
 	log.Debug(fmt.Sprintf("epoch %d start action in consensus", hdr.GetEpoch()))
 
+	whitelisted, err := sr.NodesCoordinator().GetConsensusWhitelistedNodes(hdr.GetEpoch())
+	if err != nil {
+		// without the refresh a syncing node keeps rejecting new-epoch
+		// validators (the exact stall this action exists to prevent), so
+		// failing here must be loud
+		log.Error("EpochStartAction: could not refresh elected nodes",
+			"epoch", hdr.GetEpoch(),
+			"error", err.Error())
+		return
+	}
+
+	sr.RefreshElectedNodes(whitelisted)
+	sr.resetConsensusMessages()
 }
 
 // NotifyOrder returns the notification order for a start of epoch event

--- a/core/consensus/slot/bls/subslotStartSlot.go
+++ b/core/consensus/slot/bls/subslotStartSlot.go
@@ -246,33 +246,32 @@ func (sr *subslotStartSlot) EpochStartPrepare(metaHdr data.HeaderHandler) {
 }
 
 // EpochStartAction is called upon a start of epoch event.
-// It refreshes the elected nodes set from the coordinator so that
-// IsNodeInConsensusGroup accepts validators from the new epoch even while the
-// node is still syncing (initCurrentSlot is gated on NsSynchronized and would
-// leave the set stale otherwise).
-// The elected-set swap and resetConsensusMessages are not serialized with
-// ProcessReceivedMessage, which checks the set and increments the per-key
-// message budget in its own critical sections. A message landing between the
-// two therefore costs at most one extra accepted message for one key in the
-// transition slot; serializing would mean holding a lock across the full
-// validity pipeline including BLS verification, on the consensus hot path.
-// The action also re-fires when fork recovery reverts through an epoch-start
-// block (trigger.RevertStateToBlock calls SetProcessed again). On a live,
-// synchronized validator that widens the set and clears the budgets mid-slot;
-// this is bounded the same way: initCurrentSlot re-narrows the set at the next
-// slot and every state-changing path re-validates against the tight consensus
-// group (ConsensusGroupIndex, SetJobDone).
+// On syncing nodes it refreshes the elected nodes set from the coordinator so
+// that IsNodeInConsensusGroup accepts validators from the new epoch (since
+// initCurrentSlot is gated on NsSynchronized and would leave the set stale).
+// On synchronized validators this is skipped: widening the elected set mid-slot
+// would let previous-epoch validators (including shuffled-out ones) pass the
+// pre-BLS membership gate and reach the fork detector, and would also cause
+// shuffled-out nodes to sign rounds they are not in. Synchronized validators
+// get the narrow consensus group from initCurrentSlot at the next slot.
 func (sr *subslotStartSlot) EpochStartAction(hdr data.HeaderHandler) {
 	log.Debug(fmt.Sprintf("epoch %d start action in consensus", hdr.GetEpoch()))
 
+	if sr.BootStrapper().GetNodeState() == core.NsSynchronized {
+		return
+	}
+
 	whitelisted, err := sr.NodesCoordinator().GetConsensusWhitelistedNodes(hdr.GetEpoch())
 	if err != nil {
-		// without the refresh a syncing node keeps rejecting new-epoch
-		// validators (the exact stall this action exists to prevent), so
-		// failing here must be loud
 		log.Error("EpochStartAction: could not refresh elected nodes",
 			"epoch", hdr.GetEpoch(),
 			"error", err.Error())
+		return
+	}
+
+	if len(whitelisted) == 0 {
+		log.Warn("EpochStartAction: refusing empty elected set refresh",
+			"epoch", hdr.GetEpoch())
 		return
 	}
 

--- a/core/consensus/slot/bls/subslotStartSlot_test.go
+++ b/core/consensus/slot/bls/subslotStartSlot_test.go
@@ -489,6 +489,9 @@ func TestSubslotStartSlot_EpochStartActionRefreshesElectedNodes(t *testing.T) {
 	}
 	container := mock.InitConsensusCore()
 	container.SetValidatorGroupSelector(coordinator)
+	container.SetBootStrapper(&mock.BootstrapperMock{GetNodeStateCalled: func() core.NodeState {
+		return core.NsNotSynchronized
+	}})
 
 	consensusState := initConsensusState()
 	ch := make(chan bool, 1)
@@ -532,6 +535,9 @@ func TestSubslotStartSlot_EpochStartActionKeepsElectedNodesOnCoordinatorError(t 
 	}
 	container := mock.InitConsensusCore()
 	container.SetValidatorGroupSelector(coordinator)
+	container.SetBootStrapper(&mock.BootstrapperMock{GetNodeStateCalled: func() core.NodeState {
+		return core.NsNotSynchronized
+	}})
 
 	consensusState := initConsensusState()
 	ch := make(chan bool, 1)

--- a/core/consensus/slot/bls/subslotStartSlot_test.go
+++ b/core/consensus/slot/bls/subslotStartSlot_test.go
@@ -567,47 +567,62 @@ func TestSubslotStartSlot_EpochStartActionKeepsElectedNodesOnCoordinatorError(t 
 	require.Equal(t, 0, resetCount)
 }
 
-func TestSubslotStartSlot_EpochStartActionDoesNotWidenOnUncalculatedNodeState(t *testing.T) {
+func TestSubslotStartSlot_EpochStartActionNodeStateHandling(t *testing.T) {
 	t.Parallel()
 
-	// GetNodeState reports NsNotCalculated for a few milliseconds after every
-	// slot boundary, including on a fully synchronized validator. Treating that
-	// as "syncing" would widen the elected set mid-slot on a healthy validator,
-	// which is exactly what the synchronized skip exists to prevent
-	for _, nodeState := range []core.NodeState{core.NsSynchronized, core.NsNotCalculated} {
-		newEpochKey := "newEpochValidator"
-		coordinator := &whitelistNodesCoordinatorMock{
-			NodesCoordinatorMock: cMock.NewNodesCoordinatorMock(),
-			whitelisted:          map[string]struct{}{newEpochKey: {}},
-		}
-		container := mock.InitConsensusCore()
-		container.SetValidatorGroupSelector(coordinator)
-		container.SetBootStrapper(&mock.BootstrapperMock{GetNodeStateCalled: func() core.NodeState {
-			return nodeState
-		}})
+	// GetNodeState is a tri-state. Only NsSynchronized skips the refresh:
+	// NsNotCalculated is the common state for a syncing node at this point, and
+	// EpochStartAction fires once per epoch with no retry, so it must widen
+	tests := []struct {
+		name        string
+		nodeState   core.NodeState
+		shouldWiden bool
+	}{
+		{name: "synchronized skips the refresh", nodeState: core.NsSynchronized, shouldWiden: false},
+		{name: "not synchronized refreshes", nodeState: core.NsNotSynchronized, shouldWiden: true},
+		{name: "not calculated refreshes", nodeState: core.NsNotCalculated, shouldWiden: true},
+	}
 
-		consensusState := initConsensusState()
-		ch := make(chan bool, 1)
-		sr, err := defaultSubslot(consensusState, ch, container)
-		require.Nil(t, err)
-		resetCount := 0
-		srStartSlotPtr, err := bls.NewSubslotStartSlot(
-			sr,
-			extend,
-			bls.ProcessingThresholdPercent,
-			executeStoredMessages,
-			func() { resetCount++ },
-		)
-		require.Nil(t, err)
-		srStartSlot := *srStartSlotPtr
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newEpochKey := "newEpochValidator"
+			coordinator := &whitelistNodesCoordinatorMock{
+				NodesCoordinatorMock: cMock.NewNodesCoordinatorMock(),
+				whitelisted:          map[string]struct{}{newEpochKey: {}},
+			}
+			container := mock.InitConsensusCore()
+			container.SetValidatorGroupSelector(coordinator)
+			container.SetBootStrapper(&mock.BootstrapperMock{GetNodeStateCalled: func() core.NodeState {
+				return tt.nodeState
+			}})
 
-		oldKey := consensusState.ConsensusGroup()[0]
+			consensusState := initConsensusState()
+			ch := make(chan bool, 1)
+			sr, err := defaultSubslot(consensusState, ch, container)
+			require.Nil(t, err)
+			resetCount := 0
+			srStartSlotPtr, err := bls.NewSubslotStartSlot(
+				sr,
+				extend,
+				bls.ProcessingThresholdPercent,
+				executeStoredMessages,
+				func() { resetCount++ },
+			)
+			require.Nil(t, err)
+			srStartSlot := *srStartSlotPtr
 
-		srStartSlot.EpochStartAction(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+			oldKey := consensusState.ConsensusGroup()[0]
 
-		require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
-		require.False(t, consensusState.IsNodeInConsensusGroup(newEpochKey))
-		require.Equal(t, 0, resetCount)
+			srStartSlot.EpochStartAction(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+			require.Equal(t, tt.shouldWiden, consensusState.IsNodeInConsensusGroup(newEpochKey))
+			require.Equal(t, !tt.shouldWiden, consensusState.IsNodeInConsensusGroup(oldKey))
+			if tt.shouldWiden {
+				require.Equal(t, 1, resetCount)
+			} else {
+				require.Equal(t, 0, resetCount)
+			}
+		})
 	}
 }
 

--- a/core/consensus/slot/bls/subslotStartSlot_test.go
+++ b/core/consensus/slot/bls/subslotStartSlot_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/core/consensus/slot"
 	"github.com/klever-io/klever-go/core/consensus/slot/bls"
+	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/sharding"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func defaultSubslotStartSlotFromSubslot(sr *slot.Subslot) (bls.SubslotStartSlot, error) {
@@ -458,4 +460,126 @@ func TestSubslotStartSlot_GenerateNextConsensusGroupShouldReturnErr(t *testing.T
 	err2 := srStartSlot.GenerateNextConsensusGroup(0)
 
 	assert.Equal(t, err, err2)
+}
+
+// whitelistNodesCoordinatorMock overrides GetConsensusWhitelistedNodes, which
+// the embedded common mock leaves unimplemented (it panics)
+type whitelistNodesCoordinatorMock struct {
+	*cMock.NodesCoordinatorMock
+	whitelisted    map[string]struct{}
+	err            error
+	requestedEpoch uint32
+}
+
+func (w *whitelistNodesCoordinatorMock) GetConsensusWhitelistedNodes(epoch uint32) (map[string]struct{}, error) {
+	w.requestedEpoch = epoch
+	if w.err != nil {
+		return nil, w.err
+	}
+	return w.whitelisted, nil
+}
+
+func TestSubslotStartSlot_EpochStartActionRefreshesElectedNodes(t *testing.T) {
+	t.Parallel()
+
+	newEpochKey := "newEpochValidator"
+	coordinator := &whitelistNodesCoordinatorMock{
+		NodesCoordinatorMock: cMock.NewNodesCoordinatorMock(),
+		whitelisted:          map[string]struct{}{newEpochKey: {}},
+	}
+	container := mock.InitConsensusCore()
+	container.SetValidatorGroupSelector(coordinator)
+
+	consensusState := initConsensusState()
+	ch := make(chan bool, 1)
+	sr, err := defaultSubslot(consensusState, ch, container)
+	require.Nil(t, err)
+	resetCount := 0
+	srStartSlotPtr, err := bls.NewSubslotStartSlot(
+		sr,
+		extend,
+		bls.ProcessingThresholdPercent,
+		executeStoredMessages,
+		func() { resetCount++ },
+	)
+	require.Nil(t, err)
+	srStartSlot := *srStartSlotPtr
+
+	oldKey := consensusState.ConsensusGroup()[0]
+	require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
+	require.False(t, consensusState.IsNodeInConsensusGroup(newEpochKey))
+
+	srStartSlot.EpochStartAction(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+	// the whitelist must be requested for the epoch of the triggering header
+	require.Equal(t, uint32(1), coordinator.requestedEpoch)
+
+	// the elected set is replaced wholesale with the new epoch's whitelisted
+	// nodes, so the new-epoch validator is accepted and the old one is not
+	require.True(t, consensusState.IsNodeInConsensusGroup(newEpochKey))
+	require.False(t, consensusState.IsNodeInConsensusGroup(oldKey))
+
+	// the per-slot message budgets of the previous epoch are cleared exactly once
+	require.Equal(t, 1, resetCount)
+}
+
+func TestSubslotStartSlot_EpochStartActionKeepsElectedNodesOnCoordinatorError(t *testing.T) {
+	t.Parallel()
+
+	coordinator := &whitelistNodesCoordinatorMock{
+		NodesCoordinatorMock: cMock.NewNodesCoordinatorMock(),
+		err:                  errors.New("coordinator has no config for the epoch"),
+	}
+	container := mock.InitConsensusCore()
+	container.SetValidatorGroupSelector(coordinator)
+
+	consensusState := initConsensusState()
+	ch := make(chan bool, 1)
+	sr, err := defaultSubslot(consensusState, ch, container)
+	require.Nil(t, err)
+	resetCount := 0
+	srStartSlotPtr, err := bls.NewSubslotStartSlot(
+		sr,
+		extend,
+		bls.ProcessingThresholdPercent,
+		executeStoredMessages,
+		func() { resetCount++ },
+	)
+	require.Nil(t, err)
+	srStartSlot := *srStartSlotPtr
+
+	oldKey := consensusState.ConsensusGroup()[0]
+	require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
+
+	srStartSlot.EpochStartAction(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+	require.Equal(t, uint32(1), coordinator.requestedEpoch)
+
+	// on a coordinator error the previous elected set is kept unchanged and the
+	// message budgets are not cleared, since no epoch transition was applied
+	require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
+	require.Equal(t, 0, resetCount)
+}
+
+func TestSubslotStartSlot_NewSubslotStartSlotNilResetConsensusMessagesShouldFail(t *testing.T) {
+	t.Parallel()
+
+	container := mock.InitConsensusCore()
+	consensusState := initConsensusState()
+	ch := make(chan bool, 1)
+	sr, err := defaultSubslot(consensusState, ch, container)
+	require.Nil(t, err)
+
+	// doStartSlotJob and EpochStartAction call it unconditionally, so a nil
+	// callback must be rejected at construction instead of panicking later
+	srStartSlot, err := bls.NewSubslotStartSlot(
+		sr,
+		extend,
+		bls.ProcessingThresholdPercent,
+		executeStoredMessages,
+		nil,
+	)
+
+	require.Nil(t, srStartSlot)
+	require.Equal(t, slot.ErrNilResetConsensusMessages, err)
 }

--- a/core/consensus/slot/bls/subslotStartSlot_test.go
+++ b/core/consensus/slot/bls/subslotStartSlot_test.go
@@ -567,6 +567,50 @@ func TestSubslotStartSlot_EpochStartActionKeepsElectedNodesOnCoordinatorError(t 
 	require.Equal(t, 0, resetCount)
 }
 
+func TestSubslotStartSlot_EpochStartActionDoesNotWidenOnUncalculatedNodeState(t *testing.T) {
+	t.Parallel()
+
+	// GetNodeState reports NsNotCalculated for a few milliseconds after every
+	// slot boundary, including on a fully synchronized validator. Treating that
+	// as "syncing" would widen the elected set mid-slot on a healthy validator,
+	// which is exactly what the synchronized skip exists to prevent
+	for _, nodeState := range []core.NodeState{core.NsSynchronized, core.NsNotCalculated} {
+		newEpochKey := "newEpochValidator"
+		coordinator := &whitelistNodesCoordinatorMock{
+			NodesCoordinatorMock: cMock.NewNodesCoordinatorMock(),
+			whitelisted:          map[string]struct{}{newEpochKey: {}},
+		}
+		container := mock.InitConsensusCore()
+		container.SetValidatorGroupSelector(coordinator)
+		container.SetBootStrapper(&mock.BootstrapperMock{GetNodeStateCalled: func() core.NodeState {
+			return nodeState
+		}})
+
+		consensusState := initConsensusState()
+		ch := make(chan bool, 1)
+		sr, err := defaultSubslot(consensusState, ch, container)
+		require.Nil(t, err)
+		resetCount := 0
+		srStartSlotPtr, err := bls.NewSubslotStartSlot(
+			sr,
+			extend,
+			bls.ProcessingThresholdPercent,
+			executeStoredMessages,
+			func() { resetCount++ },
+		)
+		require.Nil(t, err)
+		srStartSlot := *srStartSlotPtr
+
+		oldKey := consensusState.ConsensusGroup()[0]
+
+		srStartSlot.EpochStartAction(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+		require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
+		require.False(t, consensusState.IsNodeInConsensusGroup(newEpochKey))
+		require.Equal(t, 0, resetCount)
+	}
+}
+
 func TestSubslotStartSlot_NewSubslotStartSlotNilResetConsensusMessagesShouldFail(t *testing.T) {
 	t.Parallel()
 

--- a/core/consensus/slot/consensusMessageValidator.go
+++ b/core/consensus/slot/consensusMessageValidator.go
@@ -68,7 +68,7 @@ func (cmv *consensusMessageValidator) getPublicKeyBitmapSize() int {
 	return bitmapSize
 }
 
-func (cmv *consensusMessageValidator) checkConsensusMessageValidity(cnsMsg *consensus.Message, originator core.PeerID) error {
+func (cmv *consensusMessageValidator) checkConsensusMessageValidity(cnsMsg *consensus.Message, originator core.PeerID, skipBudget bool) error {
 	if !bytes.Equal(cnsMsg.ChainID, cmv.chainID) {
 		return fmt.Errorf("%w : received chain ID from consensus topic is invalid: %s",
 			ErrInvalidChainID,
@@ -139,16 +139,13 @@ func (cmv *consensusMessageValidator) checkConsensusMessageValidity(cnsMsg *cons
 			cnsMsg.SlotIndex)
 	}
 
-	if cmv.isMessageTypeLimitReached(cnsMsg.PubKey, cnsMsg.SlotIndex, msgType) {
+	if !skipBudget && cmv.isMessageTypeLimitReached(cnsMsg.PubKey, cnsMsg.SlotIndex, msgType) {
 		log.Trace("received message type from consensus topic reached the limit",
 			"msg type", cmv.consensusService.GetStringValue(msgType),
 			"public key", cnsMsg.PubKey,
 		)
 
-		return fmt.Errorf("%w : received message type %s from consensus topic reached the limit for public key: %s",
-			ErrMessageTypeLimitReached,
-			cmv.consensusService.GetStringValue(msgType),
-			logger.DisplayByteSlice(cnsMsg.PubKey))
+		return cmv.errMessageTypeLimitReached(msgType, cnsMsg.PubKey)
 	}
 
 	err = cmv.peerSignatureHandler.VerifyPeerSignature(cnsMsg.PubKey, core.PeerID(cnsMsg.OriginatorPid), cnsMsg.Signature)
@@ -164,14 +161,22 @@ func (cmv *consensusMessageValidator) checkConsensusMessageValidity(cnsMsg *cons
 			ErrOriginatorMismatch, p2p.PeerIDToShortString(originator), p2p.PeerIDToShortString(cnsMsgOriginator))
 	}
 
-	if !cmv.tryAddMessageTypeToPublicKey(cnsMsg.PubKey, cnsMsg.SlotIndex, msgType) {
-		return fmt.Errorf("%w : received message type %s from consensus topic reached the limit for public key: %s",
-			ErrMessageTypeLimitReached,
-			cmv.consensusService.GetStringValue(msgType),
-			logger.DisplayByteSlice(cnsMsg.PubKey))
+	if !skipBudget && !cmv.tryAddMessageTypeToPublicKey(cnsMsg.PubKey, cnsMsg.SlotIndex, msgType) {
+		return cmv.errMessageTypeLimitReached(msgType, cnsMsg.PubKey)
 	}
 
 	return nil
+}
+
+func (cmv *consensusMessageValidator) verifyPeerSignature(pubKey []byte, pid core.PeerID, sig []byte) error {
+	return cmv.peerSignatureHandler.VerifyPeerSignature(pubKey, pid, sig)
+}
+
+func (cmv *consensusMessageValidator) errMessageTypeLimitReached(msgType consensus.MessageType, pk []byte) error {
+	return fmt.Errorf("%w : received message type %s from consensus topic reached the limit for public key: %s",
+		ErrMessageTypeLimitReached,
+		cmv.consensusService.GetStringValue(msgType),
+		logger.DisplayByteSlice(pk))
 }
 
 func (cmv *consensusMessageValidator) isBlockHeaderHashSizeValid(cnsMsg *consensus.Message) bool {

--- a/core/consensus/slot/consensusMessageValidator.go
+++ b/core/consensus/slot/consensusMessageValidator.go
@@ -164,7 +164,12 @@ func (cmv *consensusMessageValidator) checkConsensusMessageValidity(cnsMsg *cons
 			ErrOriginatorMismatch, p2p.PeerIDToShortString(originator), p2p.PeerIDToShortString(cnsMsgOriginator))
 	}
 
-	cmv.addMessageTypeToPublicKey(cnsMsg.PubKey, cnsMsg.SlotIndex, msgType)
+	if !cmv.tryAddMessageTypeToPublicKey(cnsMsg.PubKey, cnsMsg.SlotIndex, msgType) {
+		return fmt.Errorf("%w : received message type %s from consensus topic reached the limit for public key: %s",
+			ErrMessageTypeLimitReached,
+			cmv.consensusService.GetStringValue(msgType),
+			logger.DisplayByteSlice(cnsMsg.PubKey))
+	}
 
 	return nil
 }
@@ -311,7 +316,13 @@ func (cmv *consensusMessageValidator) isMessageTypeLimitReached(pk []byte, slot 
 	return numMsgType >= MaxNumOfMessageTypeAccepted
 }
 
-func (cmv *consensusMessageValidator) addMessageTypeToPublicKey(pk []byte, slot int64, msgType consensus.MessageType) {
+// tryAddMessageTypeToPublicKey atomically checks the per-(pk, slot, msgType)
+// budget and records the message, returning false when the budget was already
+// exhausted. The check and the increment share one critical section, so
+// concurrent duplicates of the same message arriving via distinct peers cannot
+// all pass; the isMessageTypeLimitReached pre-check before signature
+// verification is only an optimization and runs in a separate critical section
+func (cmv *consensusMessageValidator) tryAddMessageTypeToPublicKey(pk []byte, slot int64, msgType consensus.MessageType) bool {
 	cmv.mutPkConsensusMessages.Lock()
 	defer cmv.mutPkConsensusMessages.Unlock()
 
@@ -323,7 +334,13 @@ func (cmv *consensusMessageValidator) addMessageTypeToPublicKey(pk []byte, slot 
 		cmv.mapPkConsensusMessages[key] = mapMsgType
 	}
 
+	if mapMsgType[msgType] >= MaxNumOfMessageTypeAccepted {
+		return false
+	}
+
 	mapMsgType[msgType]++
+
+	return true
 }
 
 func (cmv *consensusMessageValidator) resetConsensusMessages() {

--- a/core/consensus/slot/consensusMessageValidator_test.go
+++ b/core/consensus/slot/consensusMessageValidator_test.go
@@ -3,6 +3,8 @@ package slot_test
 import (
 	"crypto/rand"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	commonMock "github.com/klever-io/klever-go/common/mock"
@@ -438,6 +440,100 @@ func TestCheckConsensusMessageValidity_ErrMessageTypeLimitReached(t *testing.T) 
 	}
 	err := cmv.CheckConsensusMessageValidity(cnsMsg, "")
 	assert.True(t, errors.Is(err, slot.ErrMessageTypeLimitReached))
+}
+
+// TestCheckConsensusMessageValidity_BudgetExhaustedDuringVerification pins the
+// atomic check-and-add: the cheap budget pre-check passes, the budget fills
+// while the (mocked) signature verification runs (as a concurrent duplicate via
+// another peer would), and the final atomic add must reject the message instead
+// of exceeding the budget
+func TestCheckConsensusMessageValidity_BudgetExhaustedDuringVerification(t *testing.T) {
+	t.Parallel()
+
+	consensusMessageValidatorArgs := createDefaultConsensusMessageValidatorArgs()
+	consensusMessageValidatorArgs.ConsensusState.SlotIndex = 10
+
+	var fillBudget func()
+	singleSignerMock := &commonMock.SingleSignerMock{
+		SignStub: func(private crypto.PrivateKey, msg []byte) ([]byte, error) {
+			return []byte("signed"), nil
+		},
+		VerifyStub: func(public crypto.PublicKey, msg []byte, sig []byte) error {
+			if fillBudget != nil {
+				fillBudget()
+			}
+			return nil
+		},
+	}
+	keyGeneratorMock, _, _ := mock.InitKeys()
+	consensusMessageValidatorArgs.PeerSignatureHandler = &commonMock.PeerSignatureHandler{Signer: singleSignerMock, KeyGen: keyGeneratorMock}
+	cmv, _ := slot.NewConsensusMessageValidator(consensusMessageValidatorArgs)
+
+	headerBytes := make([]byte, 100)
+	_, _ = rand.Read(headerBytes)
+	headerHash := make([]byte, consensusMessageValidatorArgs.HasherSize)
+	_, _ = rand.Read(headerHash)
+	pubKey := []byte(consensusMessageValidatorArgs.ConsensusState.ConsensusGroup()[0])
+	sig := make([]byte, SignatureSize)
+	_, _ = rand.Read(sig)
+
+	fillBudget = func() {
+		cmv.TryAddMessageTypeToPublicKey(pubKey, 10, bls.MtBlockHeader)
+	}
+
+	cnsMsg := &consensus.Message{
+		ChainID: chainID, MsgType: int64(bls.MtBlockHeader),
+		Header: headerBytes, BlockHeaderHash: headerHash, PubKey: pubKey, Signature: sig, SlotIndex: 10,
+	}
+	err := cmv.CheckConsensusMessageValidity(cnsMsg, "")
+	assert.True(t, errors.Is(err, slot.ErrMessageTypeLimitReached))
+}
+
+func TestTryAddMessageTypeToPublicKey_StopsAtLimit(t *testing.T) {
+	t.Parallel()
+
+	consensusMessageValidatorArgs := createDefaultConsensusMessageValidatorArgs()
+	cmv, _ := slot.NewConsensusMessageValidator(consensusMessageValidatorArgs)
+	pubKey := []byte(consensusMessageValidatorArgs.ConsensusState.ConsensusGroup()[0])
+
+	for i := 0; i < slot.MaxNumOfMessageTypeAccepted; i++ {
+		assert.True(t, cmv.TryAddMessageTypeToPublicKey(pubKey, 10, bls.MtBlockHeader))
+	}
+	assert.False(t, cmv.TryAddMessageTypeToPublicKey(pubKey, 10, bls.MtBlockHeader))
+
+	// other slot or message type is unaffected
+	assert.True(t, cmv.TryAddMessageTypeToPublicKey(pubKey, 11, bls.MtBlockHeader))
+	assert.True(t, cmv.TryAddMessageTypeToPublicKey(pubKey, 10, bls.MtSignature))
+}
+
+func TestTryAddMessageTypeToPublicKey_ConcurrentDuplicatesRespectBudget(t *testing.T) {
+	t.Parallel()
+
+	// the check and the increment share one critical section, so concurrent
+	// duplicates of the same message (distinct gossip peers) cannot all pass;
+	// exactly MaxNumOfMessageTypeAccepted of them may be accepted
+	consensusMessageValidatorArgs := createDefaultConsensusMessageValidatorArgs()
+	cmv, _ := slot.NewConsensusMessageValidator(consensusMessageValidatorArgs)
+	pubKey := []byte(consensusMessageValidatorArgs.ConsensusState.ConsensusGroup()[0])
+
+	const goroutines = 32
+	var accepted atomic.Uint32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if cmv.TryAddMessageTypeToPublicKey(pubKey, 10, bls.MtBlockHeader) {
+				accepted.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, uint32(slot.MaxNumOfMessageTypeAccepted), accepted.Load())
 }
 
 func TestCheckConsensusMessageValidity_InvalidSignature(t *testing.T) {

--- a/core/consensus/slot/errors.go
+++ b/core/consensus/slot/errors.go
@@ -26,6 +26,9 @@ var ErrNilConsensusState = errors.New("consensus state is nil")
 // ErrNilExecuteStoredMessages is raised when a valid executeStoredMessages function is expected but nil used
 var ErrNilExecuteStoredMessages = errors.New("executeStoredMessages is nil")
 
+// ErrNilResetConsensusMessages is raised when a valid resetConsensusMessages function is expected but nil used
+var ErrNilResetConsensusMessages = errors.New("resetConsensusMessages is nil")
+
 // ErrInvalidChainID signals that an invalid chain ID has been provided
 var ErrInvalidChainID = errors.New("invalid chain ID in consensus")
 

--- a/core/consensus/slot/export_test.go
+++ b/core/consensus/slot/export_test.go
@@ -176,7 +176,7 @@ func (wrk *Worker) LastNetworkDegradedAlertSlot() int64 {
 // consensusMessageValidator
 
 func (cmv *consensusMessageValidator) CheckConsensusMessageValidity(cnsMsg *consensus.Message, originator core.PeerID) error {
-	return cmv.checkConsensusMessageValidity(cnsMsg, originator)
+	return cmv.checkConsensusMessageValidity(cnsMsg, originator, false)
 }
 
 func (cmv *consensusMessageValidator) CheckMessageWithFinalInfoValidity(cnsMsg *consensus.Message) error {

--- a/core/consensus/slot/export_test.go
+++ b/core/consensus/slot/export_test.go
@@ -200,7 +200,11 @@ func (cmv *consensusMessageValidator) IsBlockHeaderHashSizeValid(cnsMsg *consens
 }
 
 func (cmv *consensusMessageValidator) AddMessageTypeToPublicKey(pk []byte, slot int64, msgType consensus.MessageType) {
-	cmv.addMessageTypeToPublicKey(pk, slot, msgType)
+	cmv.tryAddMessageTypeToPublicKey(pk, slot, msgType)
+}
+
+func (cmv *consensusMessageValidator) TryAddMessageTypeToPublicKey(pk []byte, slot int64, msgType consensus.MessageType) bool {
+	return cmv.tryAddMessageTypeToPublicKey(pk, slot, msgType)
 }
 
 func (cmv *consensusMessageValidator) IsMessageTypeLimitReached(pk []byte, slot int64, msgType consensus.MessageType) bool {

--- a/core/consensus/slot/slotConsensus.go
+++ b/core/consensus/slot/slotConsensus.go
@@ -176,6 +176,20 @@ func (rcns *slotConsensus) SetSelfJobDone(subslotId int, value bool) error {
 	return rcns.SetJobDone(rcns.selfPubKey, subslotId, value)
 }
 
+// RefreshElectedNodes replaces the elected nodes map without touching the
+// consensus group or validator slot states. Called on epoch start to keep the
+// IsNodeInConsensusGroup gate current while the node is still syncing and
+// initCurrentSlot (which calls SetConsensusGroup) is not running yet.
+// Ownership of elected transfers to the receiver: the caller must not retain or
+// write to the map afterwards, since readers access it under mutElected only.
+// The sole caller, EpochStartAction, passes the fresh map built by
+// GetConsensusWhitelistedNodes.
+func (rcns *slotConsensus) RefreshElectedNodes(elected map[string]struct{}) {
+	rcns.mutElected.Lock()
+	rcns.electedNodes = elected
+	rcns.mutElected.Unlock()
+}
+
 // IsNodeInConsensusGroup method checks if the node is part of consensus group of the current slot
 func (rcns *slotConsensus) IsNodeInConsensusGroup(node string) bool {
 	rcns.mutElected.RLock()

--- a/core/consensus/slot/worker.go
+++ b/core/consensus/slot/worker.go
@@ -377,7 +377,7 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	err = wrk.consensusMessageValidator.checkConsensusMessageValidity(cnsMsg, message.Peer(), syncing)
 	wrk.resetRedundancyInactivityOnValidMessage(cnsMsg, message.Peer(), err)
 	if err != nil {
-		return err
+		return relayTolerantValidityError(err, syncing)
 	}
 
 	wrk.updateNetworkShardingVals(message, cnsMsg)
@@ -450,6 +450,30 @@ func (wrk *Worker) resetRedundancyInactivityOnValidMessage(cnsMsg *consensus.Mes
 
 func isSlotTimingError(err error) bool {
 	return errors.Is(err, ErrMessageForPastSlot) || errors.Is(err, ErrMessageForFutureSlot)
+}
+
+// isStaleLocalViewError reports whether a validity error is a verdict about this
+// node's own view (a stale elected set, a lagging slot index) rather than about
+// the message itself
+func isStaleLocalViewError(err error) bool {
+	return isSlotTimingError(err) || errors.Is(err, ErrNodeIsNotInConsensusGroup)
+}
+
+// relayTolerantValidityError maps a validity error to what ProcessReceivedMessage
+// returns to pubsub. A non-nil return marks the message invalid, so this node
+// stops relaying it to its mesh peers. While syncing, this node's elected set and
+// slot index are behind the network, so rejecting on those grounds says nothing
+// about the message and must not cost the network this node's relay for the whole
+// catch-up
+func relayTolerantValidityError(err error, syncing bool) error {
+	if !syncing || !isStaleLocalViewError(err) {
+		return err
+	}
+
+	log.Trace("consensus message rejected against a stale local view while syncing, still relayed",
+		"error", err.Error())
+
+	return nil
 }
 
 func (wrk *Worker) storeMessage(cnsDta *consensus.Message) {

--- a/core/consensus/slot/worker.go
+++ b/core/consensus/slot/worker.go
@@ -343,10 +343,11 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	cnsMsg := &consensus.Message{}
 
 	defer func() {
+		if wrk.bootstrapper.GetNodeState() != core.NsSynchronized {
+			return
+		}
 		errNotCritical := wrk.checkSelfState(cnsMsg)
 		if errNotCritical == nil && wrk.shouldBlacklistPeer(err) {
-			//this situation is so severe that we have to black list both the message originator and the connected peer
-			//that disseminated this message.
 			log.Debug("Worker: invalid consensus message",
 				"originator", message.Peer().Pretty(),
 				"err", process.SanitizeBlacklistReason(err.Error()))
@@ -370,29 +371,18 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		"size", len(message.Data()),
 	)
 
-	err = wrk.consensusMessageValidator.checkConsensusMessageValidity(cnsMsg, message.Peer())
+	nodeState := wrk.bootstrapper.GetNodeState()
+	syncing := nodeState != core.NsSynchronized
+
+	err = wrk.consensusMessageValidator.checkConsensusMessageValidity(cnsMsg, message.Peer(), syncing)
 	wrk.resetRedundancyInactivityOnValidMessage(cnsMsg, message.Peer(), err)
 	if err != nil {
 		return err
 	}
 
-	// learn the peer id -> public key mapping before any early return, so a node
-	// that is still syncing keeps classifying new-epoch validators correctly; the
-	// antiflood originator gate on validator-only topics depends on this mapping,
-	// and gating it on the synchronized state stalls a fallback node's resync after
-	// an epoch shuffle-out
 	wrk.updateNetworkShardingVals(message, cnsMsg)
 
-	nodeState := wrk.bootstrapper.GetNodeState()
-	if nodeState != core.NsSynchronized {
-		// the node is still bootstrapping; drop the message without processing.
-		// note: checkConsensusMessageValidity above already called addMessageTypeToPublicKey,
-		// burning the (pk, slot, msgType) budget for this message type; if the node becomes
-		// synchronized mid-slot, a duplicate arriving on another gossip path will hit
-		// ErrMessageTypeLimitReached and be dropped, costing one slot on resync; this is
-		// bounded (resetConsensusMessages clears the budget at the next slot) and acceptable
-		// because the alternative (skipping validity entirely) would let unverified pubkeys
-		// into the PeerShardMapper
+	if syncing {
 		return nil
 	}
 
@@ -435,15 +425,19 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	return nil
 }
 
-// resetRedundancyInactivityOnValidMessage resets the redundancy inactivity
-// counter when the main machine is alive. Only a fully valid message counts as
-// evidence: checkConsensusMessageValidity runs its cheap rejections (including
-// the per-key message budget) before VerifyPeerSignature, so any error return
-// leaves the pubkey binding unproven. Accepting one of those errors would let
-// anyone replay the public validator key to keep this backup from taking over
-// for a dead main machine.
 func (wrk *Worker) resetRedundancyInactivityOnValidMessage(cnsMsg *consensus.Message, peer core.PeerID, validityErr error) {
-	if !wrk.nodeRedundancyHandler.IsRedundancyNode() || validityErr != nil {
+	if !wrk.nodeRedundancyHandler.IsRedundancyNode() {
+		return
+	}
+
+	authenticated := validityErr == nil
+	if !authenticated && isSlotTimingError(validityErr) {
+		sigErr := wrk.consensusMessageValidator.verifyPeerSignature(
+			cnsMsg.PubKey, core.PeerID(cnsMsg.OriginatorPid), cnsMsg.Signature)
+		authenticated = sigErr == nil
+	}
+
+	if !authenticated {
 		return
 	}
 
@@ -452,6 +446,10 @@ func (wrk *Worker) resetRedundancyInactivityOnValidMessage(cnsMsg *consensus.Mes
 		string(cnsMsg.PubKey),
 		peer,
 	)
+}
+
+func isSlotTimingError(err error) bool {
+	return errors.Is(err, ErrMessageForPastSlot) || errors.Is(err, ErrMessageForFutureSlot)
 }
 
 func (wrk *Worker) storeMessage(cnsDta *consensus.Message) {

--- a/core/consensus/slot/worker.go
+++ b/core/consensus/slot/worker.go
@@ -335,12 +335,6 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		return err
 	}
 
-	nodeState := wrk.bootstrapper.GetNodeState()
-	if nodeState != core.NsSynchronized { // if node is not synchronized yet, it has to continue the bootstrapping mechanism
-		log.Trace("Skipping consensus message due to unsynchronized state")
-		return nil
-	}
-
 	err := wrk.antifloodHandler.CanProcessMessagesOnTopic(message.Peer(), common.ConsensusTopic, 1, uint64(len(message.Data())), message.SeqNo())
 	if err != nil {
 		return err
@@ -366,14 +360,6 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		return err
 	}
 
-	if wrk.nodeRedundancyHandler.IsRedundancyNode() {
-		wrk.nodeRedundancyHandler.ResetInactivityIfNeeded(
-			wrk.consensusState.SelfPubKey(),
-			string(cnsMsg.PubKey),
-			message.Peer(),
-		)
-	}
-
 	msgType := consensus.MessageType(cnsMsg.MsgType)
 
 	log.Trace("received message from consensus topic",
@@ -385,8 +371,29 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	)
 
 	err = wrk.consensusMessageValidator.checkConsensusMessageValidity(cnsMsg, message.Peer())
+	wrk.resetRedundancyInactivityOnValidMessage(cnsMsg, message.Peer(), err)
 	if err != nil {
 		return err
+	}
+
+	// learn the peer id -> public key mapping before any early return, so a node
+	// that is still syncing keeps classifying new-epoch validators correctly; the
+	// antiflood originator gate on validator-only topics depends on this mapping,
+	// and gating it on the synchronized state stalls a fallback node's resync after
+	// an epoch shuffle-out
+	wrk.updateNetworkShardingVals(message, cnsMsg)
+
+	nodeState := wrk.bootstrapper.GetNodeState()
+	if nodeState != core.NsSynchronized {
+		// the node is still bootstrapping; drop the message without processing.
+		// note: checkConsensusMessageValidity above already called addMessageTypeToPublicKey,
+		// burning the (pk, slot, msgType) budget for this message type; if the node becomes
+		// synchronized mid-slot, a duplicate arriving on another gossip path will hit
+		// ErrMessageTypeLimitReached and be dropped, costing one slot on resync; this is
+		// bounded (resetConsensusMessages clears the budget at the next slot) and acceptable
+		// because the alternative (skipping validity entirely) would let unverified pubkeys
+		// into the PeerShardMapper
+		return nil
 	}
 
 	wrk.consensusState.RLockSlotState()
@@ -403,7 +410,6 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		return nil
 	}
 
-	wrk.updateNetworkShardingVals(message, cnsMsg)
 	IsMessageWithBlockHeader := wrk.consensusService.IsMessageWithBlockHeader(msgType)
 	if IsMessageWithBlockHeader {
 		err = wrk.doJobOnMessageWithHeader(cnsMsg)
@@ -427,6 +433,25 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	go wrk.executeReceivedMessages(cnsMsg)
 
 	return nil
+}
+
+// resetRedundancyInactivityOnValidMessage resets the redundancy inactivity
+// counter when the main machine is alive. Only a fully valid message counts as
+// evidence: checkConsensusMessageValidity runs its cheap rejections (including
+// the per-key message budget) before VerifyPeerSignature, so any error return
+// leaves the pubkey binding unproven. Accepting one of those errors would let
+// anyone replay the public validator key to keep this backup from taking over
+// for a dead main machine.
+func (wrk *Worker) resetRedundancyInactivityOnValidMessage(cnsMsg *consensus.Message, peer core.PeerID, validityErr error) {
+	if !wrk.nodeRedundancyHandler.IsRedundancyNode() || validityErr != nil {
+		return
+	}
+
+	wrk.nodeRedundancyHandler.ResetInactivityIfNeeded(
+		wrk.consensusState.SelfPubKey(),
+		string(cnsMsg.PubKey),
+		peer,
+	)
 }
 
 func (wrk *Worker) storeMessage(cnsDta *consensus.Message) {

--- a/core/consensus/slot/worker_test.go
+++ b/core/consensus/slot/worker_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/klever-io/klever-go/tools"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var fromConnectedPeerId = core.PeerID("connected peer id")
@@ -518,10 +519,115 @@ func TestWorker_ProcessReceivedMessageRedundancyNodeShouldResetInactivityIfNeede
 		},
 	}
 	wrk.SetNodeRedundancyHandler(nodeRedundancyMock)
-	buff, _ := wrk.Marshalizer().Marshal(&consensus.Message{})
-	_ = wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+
+	// the inactivity reset runs only after checkConsensusMessageValidity, so the
+	// message must be valid to reach it
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshalHdr := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshalHdr)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		0,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	err := wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff, PeerField: currentPid}, fromConnectedPeerId)
+	require.NoError(t, err)
 
 	assert.True(t, wasCalled)
+}
+
+func TestWorker_ProcessReceivedMessageRedundancyResetSkippedOnInvalidMessage(t *testing.T) {
+	t.Parallel()
+	wrk := *initWorker()
+	var wasCalled bool
+	nodeRedundancyMock := &mock.NodeRedundancyHandlerStub{
+		IsRedundancyNodeCalled: func() bool {
+			return true
+		},
+		ResetInactivityIfNeededCalled: func(selfPubKey string, consensusMsgPubKey string, consensusMsgPeerID core.PeerID) {
+			wasCalled = true
+		},
+	}
+	wrk.SetNodeRedundancyHandler(nodeRedundancyMock)
+
+	// an unsigned/invalid message must not reach the inactivity reset: a spoofed
+	// message carrying the backup's own pubkey could otherwise keep it from taking
+	// over for a dead main machine
+	buff, err := wrk.Marshalizer().Marshal(&consensus.Message{})
+	require.NoError(t, err)
+	err = wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+	require.Error(t, err)
+
+	assert.False(t, wasCalled)
+}
+
+func TestWorker_ProcessReceivedMessageRedundancyNoResetOnMessageTypeLimitReached(t *testing.T) {
+	t.Parallel()
+	wrk := *initWorker()
+	resetCount := 0
+	nodeRedundancyMock := &mock.NodeRedundancyHandlerStub{
+		IsRedundancyNodeCalled: func() bool {
+			return true
+		},
+		ResetInactivityIfNeededCalled: func(selfPubKey string, consensusMsgPubKey string, consensusMsgPeerID core.PeerID) {
+			resetCount++
+		},
+	}
+	wrk.SetNodeRedundancyHandler(nodeRedundancyMock)
+
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, err := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, err)
+	hdrStr, err := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, err)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	proposerPk := []byte(wrk.ConsensusState().ConsensusGroup()[0])
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		proposerPk,
+		signature,
+		int(bls.MtBlockHeader),
+		0,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, err := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, err)
+	msg := &cMock.P2PMessageMock{DataField: buff, PeerField: currentPid}
+
+	// first call passes the full pipeline including VerifyPeerSignature and resets
+	err = wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+	require.NoError(t, err)
+	assert.Equal(t, 1, resetCount)
+
+	// the budget for this (pubkey, slot, msgType) is now exhausted, so the second
+	// call returns before VerifyPeerSignature runs. the pubkey binding is unproven
+	// for this message, so it must NOT reset: otherwise anyone could replay the
+	// public validator key to keep a backup from taking over for a dead main machine
+	err = wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+	assert.True(t, errors.Is(err, slot.ErrMessageTypeLimitReached))
+	assert.Equal(t, 1, resetCount)
 }
 
 func TestWorker_ProcessReceivedMessageNodeNotInConsensusGroupShouldErr(t *testing.T) {
@@ -620,6 +726,231 @@ func TestWorker_ProcessReceivedMessageComputeReceivedProposedBlockMetric(t *test
 		receivedValue >= minimumExpectedValue,
 		fmt.Sprintf("minimum expected was %d, got %d", minimumExpectedValue, receivedValue),
 	)
+}
+
+func TestWorker_ProcessReceivedMessageLearnsPeerIDPublicKeyWhenNotSynchronized(t *testing.T) {
+	t.Parallel()
+
+	var learnedPid core.PeerID
+	var learnedPk []byte
+	learnedCalled := false
+	collector := &mock.NetworkShardingCollectorStub{
+		UpdatePeerIDPublicKeyCalled: func(pid core.PeerID, pk []byte) {
+			learnedCalled = true
+			learnedPid = pid
+			learnedPk = pk
+		},
+	}
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.NetworkShardingCollector = collector
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	// use a key that is NOT in ConsensusGroup() to prove that an out-of-group
+	// validator (e.g. one shuffled in after an epoch transition) gets its mapping
+	// learned; add it to the elected set via RefreshElectedNodes, simulating an
+	// epoch-start whitelist refresh
+	outOfGroupPk := make([]byte, PublicKeySize)
+	for i := range outOfGroupPk {
+		outOfGroupPk[i] = 0xAB
+	}
+	elected := make(map[string]struct{})
+	for _, pk := range wrk.ConsensusState().ConsensusGroup() {
+		elected[pk] = struct{}{}
+	}
+	elected[string(outOfGroupPk)] = struct{}{}
+	wrk.ConsensusState().RefreshElectedNodes(elected)
+
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshal := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshal)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		outOfGroupPk,
+		signature,
+		int(bls.MtBlockHeader),
+		// a future slot index, so the "not stored" assertion below is only
+		// satisfied by the unsynchronized early return
+		1,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	msg := &cMock.P2PMessageMock{
+		DataField: buff,
+		PeerField: currentPid,
+	}
+
+	err := wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+
+	require.NoError(t, err)
+	assert.True(t, learnedCalled, "peer id -> public key mapping must be learned for out-of-group validators while not synchronized")
+	assert.Equal(t, currentPid, learnedPid)
+	assert.Equal(t, outOfGroupPk, learnedPk)
+	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bls.MtBlockHeader]),
+		"the mapping is learned but the message itself must still not be processed")
+}
+
+func TestWorker_ProcessReceivedMessageDoesNotLearnPeerIDPublicKeyOnInvalidMessage(t *testing.T) {
+	t.Parallel()
+
+	// the inverse of the test above: updateNetworkShardingVals runs only after
+	// checkConsensusMessageValidity returns nil, so an unverified public key must
+	// never reach the PeerShardMapper. this pins the ordering in worker.go; a
+	// reordering of those two blocks would otherwise pass every other test
+	learnedCalled := false
+	collector := &mock.NetworkShardingCollectorStub{
+		UpdatePeerIDPublicKeyCalled: func(_ core.PeerID, _ []byte) {
+			learnedCalled = true
+		},
+	}
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.NetworkShardingCollector = collector
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	// a wrong chain ID fails checkConsensusMessageValidity before the mapping is learned
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshal := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshal)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		0,
+		0,
+		[]byte("wrong chain ID"),
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+
+	err := wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff, PeerField: currentPid}, fromConnectedPeerId)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, slot.ErrInvalidChainID))
+	assert.False(t, learnedCalled, "an unverified public key must never reach the PeerShardMapper")
+}
+
+func TestWorker_ProcessReceivedMessageWhenNotSynchronizedStillRejectsInvalidMessage(t *testing.T) {
+	t.Parallel()
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	// an unsynchronized node still runs full validity checks (the early return sits
+	// below them), so a malformed message is rejected rather than silently ignored
+	blk := &block.Block{Header: &block.BlockHeader{}}
+	blkStr, errMarshalBlk := mock.MarshalizerMock{}.Marshal(blk)
+	require.NoError(t, errMarshalBlk)
+	cnsMsg := consensus.NewConsensusMessage(
+		blockHeaderHash,
+		nil,
+		blkStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		1,
+		1,
+		[]byte("inconsistent chain ID"),
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	err := wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, slot.ErrInvalidChainID))
+}
+
+func TestWorker_ProcessReceivedMessageWhenNotSynchronizedSkipsProcessing(t *testing.T) {
+	t.Parallel()
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshal := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshal)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		// a slot index above the worker's current index: a synchronized worker
+		// would store this message, so the assertion below only holds because of
+		// the unsynchronized early return
+		1,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	msg := &cMock.P2PMessageMock{
+		DataField: buff,
+		PeerField: currentPid,
+	}
+
+	err := wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bls.MtBlockHeader]),
+		"an unsynchronized worker must not store the message for a future slot")
 }
 
 func TestWorker_ProcessReceivedMessageInconsistentChainIDInConsensusMessageShouldErr(t *testing.T) {

--- a/core/consensus/slot/worker_test.go
+++ b/core/consensus/slot/worker_test.go
@@ -903,6 +903,70 @@ func TestWorker_ProcessReceivedMessageWhenNotSynchronizedStillRejectsInvalidMess
 	assert.True(t, errors.Is(err, slot.ErrInvalidChainID))
 }
 
+func TestWorker_ProcessReceivedMessageWhenNotSynchronizedKeepsRelayingOnStaleLocalView(t *testing.T) {
+	t.Parallel()
+
+	// a syncing node's elected set is the one it bootstrapped with, so live
+	// consensus messages fail IsNodeInConsensusGroup. Returning that error to
+	// pubsub marks the message invalid and stops this node relaying it to its
+	// mesh peers for the whole catch-up, which develop did not do. The verdict
+	// is about this node's stale view, not about the message, so the message is
+	// still relayed while nothing is learned or processed from it
+	learnedCalled := false
+	collector := &mock.NetworkShardingCollectorStub{
+		UpdatePeerIDPublicKeyCalled: func(_ core.PeerID, _ []byte) {
+			learnedCalled = true
+		},
+	}
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.NetworkShardingCollector = collector
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshal := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshal)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+
+	// a well-formed public key the node does not have in its elected set, which
+	// is what a live validator looks like to a node still on its bootstrap epoch
+	outOfGroupPk := make([]byte, PublicKeySize)
+	for i := range outOfGroupPk {
+		outOfGroupPk[i] = 0xCD
+	}
+
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		outOfGroupPk,
+		signature,
+		int(bls.MtBlockHeader),
+		0,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+
+	err := wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff, PeerField: currentPid}, fromConnectedPeerId)
+
+	require.NoError(t, err, "a stale-view rejection must not stop this node relaying the message")
+	assert.False(t, learnedCalled, "an unverified public key must never reach the PeerShardMapper")
+}
+
 func TestWorker_ProcessReceivedMessageWhenNotSynchronizedSkipsProcessing(t *testing.T) {
 	t.Parallel()
 

--- a/core/process/interface.go
+++ b/core/process/interface.go
@@ -298,6 +298,7 @@ type Bootstrapper interface {
 type ValidatorsProvider interface {
 	GetLatestValidators() map[string]*state.ValidatorApiResponse
 	GetLatestPeers() []state.PeerAccountHandler
+	RefreshCache(epoch uint32)
 	IsInterfaceNil() bool
 }
 

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -132,10 +132,12 @@ func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
 	}
 
 	ptp.mutCache.Lock()
-	if epoch >= ptp.cacheEpoch {
-		ptp.cache = newCache
-		ptp.cacheEpoch = epoch
+	if epoch < ptp.cacheEpoch {
+		log.Warn("peerTypeProvider - cache epoch going backward",
+			"previous", ptp.cacheEpoch, "new", epoch)
 	}
+	ptp.cache = newCache
+	ptp.cacheEpoch = epoch
 	ptp.mutCache.Unlock()
 }
 
@@ -167,12 +169,12 @@ func (ptp *PeerTypeProvider) createNewCache(
 	}
 	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
 
-	// all three getters fail on the same missing nodesConfig[epoch] lookup, so
-	// they fail or succeed together; keep the previous cache only when the
-	// epoch config is entirely missing
-	allListsFailed := electedErr != nil && eligibleErr != nil && waitingErr != nil
+	// the three getters each acquire mutNodesConfig independently, so the epoch
+	// config can disappear between calls; treat any single failure as stale and
+	// keep the previous cache to avoid installing a partial validator set
+	anyListFailed := electedErr != nil || eligibleErr != nil || waitingErr != nil
 
-	return newCache, !allListsFailed
+	return newCache, !anyListFailed
 }
 
 func computePeerType(

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -116,10 +116,8 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 
 // RefreshCache rebuilds the peer type cache from the nodes coordinator for the
 // given epoch; used after the storage bootstrap restores the coordinator state.
-// Epoch ordering is enforced between real updates (a stale refresh cannot
-// overwrite a newer epoch-start update), but the construction-time seed never
-// takes precedence: the first refresh always applies, also after a storage
-// restore that walks back to an epoch older than the construction epoch.
+// Backward epoch updates are allowed (with a warning log) so that chain reverts
+// correctly refresh the cache with the reverted-to epoch's validator set.
 func (ptp *PeerTypeProvider) RefreshCache(epoch uint32) {
 	ptp.updateCache(epoch)
 }

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -22,6 +22,7 @@ type peerListAndShard struct {
 type PeerTypeProvider struct {
 	nodesCoordinator sharding.NodesCoordinator
 	cache            map[string]*peerListAndShard
+	cacheEpoch       uint32
 	mutCache         sync.RWMutex
 }
 
@@ -47,7 +48,18 @@ func NewPeerTypeProvider(arg ArgPeerTypeProvider) (*PeerTypeProvider, error) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	ptp.updateCache(arg.StartEpoch)
+	// seed the cache with construction-time data but leave cacheEpoch at zero:
+	// construction runs before the storage bootstrap restores the coordinator
+	// state, so this seed must never outrank the post-bootstrap RefreshCache,
+	// not even when a restore walk-back targets an older epoch than StartEpoch
+	seedCache, ok := ptp.createNewCache(arg.StartEpoch)
+	if ok {
+		ptp.mutCache.Lock()
+		ptp.cache = seedCache
+		ptp.mutCache.Unlock()
+	} else {
+		log.Warn("peerTypeProvider - no validator list available at construction", "epoch", arg.StartEpoch)
+	}
 
 	arg.EpochStartEventNotifier.RegisterHandler(ptp.epochStartEventHandler())
 
@@ -93,39 +105,74 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 				"epoch", hdr.GetEpoch())
 			ptp.updateCache(hdr.GetEpoch())
 		},
-		func(_ data.HeaderHandler) {},
+		func(_ data.HeaderHandler) {
+			// nothing to do on epoch start prepare; the cache refresh happens on the action event above
+		},
 		core.IndexerOrder,
 	)
 
 	return subscribeHandler
 }
 
+// RefreshCache rebuilds the peer type cache from the nodes coordinator for the
+// given epoch; used after the storage bootstrap restores the coordinator state.
+// Epoch ordering is enforced between real updates (a stale refresh cannot
+// overwrite a newer epoch-start update), but the construction-time seed never
+// takes precedence: the first refresh always applies, also after a storage
+// restore that walks back to an epoch older than the construction epoch.
+func (ptp *PeerTypeProvider) RefreshCache(epoch uint32) {
+	ptp.updateCache(epoch)
+}
+
 func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
-	newCache := ptp.createNewCache(epoch)
+	newCache, ok := ptp.createNewCache(epoch)
+	if !ok {
+		log.Warn("peerTypeProvider - no validator list available, keeping previous cache", "epoch", epoch)
+		return
+	}
 
 	ptp.mutCache.Lock()
-	ptp.cache = newCache
+	if epoch >= ptp.cacheEpoch {
+		ptp.cache = newCache
+		ptp.cacheEpoch = epoch
+	}
 	ptp.mutCache.Unlock()
 }
 
+// createNewCache returns (cache, false) when the epoch config is entirely
+// missing (all three getters fail), preserving the previous cache; when the
+// config exists but lists are empty the new (empty) cache replaces the old one
 func (ptp *PeerTypeProvider) createNewCache(
 	epoch uint32,
-) map[string]*peerListAndShard {
+) (map[string]*peerListAndShard, bool) {
 	newCache := make(map[string]*peerListAndShard)
 
-	nodesMapElected, err := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch)
+	// the coordinator produces disjoint lists; if they ever overlap, the last
+	// list merged below wins
+	nodesMapElected, electedErr := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
+	if electedErr != nil {
+		log.Debug("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch, "error", electedErr)
 	}
 	computePeerType(newCache, nodesMapElected, core.ElectedList)
 
-	nodesMapEligible, err := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch)
+	nodesMapEligible, eligibleErr := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
+	if eligibleErr != nil {
+		log.Debug("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch, "error", eligibleErr)
 	}
 	computePeerType(newCache, nodesMapEligible, core.EligibleList)
 
-	return newCache
+	nodesMapWaiting, waitingErr := ptp.nodesCoordinator.GetAllWaitingValidatorsKeys(epoch, false)
+	if waitingErr != nil {
+		log.Debug("peerTypeProvider - GetAllWaitingValidatorsKeys failed", "epoch", epoch, "error", waitingErr)
+	}
+	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
+
+	// all three getters fail on the same missing nodesConfig[epoch] lookup, so
+	// they fail or succeed together; keep the previous cache only when the
+	// epoch config is entirely missing
+	allListsFailed := electedErr != nil && eligibleErr != nil && waitingErr != nil
+
+	return newCache, !allListsFailed
 }
 
 func computePeerType(

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -116,12 +116,20 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 
 // RefreshCache rebuilds the peer type cache from the nodes coordinator for the
 // given epoch; used after the storage bootstrap restores the coordinator state.
-// Backward epoch updates are allowed (with a warning log) so that chain reverts
-// correctly refresh the cache with the reverted-to epoch's validator set.
 func (ptp *PeerTypeProvider) RefreshCache(epoch uint32) {
 	ptp.updateCache(epoch)
 }
 
+// updateCache installs a freshly built cache for the given epoch. Backward moves
+// are applied, not dropped, and only logged. Both callers carry an authoritative
+// epoch: the epoch start notification is driven by block processing and is how a
+// revert arrives (RevertStateToBlock -> SetProcessed -> NotifyAll), and
+// RefreshCache runs once from StartConsensus with the epoch the storage
+// bootstrap actually restored, which is legitimately older than an epoch start
+// that fired earlier during LoadStorage. Ordering the two would drop whichever
+// arrives second on a bootstrap walk-back. There is no third, asynchronous
+// caller to protect against: block syncing only starts after the RefreshCache
+// call site.
 func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
 	newCache, ok := ptp.createNewCache(epoch)
 	if !ok {
@@ -130,18 +138,22 @@ func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
 	}
 
 	ptp.mutCache.Lock()
+	defer ptp.mutCache.Unlock()
+
 	if epoch < ptp.cacheEpoch {
 		log.Warn("peerTypeProvider - cache epoch going backward",
 			"previous", ptp.cacheEpoch, "new", epoch)
 	}
+
 	ptp.cache = newCache
 	ptp.cacheEpoch = epoch
-	ptp.mutCache.Unlock()
 }
 
-// createNewCache returns (cache, false) when the epoch config is entirely
-// missing (all three getters fail), preserving the previous cache; when the
-// config exists but lists are empty the new (empty) cache replaces the old one
+// createNewCache always runs all three getters and returns (cache, false) when
+// any of them failed, preserving the previous cache: the getters lock
+// independently, so a partial result would install an incomplete validator set.
+// When all three succeed but the lists are empty, the new (empty) cache
+// replaces the old one
 func (ptp *PeerTypeProvider) createNewCache(
 	epoch uint32,
 ) (map[string]*peerListAndShard, bool) {

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -689,23 +689,27 @@ func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T
 		defer wg.Done()
 		epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: 2}})
 	}()
+	// GetAllPeerTypeInfos reads the whole cache under one lock, so a mix of the
+	// two epochs here would be a genuine torn read rather than a scheduling
+	// artefact of two separate lookups
+	mixedRead := int32(0)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 50; i++ {
-			_, _, errCompute := ptp.ComputeForPubKey(pkNewEpoch)
-			// assert, not require: FailNow from a non-test goroutine is undefined
-			assert.Nil(t, errCompute)
+		for i := 0; i < 200; i++ {
+			infos := ptp.GetAllPeerTypeInfos()
+			if len(infos) > 1 {
+				atomic.StoreInt32(&mixedRead, 1)
+			}
 		}
 	}()
 
 	wg.Wait()
 
-	// exactly one of the two caches must be installed, never a mix of both
-	newType, _, err := ptp.ComputeForPubKey(pkNewEpoch)
-	require.Nil(t, err)
-	oldType, _, err := ptp.ComputeForPubKey(pkOldEpoch)
-	require.Nil(t, err)
-	require.NotEqual(t, newType, oldType)
-	require.Contains(t, []core.PeerType{newType, oldType}, core.ElectedList)
-	require.Contains(t, []core.PeerType{newType, oldType}, core.ObserverList)
+	require.Zero(t, atomic.LoadInt32(&mixedRead), "a reader saw a cache mixing both epochs")
+
+	// exactly one of the two caches survived, never a merge of both
+	infos := ptp.GetAllPeerTypeInfos()
+	require.Len(t, infos, 1)
+	require.Contains(t, []string{string(pkNewEpoch), string(pkOldEpoch)}, infos[0].PublicKey)
+	require.Equal(t, string(core.ElectedList), infos[0].PeerType)
 }

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/eventNotifier"
+	"github.com/klever-io/klever-go/sharding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,7 +122,9 @@ func TestNewPeerTypeProvider_createCache(t *testing.T) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
 
 	assert.NotNil(t, cache)
 
@@ -129,6 +133,224 @@ func TestNewPeerTypeProvider_createCache(t *testing.T) {
 
 	assert.NotNil(t, cache[pkEligible])
 	assert.Equal(t, core.EligibleList, cache[pkEligible].pType)
+}
+
+func TestNewPeerTypeProvider_createCacheIncludesWaitingList(t *testing.T) {
+	pkElected := "pk1"
+	pkEligible := "pk2"
+	pkWaiting := "pk3"
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkElected)}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkEligible)}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkWaiting)}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
+
+	require.NotNil(t, cache[pkWaiting])
+	require.Equal(t, core.WaitingList, cache[pkWaiting].pType)
+}
+
+func TestPeerTypeProvider_RefreshCacheRebuildsFromCoordinator(t *testing.T) {
+	// mimic a restart: at construction time the coordinator only holds stale
+	// data (no validators); after LoadState restores the real configs a
+	// RefreshCache call must rebuild the cache from the coordinator, querying
+	// it with the exact epoch the caller passed
+	pk := []byte("pk1")
+	restored := false
+	restoredEpoch := uint32(5)
+	var lastQueriedEpoch uint32
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			lastQueriedEpoch = epoch
+			if restored {
+				return [][]byte{pk}, nil
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+
+	restored = true
+	ptp.RefreshCache(restoredEpoch)
+
+	require.Equal(t, restoredEpoch, lastQueriedEpoch)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheReplacesCacheWhenListsAreEmptyWithoutError(t *testing.T) {
+	pk := []byte("pk1")
+	demoted := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			if demoted {
+				return [][]byte{}, nil
+			}
+			return [][]byte{pk}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	// successful fetches returning empty lists are a genuine state (validator
+	// demoted) and must replace the cache, unlike the all-fetches-failed case
+	demoted = true
+	ptp.RefreshCache(6)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheAppliesForEpochOlderThanConstruction(t *testing.T) {
+	// mimic a restart where the storage bootstrap walks back to an older epoch:
+	// construction happens at StartEpoch 5 (pre-restore data), then the restored
+	// chain head is in epoch 4; RefreshCache(4) must rebuild the cache, the
+	// construction-time seed must not claim epoch precedence
+	pkRestored := []byte("pkRestored")
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.StartEpoch = 5
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			if epoch == 4 {
+				return [][]byte{pkRestored}, nil
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pkRestored)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+
+	ptp.RefreshCache(4)
+
+	peerType, _, err = ptp.ComputeForPubKey(pkRestored)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_UpdateCacheIgnoresStaleEpochAfterNewerUpdate(t *testing.T) {
+	// epoch ordering between real updates: once the cache was rebuilt for epoch
+	// 5, a late refresh for epoch 4 must not overwrite it
+	pkNew := []byte("pkNewEpoch")
+	pkOld := []byte("pkOldEpoch")
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			if epoch == 5 {
+				return [][]byte{pkNew}, nil
+			}
+			return [][]byte{pkOld}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	ptp.RefreshCache(5)
+
+	peerType, _, err := ptp.ComputeForPubKey(pkNew)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	ptp.RefreshCache(4)
+
+	peerType, _, err = ptp.ComputeForPubKey(pkNew)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	peerType, _, err = ptp.ComputeForPubKey(pkOld)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheKeepsPreviousCacheWhenAllListsFail(t *testing.T) {
+	pk := []byte("pk1")
+	failing := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{pk}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	// a refresh for an epoch the coordinator does not know must not wipe the
+	// previously valid cache
+	failing = true
+	ptp.RefreshCache(42)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
 }
 
 func TestNewPeerTypeProvider_CallsUpdateCacheOnEpochChange(t *testing.T) {
@@ -274,7 +496,9 @@ func TestPeerTypeProvider_CreateNewCacheScenarios(t *testing.T) {
 	}
 	ptp, _ := NewPeerTypeProvider(arg)
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
 	assert.Len(t, cache, 3)
 	assert.Equal(t, core.EligibleList, cache["elected1"].pType) // elected1 is also eligible as it have been updated in the eligible list
 	assert.Equal(t, core.ElectedList, cache["elected2"].pType)
@@ -316,4 +540,113 @@ func TestPeerTypeProvider_GetAllPeerTypeInfos(t *testing.T) {
 	ptp.cache = make(map[string]*peerListAndShard)
 	emptyPeerTypeInfos := ptp.GetAllPeerTypeInfos()
 	assert.Empty(t, emptyPeerTypeInfos, "Should return empty slice for empty cache")
+}
+
+func TestNewPeerTypeProvider_KeepsEmptyCacheWhenConstructionSeedFails(t *testing.T) {
+	// all three list fetches fail at construction (no config for the epoch
+	// yet); the provider must still construct with an empty cache, and a later
+	// refresh must fill it
+	pk := []byte("pk1")
+	restored := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(_ uint32) ([][]byte, error) {
+			if restored {
+				return [][]byte{pk}, nil
+			}
+			return nil, errors.New("no config for epoch")
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return nil, errors.New("no config for epoch")
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return nil, errors.New("no config for epoch")
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+
+	restored = true
+	ptp.RefreshCache(1)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_EpochStartPrepareIsANoOp(t *testing.T) {
+	pk := []byte("pk1")
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{pk}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	handler := ptp.epochStartEventHandler()
+	handler.EpochStartPrepare(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+	// prepare must not touch the cache; the refresh happens on the action event
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T) {
+	// two writers exist in production: the epoch-start notifier callback and
+	// RefreshCache from StartConsensus, both racing readers of ComputeForPubKey.
+	// whichever order they land in, the highest epoch must win the cache
+	pkNewEpoch := []byte("pkNewEpoch")
+
+	arg := createDefaultArgPeerTypeProvider()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			if epoch == 2 {
+				return [][]byte{pkNewEpoch}, nil
+			}
+			return [][]byte{[]byte("pkOldEpoch")}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		ptp.RefreshCache(1)
+	}()
+	go func() {
+		defer wg.Done()
+		epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: 2}})
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_, _, errCompute := ptp.ComputeForPubKey(pkNewEpoch)
+			require.Nil(t, errCompute)
+		}
+	}()
+
+	wg.Wait()
+
+	// epoch 2 is the highest applied epoch, so its cache must be the surviving one
+	ptp.RefreshCache(2)
+	peerType, _, err := ptp.ComputeForPubKey(pkNewEpoch)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
 }

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -274,9 +274,10 @@ func TestPeerTypeProvider_RefreshCacheAppliesForEpochOlderThanConstruction(t *te
 	require.Equal(t, core.ElectedList, peerType)
 }
 
-func TestPeerTypeProvider_UpdateCacheIgnoresStaleEpochAfterNewerUpdate(t *testing.T) {
-	// epoch ordering between real updates: once the cache was rebuilt for epoch
-	// 5, a late refresh for epoch 4 must not overwrite it
+func TestPeerTypeProvider_UpdateCacheAcceptsBackwardEpochForRevert(t *testing.T) {
+	// a revert from epoch 5 to epoch 4 must update the cache with the older
+	// epoch's data; the previous monotonic guard blocked this and left the
+	// reverted-to epoch's validators stuck as observers
 	pkNew := []byte("pkNewEpoch")
 	pkOld := []byte("pkOldEpoch")
 
@@ -299,13 +300,14 @@ func TestPeerTypeProvider_UpdateCacheIgnoresStaleEpochAfterNewerUpdate(t *testin
 	require.Nil(t, err)
 	require.Equal(t, core.ElectedList, peerType)
 
+	// simulate a revert to epoch 4; the cache must now reflect epoch 4's data
 	ptp.RefreshCache(4)
 
-	peerType, _, err = ptp.ComputeForPubKey(pkNew)
+	peerType, _, err = ptp.ComputeForPubKey(pkOld)
 	require.Nil(t, err)
 	require.Equal(t, core.ElectedList, peerType)
 
-	peerType, _, err = ptp.ComputeForPubKey(pkOld)
+	peerType, _, err = ptp.ComputeForPubKey(pkNew)
 	require.Nil(t, err)
 	require.Equal(t, core.ObserverList, peerType)
 }
@@ -545,7 +547,7 @@ func TestPeerTypeProvider_GetAllPeerTypeInfos(t *testing.T) {
 func TestNewPeerTypeProvider_KeepsEmptyCacheWhenConstructionSeedFails(t *testing.T) {
 	// all three list fetches fail at construction (no config for the epoch
 	// yet); the provider must still construct with an empty cache, and a later
-	// refresh must fill it
+	// refresh (where all getters succeed) must fill it
 	pk := []byte("pk1")
 	restored := false
 
@@ -558,9 +560,15 @@ func TestNewPeerTypeProvider_KeepsEmptyCacheWhenConstructionSeedFails(t *testing
 			return nil, errors.New("no config for epoch")
 		},
 		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			if restored {
+				return [][]byte{}, nil
+			}
 			return nil, errors.New("no config for epoch")
 		},
 		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			if restored {
+				return [][]byte{}, nil
+			}
 			return nil, errors.New("no config for epoch")
 		},
 	}

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -275,13 +275,17 @@ func TestPeerTypeProvider_RefreshCacheAppliesForEpochOlderThanConstruction(t *te
 }
 
 func TestPeerTypeProvider_UpdateCacheAcceptsBackwardEpochForRevert(t *testing.T) {
-	// a revert from epoch 5 to epoch 4 must update the cache with the older
-	// epoch's data; the previous monotonic guard blocked this and left the
-	// reverted-to epoch's validators stuck as observers
+	// a revert from epoch 5 to epoch 4 arrives through the epoch start
+	// notification (RevertStateToBlock -> SetProcessed -> NotifyAll) and must
+	// update the cache with the older epoch's data; the previous monotonic
+	// guard blocked this and left the reverted-to epoch's validators stuck as
+	// observers
 	pkNew := []byte("pkNewEpoch")
 	pkOld := []byte("pkOldEpoch")
 
 	arg := createDefaultArgPeerTypeProvider()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
 		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
 			if epoch == 5 {
@@ -294,13 +298,53 @@ func TestPeerTypeProvider_UpdateCacheAcceptsBackwardEpochForRevert(t *testing.T)
 	ptp, err := NewPeerTypeProvider(arg)
 	require.Nil(t, err)
 
-	ptp.RefreshCache(5)
+	epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: 5}})
 
 	peerType, _, err := ptp.ComputeForPubKey(pkNew)
 	require.Nil(t, err)
 	require.Equal(t, core.ElectedList, peerType)
 
-	// simulate a revert to epoch 4; the cache must now reflect epoch 4's data
+	epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: 4}})
+
+	peerType, _, err = ptp.ComputeForPubKey(pkOld)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	peerType, _, err = ptp.ComputeForPubKey(pkNew)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheAppliesAfterEpochStartMovedCacheForward(t *testing.T) {
+	// LoadStorage can restore an epoch start block, which notifies epoch 5 and
+	// moves cacheEpoch forward, and then walk back to an earlier checkpoint. The
+	// post-bootstrap RefreshCache at the end of StartConsensus then carries the
+	// epoch actually restored (4) and must be applied; ordering the two would
+	// leave the node reporting epoch 5's validator set
+	pkOld := []byte("pkOldEpoch")
+	pkNew := []byte("pkNewEpoch")
+
+	arg := createDefaultArgPeerTypeProvider()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			if epoch == 5 {
+				return [][]byte{pkNew}, nil
+			}
+			return [][]byte{pkOld}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: 5}})
+
+	peerType, _, err := ptp.ComputeForPubKey(pkNew)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
 	ptp.RefreshCache(4)
 
 	peerType, _, err = ptp.ComputeForPubKey(pkOld)
@@ -613,7 +657,10 @@ func TestPeerTypeProvider_EpochStartPrepareIsANoOp(t *testing.T) {
 func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T) {
 	// two writers exist in production: the epoch-start notifier callback and
 	// RefreshCache from StartConsensus, both racing readers of ComputeForPubKey.
-	// whichever order they land in, the highest epoch must win the cache
+	// backward writes are applied rather than ordered, so the surviving cache is
+	// whichever writer landed last; what must hold is that a reader never sees a
+	// half-installed cache mixing the two epochs
+	pkOldEpoch := []byte("pkOldEpoch")
 	pkNewEpoch := []byte("pkNewEpoch")
 
 	arg := createDefaultArgPeerTypeProvider()
@@ -624,7 +671,7 @@ func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T
 			if epoch == 2 {
 				return [][]byte{pkNewEpoch}, nil
 			}
-			return [][]byte{[]byte("pkOldEpoch")}, nil
+			return [][]byte{pkOldEpoch}, nil
 		},
 	}
 
@@ -646,15 +693,19 @@ func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T
 		defer wg.Done()
 		for i := 0; i < 50; i++ {
 			_, _, errCompute := ptp.ComputeForPubKey(pkNewEpoch)
-			require.Nil(t, errCompute)
+			// assert, not require: FailNow from a non-test goroutine is undefined
+			assert.Nil(t, errCompute)
 		}
 	}()
 
 	wg.Wait()
 
-	// epoch 2 is the highest applied epoch, so its cache must be the surviving one
-	ptp.RefreshCache(2)
-	peerType, _, err := ptp.ComputeForPubKey(pkNewEpoch)
+	// exactly one of the two caches must be installed, never a mix of both
+	newType, _, err := ptp.ComputeForPubKey(pkNewEpoch)
 	require.Nil(t, err)
-	require.Equal(t, core.ElectedList, peerType)
+	oldType, _, err := ptp.ComputeForPubKey(pkOldEpoch)
+	require.Nil(t, err)
+	require.NotEqual(t, newType, oldType)
+	require.Contains(t, []core.PeerType{newType, oldType}, core.ElectedList)
+	require.Contains(t, []core.PeerType{newType, oldType}, core.ObserverList)
 }

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -660,6 +660,11 @@ func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T
 	// backward writes are applied rather than ordered, so the surviving cache is
 	// whichever writer landed last; what must hold is that a reader never sees a
 	// half-installed cache mixing the two epochs
+	// the constructor seeds the cache from StartEpoch, which is 0 here, so give
+	// that epoch a key of its own: sharing it with one of the writers would let
+	// the seed alone satisfy every assertion below and the test would still pass
+	// with updateCache disabled entirely
+	pkSeedEpoch := []byte("pkSeedEpoch")
 	pkOldEpoch := []byte("pkOldEpoch")
 	pkNewEpoch := []byte("pkNewEpoch")
 
@@ -668,10 +673,14 @@ func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T
 	arg.EpochStartEventNotifier = epochStartNotifier
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
 		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
-			if epoch == 2 {
+			switch epoch {
+			case 2:
 				return [][]byte{pkNewEpoch}, nil
+			case 1:
+				return [][]byte{pkOldEpoch}, nil
+			default:
+				return [][]byte{pkSeedEpoch}, nil
 			}
-			return [][]byte{pkOldEpoch}, nil
 		},
 	}
 
@@ -707,9 +716,15 @@ func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T
 
 	require.Zero(t, atomic.LoadInt32(&mixedRead), "a reader saw a cache mixing both epochs")
 
-	// exactly one of the two caches survived, never a merge of both
+	// exactly one of the two writers' caches survived, never a merge of both and
+	// never the constructor's seed, which would mean neither writer landed
 	infos := ptp.GetAllPeerTypeInfos()
 	require.Len(t, infos, 1)
 	require.Contains(t, []string{string(pkNewEpoch), string(pkOldEpoch)}, infos[0].PublicKey)
 	require.Equal(t, string(core.ElectedList), infos[0].PeerType)
+
+	ptp.mutCache.RLock()
+	cacheEpoch := ptp.cacheEpoch
+	ptp.mutCache.RUnlock()
+	require.Contains(t, []uint32{1, 2}, cacheEpoch)
 }

--- a/core/process/peer/validatorsProvider.go
+++ b/core/process/peer/validatorsProvider.go
@@ -290,6 +290,14 @@ func (vp *validatorsProvider) aggregateLists(
 
 }
 
+// RefreshCache forces an immediate cache update for the given epoch
+func (vp *validatorsProvider) RefreshCache(epoch uint32) {
+	vp.lock.Lock()
+	vp.currentEpoch = epoch
+	vp.lock.Unlock()
+	vp.updateCache()
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (vp *validatorsProvider) IsInterfaceNil() bool {
 	return vp == nil

--- a/core/process/peer/validatorsProvider.go
+++ b/core/process/peer/validatorsProvider.go
@@ -181,7 +181,9 @@ func (vp *validatorsProvider) startRefreshProcess(ctx context.Context) {
 			vp.lock.Lock()
 			vp.currentEpoch = epoch
 			vp.lock.Unlock()
-			log.Trace("startRefreshProcess - forced refresh", "epoch", vp.currentEpoch)
+			// log the local value: RefreshCache is a second writer of
+			// vp.currentEpoch, so reading the field here would race with it
+			log.Trace("startRefreshProcess - forced refresh", "epoch", epoch)
 		case <-ctx.Done():
 			log.Debug("validatorsProvider's go routine is stopping...")
 			return

--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -297,10 +297,14 @@ func TestValidatorsProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing
 	// currentEpoch has two writers: RefreshCache from StartConsensus and
 	// startRefreshProcess draining the epoch start channel. They must never touch
 	// the field outside the lock; this only fails under -race, so it is the guard
-	// for that
+	// for that.
+	// The second writer is driven by sending on refreshCache directly rather than
+	// through the notifier. EpochStartAction spawns a detached goroutine per
+	// notification onto an unbuffered channel, and startRefreshProcess drains at
+	// most one per iteration, so notifying in a loop parks thousands of senders
+	// that Close cannot unblock. Sending here gives backpressure instead: every
+	// send is consumed, which is also what actually exercises the second writer.
 	arg := createDefaultValidatorsProviderArg()
-	epochStartNotifier := &mock.EpochStartNotifierStub{}
-	arg.EpochStartEventNotifier = epochStartNotifier
 
 	vp, err := NewValidatorsProvider(arg)
 	require.Nil(t, err)
@@ -308,19 +312,21 @@ func TestValidatorsProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing
 		_ = vp.Close()
 	}()
 
+	const iterations = 500
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 5000; i++ {
+		for i := 0; i < iterations; i++ {
 			vp.RefreshCache(uint32(i))
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 5000; i++ {
-			epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: uint32(i)}})
+		for i := 0; i < iterations; i++ {
+			vp.refreshCache <- uint32(i)
 		}
 	}()
 

--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -113,11 +113,14 @@ func TestValidatorsProvider_GetLatestValidators(t *testing.T) {
 		arg := createDefaultValidatorsProviderArg()
 		vp, _ := NewValidatorsProvider(arg)
 
-		// Manually set cache and last update time
+		// Manually set cache and last update time; the constructor starts a
+		// background refresh goroutine, so the fields must be set under the lock
+		vp.lock.Lock()
 		vp.cache = map[string]*state.ValidatorApiResponse{
 			"validator1": {ValidatorStatus: "eligible"},
 		}
 		vp.lastCacheUpdate = time.Now()
+		vp.lock.Unlock()
 
 		validators := vp.GetLatestValidators()
 		assert.Len(t, validators, 1)
@@ -139,11 +142,14 @@ func TestValidatorsProvider_GetLatestValidators(t *testing.T) {
 		}
 		vp, _ := NewValidatorsProvider(arg)
 
-		// Set an old cache
+		// Set an old cache under the lock (the background refresh goroutine
+		// started by the constructor also writes these fields)
+		vp.lock.Lock()
 		vp.cache = map[string]*state.ValidatorApiResponse{
 			"validator1": {ValidatorStatus: "eligible"},
 		}
 		vp.lastCacheUpdate = time.Now().Add(-time.Hour)
+		vp.lock.Unlock()
 
 		time.Sleep(time.Millisecond * 10) // Ensure cache refresh interval has passed
 
@@ -202,7 +208,10 @@ func TestValidatorsProvider_UpdateCache(t *testing.T) {
 		vp, _ := NewValidatorsProvider(arg)
 
 		vp.updateCache()
-		assert.Empty(t, vp.cache)
+		vp.lock.RLock()
+		cache := vp.cache
+		vp.lock.RUnlock()
+		assert.Empty(t, cache)
 	})
 
 	t.Run("should update cache with new validator info", func(t *testing.T) {
@@ -220,8 +229,11 @@ func TestValidatorsProvider_UpdateCache(t *testing.T) {
 		vp, _ := NewValidatorsProvider(arg)
 
 		vp.updateCache()
-		assert.Len(t, vp.cache, 1)
-		assert.Contains(t, vp.cache, hex.EncodeToString([]byte("validator1")))
+		vp.lock.RLock()
+		cache := vp.cache
+		vp.lock.RUnlock()
+		assert.Len(t, cache, 1)
+		assert.Contains(t, cache, hex.EncodeToString([]byte("validator1")))
 	})
 }
 

--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -271,6 +271,9 @@ func TestValidatorsProvider_RefreshCache(t *testing.T) {
 
 	vp, err := NewValidatorsProvider(arg)
 	require.Nil(t, err)
+	defer func() {
+		_ = vp.Close()
+	}()
 
 	vp.RefreshCache(7)
 
@@ -286,6 +289,42 @@ func TestValidatorsProvider_RefreshCache(t *testing.T) {
 	require.Equal(t, uint32(7), currentEpoch)
 	require.Contains(t, cache, hex.EncodeToString([]byte("validator1")))
 	require.Contains(t, queried, uint32(7))
+}
+
+func TestValidatorsProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T) {
+	t.Parallel()
+
+	// currentEpoch has two writers: RefreshCache from StartConsensus and
+	// startRefreshProcess draining the epoch start channel. They must never touch
+	// the field outside the lock; this only fails under -race, so it is the guard
+	// for that
+	arg := createDefaultValidatorsProviderArg()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
+
+	vp, err := NewValidatorsProvider(arg)
+	require.Nil(t, err)
+	defer func() {
+		_ = vp.Close()
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5000; i++ {
+			vp.RefreshCache(uint32(i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5000; i++ {
+			epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: uint32(i)}})
+		}
+	}()
+
+	wg.Wait()
 }
 
 func TestValidatorsProvider_EpochStartRefreshesThroughChannel(t *testing.T) {

--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core"
 	cryptoMock "github.com/klever-io/klever-go/crypto/mock"
+	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewValidatorsProvider_WithNilValidatorStatisticsShouldErr(t *testing.T) {
@@ -235,6 +237,81 @@ func TestValidatorsProvider_UpdateCache(t *testing.T) {
 		assert.Len(t, cache, 1)
 		assert.Contains(t, cache, hex.EncodeToString([]byte("validator1")))
 	})
+}
+
+func TestValidatorsProvider_RefreshCache(t *testing.T) {
+	t.Parallel()
+
+	// StartConsensus calls this once the storage bootstrap restored the epoch,
+	// so the cache must be rebuilt against that epoch rather than the one the
+	// provider was constructed with
+	arg := createDefaultValidatorsProviderArg()
+	// the constructor's background refresh goroutine also queries the coordinator
+	var queriedMut sync.Mutex
+	queriedEpochs := make([]uint32, 0)
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			queriedMut.Lock()
+			queriedEpochs = append(queriedEpochs, epoch)
+			queriedMut.Unlock()
+
+			return [][]byte{[]byte("validator1")}, nil
+		},
+	}
+	arg.ValidatorStatistics = &mock.ValidatorStatisticsProcessorStub{
+		LastFinalizedRootHashCalled: func() []byte {
+			return []byte("rootHash")
+		},
+		GetValidatorInfoForRootHashCalled: func(_ []byte) ([]*state.ValidatorInfo, error) {
+			return []*state.ValidatorInfo{
+				{PublicKey: []byte("validator1"), List: string(core.EligibleList)},
+			}, nil
+		},
+	}
+
+	vp, err := NewValidatorsProvider(arg)
+	require.Nil(t, err)
+
+	vp.RefreshCache(7)
+
+	vp.lock.RLock()
+	currentEpoch := vp.currentEpoch
+	cache := vp.cache
+	vp.lock.RUnlock()
+
+	queriedMut.Lock()
+	queried := append([]uint32{}, queriedEpochs...)
+	queriedMut.Unlock()
+
+	require.Equal(t, uint32(7), currentEpoch)
+	require.Contains(t, cache, hex.EncodeToString([]byte("validator1")))
+	require.Contains(t, queried, uint32(7))
+}
+
+func TestValidatorsProvider_EpochStartRefreshesThroughChannel(t *testing.T) {
+	t.Parallel()
+
+	// the epoch start notification hands the new epoch to startRefreshProcess
+	// over refreshCache, which is the only path that updates currentEpoch from
+	// the background goroutine
+	arg := createDefaultValidatorsProviderArg()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
+
+	vp, err := NewValidatorsProvider(arg)
+	require.Nil(t, err)
+	defer func() {
+		_ = vp.Close()
+	}()
+
+	epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: 9}})
+
+	require.Eventually(t, func() bool {
+		vp.lock.RLock()
+		defer vp.lock.RUnlock()
+
+		return vp.currentEpoch == uint32(9)
+	}, 2*time.Second, 5*time.Millisecond)
 }
 
 func TestValidatorsProvider_CreateNewCache(t *testing.T) {

--- a/eventNotifier/notifier/common.go
+++ b/eventNotifier/notifier/common.go
@@ -32,7 +32,7 @@ func NewHandlerForEpochStart(
 // EpochStartPrepare will notify the subscriber to prepare for a start of epoch.
 // The event can be triggered multiple times
 func (hs *handlerStruct) EpochStartPrepare(blk data.HeaderHandler) {
-	if hs.act != nil {
+	if hs.prepare != nil {
 		hs.prepare(blk)
 	}
 }

--- a/eventNotifier/notifier/epochStartSubscriptionHandler.go
+++ b/eventNotifier/notifier/epochStartSubscriptionHandler.go
@@ -61,7 +61,9 @@ func (essh *epochStartSubscriptionHandler) UnregisterHandler(handlerToUnregister
 
 // NotifyAll will call all the subscribed functions from the internal slice
 func (essh *epochStartSubscriptionHandler) NotifyAll(blk data.HeaderHandler) {
-	essh.mutEpochStartHandler.RLock()
+	// the sort mutates the shared slice, so a write lock is required; a read
+	// lock would let two concurrent notifications race on the sort's swaps
+	essh.mutEpochStartHandler.Lock()
 
 	sort.Slice(essh.epochStartHandlers, func(i, j int) bool {
 		return essh.epochStartHandlers[i].NotifyOrder() < essh.epochStartHandlers[j].NotifyOrder()
@@ -70,13 +72,14 @@ func (essh *epochStartSubscriptionHandler) NotifyAll(blk data.HeaderHandler) {
 	for i := 0; i < len(essh.epochStartHandlers); i++ {
 		essh.epochStartHandlers[i].EpochStartAction(blk)
 	}
-	essh.mutEpochStartHandler.RUnlock()
+	essh.mutEpochStartHandler.Unlock()
 }
 
 // NotifyAllPrepare will call all the subscribed clients to notify them that an epoch change block has been
 // observed, but not yet confirmed/committed. Some components may need to do some initialisation/preparation
 func (essh *epochStartSubscriptionHandler) NotifyAllPrepare(blk data.HeaderHandler) {
-	essh.mutEpochStartHandler.RLock()
+	// write lock for the same reason as NotifyAll: the sort mutates the slice
+	essh.mutEpochStartHandler.Lock()
 	sort.Slice(essh.epochStartHandlers, func(i, j int) bool {
 		return essh.epochStartHandlers[i].NotifyOrder() < essh.epochStartHandlers[j].NotifyOrder()
 	})
@@ -84,7 +87,7 @@ func (essh *epochStartSubscriptionHandler) NotifyAllPrepare(blk data.HeaderHandl
 	for i := 0; i < len(essh.epochStartHandlers); i++ {
 		essh.epochStartHandlers[i].EpochStartPrepare(blk)
 	}
-	essh.mutEpochStartHandler.RUnlock()
+	essh.mutEpochStartHandler.Unlock()
 }
 
 // RegisterForEpochChangeConfirmed will register the handler function to be called when epoch change is confirmed

--- a/eventNotifier/notifier/epochStartSubscriptionHandler_test.go
+++ b/eventNotifier/notifier/epochStartSubscriptionHandler_test.go
@@ -1,6 +1,7 @@
 package notifier_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/klever-io/klever-go/data"
@@ -109,4 +110,64 @@ func TestEpochStartSubscriptionHandler_NotifyAll(t *testing.T) {
 	assert.True(t, firstHandlerWasCalled)
 	assert.True(t, secondHandlerWasCalled)
 	assert.Equal(t, lastCalled, 2)
+}
+
+func TestEpochStartSubscriptionHandler_NotifyAllPrepare(t *testing.T) {
+	t.Parallel()
+
+	firstHandlerWasCalled := false
+	secondHandlerWasCalled := false
+	lastCalled := 0
+	essh := notifier.NewEpochStartSubscriptionHandler()
+
+	// prepare handlers are the second argument; NotifyOrder must drive the
+	// call order exactly as it does for NotifyAll
+	handler1 := notifier.NewHandlerForEpochStart(nil, func(blk data.HeaderHandler) {
+		firstHandlerWasCalled = true
+		lastCalled = 1
+	}, 1)
+	handler2 := notifier.NewHandlerForEpochStart(nil, func(blk data.HeaderHandler) {
+		secondHandlerWasCalled = true
+		lastCalled = 2
+	}, 2)
+
+	essh.RegisterHandler(handler2)
+	essh.RegisterHandler(handler1)
+
+	essh.NotifyAllPrepare(&block.Block{Header: &block.BlockHeader{}})
+	assert.True(t, firstHandlerWasCalled)
+	assert.True(t, secondHandlerWasCalled)
+	assert.Equal(t, 2, lastCalled)
+}
+
+func TestEpochStartSubscriptionHandler_ConcurrentNotifyIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	// NotifyAll and NotifyAllPrepare sort the shared handler slice; under a
+	// read lock two concurrent notifications race on the sort's swaps, which
+	// the race detector catches. This test pins the write-lock fix.
+	essh := notifier.NewEpochStartSubscriptionHandler()
+	for i := 3; i >= 1; i-- {
+		order := uint32(i)
+		essh.RegisterHandler(notifier.NewHandlerForEpochStart(
+			func(blk data.HeaderHandler) {}, func(blk data.HeaderHandler) {}, order))
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			<-start
+			blk := &block.Block{Header: &block.BlockHeader{}}
+			if n%2 == 0 {
+				essh.NotifyAll(blk)
+			} else {
+				essh.NotifyAllPrepare(blk)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
 }

--- a/node/export_test.go
+++ b/node/export_test.go
@@ -9,3 +9,9 @@ func (n *Node) GetNetworkDegradedThreshold() uint32 {
 func (n *Node) GetNetworkDegradedCooldownSlots() uint32 {
 	return n.networkDegradedCooldownSlots
 }
+
+// SetHeartbeatHandler sets the heartbeat handler, for tests that exercise
+// StartConsensus without building the full heartbeat stack
+func (n *Node) SetHeartbeatHandler(handler HeartbeatHandler) {
+	n.heartbeatHandler = handler
+}

--- a/node/heartbeat/componentHandler/heartbeatHandler.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler.go
@@ -266,6 +266,16 @@ func (hbh *HeartbeatHandler) Sender() *process.Sender {
 	return hbh.sender
 }
 
+// RefreshPeerTypeCache rebuilds the peer type provider's cache for the given
+// epoch; called after the storage bootstrap restores the nodes coordinator state
+func (hbh *HeartbeatHandler) RefreshPeerTypeCache(epoch uint32) {
+	if hbh == nil || hbh.peerTypeProvider == nil {
+		return
+	}
+
+	hbh.peerTypeProvider.RefreshCache(epoch)
+}
+
 // Close stops the heartbeat sender and monitor background goroutines and waits
 // for both to exit. Idempotent: each step (cancelFunc, channel receive on closed
 // channel, monitor.Close) is safe to repeat.

--- a/node/heartbeat/componentHandler/heartbeatHandler_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_test.go
@@ -2,6 +2,7 @@ package componentHandler
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -141,4 +142,39 @@ func TestNewHeartbeatHandler_ShouldWork(t *testing.T) {
 
 	// let the sending go routine finish
 	time.Sleep(time.Second)
+}
+
+func TestHeartbeatHandler_RefreshPeerTypeCacheDelegatesToProvider(t *testing.T) {
+	t.Parallel()
+
+	// the monitor and sender goroutines started by NewHeartbeatHandler also reach
+	// the coordinator, so this callback can fire from more than one goroutine
+	var refreshedEpoch atomic.Uint32
+	coordinator := &cMock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			refreshedEpoch.Store(epoch)
+			return nil, nil
+		},
+	}
+
+	args := createMockArgument()
+	args.NodesCoordinator = coordinator
+	hbh, err := NewHeartbeatHandler(args)
+	require.Nil(t, err)
+	t.Cleanup(func() { require.NoError(t, hbh.Close()) })
+
+	hbh.RefreshPeerTypeCache(1)
+
+	assert.Equal(t, uint32(1), refreshedEpoch.Load(), "RefreshPeerTypeCache must delegate the epoch to the provider")
+}
+
+func TestHeartbeatHandler_RefreshPeerTypeCacheNilReceiverAndNilProvider(t *testing.T) {
+	t.Parallel()
+
+	// both guard paths must be no-ops instead of panicking
+	var nilHandler *HeartbeatHandler
+	nilHandler.RefreshPeerTypeCache(1)
+
+	emptyHandler := &HeartbeatHandler{}
+	emptyHandler.RefreshPeerTypeCache(1)
 }

--- a/node/heartbeat/mock/validatorsProviderStub.go
+++ b/node/heartbeat/mock/validatorsProviderStub.go
@@ -24,6 +24,10 @@ func (vp *ValidatorsProviderStub) GetLatestPeers() []state.PeerAccountHandler {
 	return nil
 }
 
+// RefreshCache -
+func (vp *ValidatorsProviderStub) RefreshCache(_ uint32) {
+}
+
 // IsInterfaceNil -
 func (vp *ValidatorsProviderStub) IsInterfaceNil() bool {
 	return vp == nil

--- a/node/interface.go
+++ b/node/interface.go
@@ -76,6 +76,7 @@ type Accumulator interface {
 type HeartbeatHandler interface {
 	Monitor() *process.Monitor
 	Sender() *process.Sender
+	RefreshPeerTypeCache(epoch uint32)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/node/node.go
+++ b/node/node.go
@@ -318,7 +318,7 @@ func (n *Node) StartConsensus() error {
 		if n.nodesCoordinator.LoadStateFailed() {
 			return common.ErrNodesCoordinatorNotReadyAfterBootstrap
 		}
-		log.Warn("nodes coordinator not ready after bootstrap, state was not loaded; node will sync from network")
+		log.Warn("nodes coordinator not ready after bootstrap, state was not loaded; node will sync from network and must be restarted to participate in consensus")
 	}
 
 	log.Trace("creating proposal kapp")

--- a/node/node.go
+++ b/node/node.go
@@ -314,12 +314,11 @@ func (n *Node) StartConsensus() error {
 
 	n.bootstrapper.LoadStorage()
 
-	// the coordinator is marked ready at construction for genesis (startEpoch==0),
-	// or after a successful LoadState for non-genesis restarts; if it is still not
-	// ready after LoadStorage, the saved state could not be restored and the node
-	// can never compute consensus groups, so fail startup loudly
 	if !n.nodesCoordinator.IsReady() {
-		return common.ErrNodesCoordinatorNotReadyAfterBootstrap
+		if n.nodesCoordinator.LoadStateFailed() {
+			return common.ErrNodesCoordinatorNotReadyAfterBootstrap
+		}
+		log.Warn("nodes coordinator not ready after bootstrap, state was not loaded; node will sync from network")
 	}
 
 	log.Trace("creating proposal kapp")
@@ -345,6 +344,10 @@ func (n *Node) StartConsensus() error {
 	// without waiting for the next epoch start
 	if !check.IfNil(n.heartbeatHandler) {
 		n.heartbeatHandler.RefreshPeerTypeCache(epoch)
+	}
+
+	if !check.IfNil(n.validatorsProvider) {
+		n.validatorsProvider.RefreshCache(epoch)
 	}
 
 	forkControllerSubscriber, ok := n.forkController.(core.EpochSubscriberHandler)

--- a/node/node.go
+++ b/node/node.go
@@ -314,6 +314,14 @@ func (n *Node) StartConsensus() error {
 
 	n.bootstrapper.LoadStorage()
 
+	// the coordinator is marked ready at construction for genesis (startEpoch==0),
+	// or after a successful LoadState for non-genesis restarts; if it is still not
+	// ready after LoadStorage, the saved state could not be restored and the node
+	// can never compute consensus groups, so fail startup loudly
+	if !n.nodesCoordinator.IsReady() {
+		return common.ErrNodesCoordinatorNotReadyAfterBootstrap
+	}
+
 	log.Trace("creating proposal kapp")
 
 	acnt, err := n.kapps.LoadAccount(kapps.ProposalKAppAddress)
@@ -330,6 +338,13 @@ func (n *Node) StartConsensus() error {
 	crtBlockHeader := n.blkc.GetCurrentBlockHeader()
 	if !check.IfNil(crtBlockHeader) {
 		epoch = crtBlockHeader.GetEpoch()
+	}
+
+	// the heartbeat's peer type cache was built before LoadStorage restored the
+	// nodes coordinator state; refresh it so the node reports its real peer type
+	// without waiting for the next epoch start
+	if !check.IfNil(n.heartbeatHandler) {
+		n.heartbeatHandler.RefreshPeerTypeCache(epoch)
 	}
 
 	forkControllerSubscriber, ok := n.forkController.(core.EpochSubscriberHandler)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -935,7 +935,8 @@ func TestStartConsensus_FailsWhenNodesCoordinatorNotReady(t *testing.T) {
 	t.Parallel()
 
 	coordinator := &mock.NodesCoordinatorMock{
-		IsReadyCalled: func() bool { return false },
+		IsReadyCalled:        func() bool { return false },
+		LoadStateFailedValue: true,
 	}
 	n := createStartConsensusNode(t, coordinator)
 
@@ -950,7 +951,8 @@ func TestStartConsensus_ReadinessFailureIsNotMaskedByLaterErrors(t *testing.T) {
 	// failure cannot mask the diagnostic that tells an operator the saved state
 	// was not restored
 	coordinator := &mock.NodesCoordinatorMock{
-		IsReadyCalled: func() bool { return false },
+		IsReadyCalled:        func() bool { return false },
+		LoadStateFailedValue: true,
 	}
 	n := createStartConsensusNodeWithFailingAccount(t, coordinator)
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -7,27 +7,37 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
 	disabledSig "github.com/klever-io/klever-go/crypto/signing/disabled/singlesig"
+	"github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/indexer"
 	"github.com/klever-io/klever-go/network/api/models"
+	heartbeatProcess "github.com/klever-io/klever-go/node/heartbeat/process"
+	"github.com/klever-io/klever-go/sharding"
 
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/config"
+	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/core/fork"
 	"github.com/klever-io/klever-go/core/kapp"
 	kappcontroller "github.com/klever-io/klever-go/core/kapp/kappController"
 	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/core/process/block/bootstrapStorage"
+	"github.com/klever-io/klever-go/core/watchdog"
 	"github.com/klever-io/klever-go/crypto"
 	"github.com/klever-io/klever-go/crypto/hashing"
 	cryptoMock "github.com/klever-io/klever-go/crypto/mock"
+	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/retriever"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/kapps"
 	"github.com/klever-io/klever-go/node"
 	"github.com/klever-io/klever-go/storage"
+	"github.com/klever-io/klever-go/storage/timecache"
 	"github.com/klever-io/klever-go/tools/marshal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -807,4 +817,215 @@ func TestEstimateTransactionsFees(t *testing.T) {
 		assert.Equal(t, kAppFee, cost.KAppFee)
 		assert.Equal(t, expectedTotalBandwidthFee, cost.BandwidthFee)
 	})
+}
+
+// nonSubscriberForkController wraps a ForkController so the wrapper type does
+// NOT satisfy core.EpochSubscriberHandler; StartConsensus then fails on its
+// fork-controller type assertion right after the coordinator readiness check,
+// which lets the tests below stop deterministically at that point
+type nonSubscriberForkController struct {
+	core.ForkController
+}
+
+// createStartConsensusNode builds a node with just enough dependencies for
+// StartConsensus to reach the nodes-coordinator readiness check
+// crtHeader is variadic so the existing two-argument call sites keep compiling;
+// pass a header to exercise the restart path where the epoch comes from the
+// current block instead of the genesis fallback
+func createStartConsensusNode(t *testing.T, coordinator sharding.NodesCoordinator, crtHeader ...data.HeaderHandler) *node.Node {
+	return newStartConsensusNode(t, coordinator, nil, crtHeader...)
+}
+
+// createStartConsensusNodeWithFailingAccount builds the same node but with a
+// kapps adapter whose LoadAccount fails, to prove an earlier check is not
+// masked by that failure
+func createStartConsensusNodeWithFailingAccount(t *testing.T, coordinator sharding.NodesCoordinator) *node.Node {
+	return newStartConsensusNode(t, coordinator, errors.New("load account failed"))
+}
+
+func newStartConsensusNode(t *testing.T, coordinator sharding.NodesCoordinator, loadAccountErr error, crtHeader ...data.HeaderHandler) *node.Node {
+	storerMock := mock.NewStorerMock("", 0)
+	genesisHeader := &block.Block{Header: &block.BlockHeader{Epoch: 0}}
+
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled: func() retriever.ShardedDataCacherNotifier {
+			return &mock.ShardedDataStub{}
+		},
+		HeadersCalled: func() retriever.HeadersPool {
+			return &mock.HeadersCacherStub{}
+		},
+	}
+
+	kappsAdapter := &mock.AccountsStub{
+		LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			if loadAccountErr != nil {
+				return nil, loadAccountErr
+			}
+			return &mock.KAppAccountHandlerStub{}, nil
+		},
+	}
+
+	n, err := node.NewNode(
+		node.WithDataPool(dataPool),
+		node.WithInternalMarshalizer(getMarshalizer()),
+		node.WithTxSignMarshalizer(getMarshalizer()),
+		node.WithDataStore(&mock.ChainStorerMock{
+			GetCalled: func(_ retriever.UnitType, key []byte) ([]byte, error) {
+				return storerMock.Get(key)
+			},
+			GetStorerCalled: func(_ retriever.UnitType) storage.Storer {
+				return storerMock
+			},
+		}),
+		node.WithUint64ByteSliceConverter(mock.NewNonceHashConverterMock()),
+		node.WithAddressPubkeyConverter(createMockPubkeyConverter()),
+		node.WithValidatorPubkeyConverter(createMockPubkeyConverter()),
+		node.WithAccountsAdapter(getAccAdapter(100)),
+		node.WithKAppsAdapter(kappsAdapter),
+		node.WithHasher(getHasher()),
+		node.WithTxSignHasher(getHasher()),
+		node.WithKeyGen(createKeyGenMock()),
+		node.WithTxFeeHandler(&mock.FeeHandlerStub{}),
+		node.WithSingleSigner(&cryptoMock.SignerMock{}),
+		node.WithTxSingleSigner(&disabledSig.DisabledSingleSig{}),
+		node.WithChainID(chainID),
+		node.WithBlockChain(&mock.BlockChainMock{
+			GetGenesisHeaderCalled: func() data.HeaderHandler {
+				return genesisHeader
+			},
+			GetGenesisHeaderHashCalled: func() []byte {
+				return []byte("genesis hash")
+			},
+			GetCurrentBlockHeaderCalled: func() data.HeaderHandler {
+				if len(crtHeader) == 0 {
+					return nil
+				}
+				return crtHeader[0]
+			},
+		}),
+		node.WithMessenger(&mock.MessengerStub{}),
+		node.WithPrivKey(&cryptoMock.PrivateKeyStub{}),
+		node.WithPeerSignatureHandler(&mock.PeerSignatureHandler{}),
+		node.WithInterceptorsContainer(&mock.InterceptorsContainerStub{}),
+		node.WithForkDetector(&mock.ForkDetectorMock{}),
+		node.WithBlockProcessor(&consensusMock.BlockProcessorMock{}),
+		node.WithBootStorer(&mock.BoostrapStorerMock{
+			GetHighestSlotCalled: func() int64 { return 0 },
+			GetCalled: func(_ int64) (*bootstrapStorage.BootstrapData, error) {
+				return nil, errors.New("no boot data")
+			},
+		}),
+		node.WithEpochStartTrigger(&mock.EpochStartTriggerStub{}),
+		node.WithRequestHandler(&mock.RequestHandlerStub{}),
+		node.WithSlotManager(&consensusMock.SlotManagerMock{}),
+		node.WithSyncer(&consensusMock.SyncTimerMock{}),
+		node.WithGenesisTime(time.Now()),
+		node.WithIndexer(indexer.NewNilIndexer()),
+		node.WithWatchdogTimer(&watchdog.DisabledWatchdog{}),
+		node.WithBlockBlackListHandler(timecache.NewTimeCache(time.Second)),
+		node.WithNodesCoordinator(coordinator),
+		node.WithForkController(&nonSubscriberForkController{ForkController: &mock.ForkControllerStub{}}),
+	)
+	require.Nil(t, err)
+
+	return n
+}
+
+func TestStartConsensus_FailsWhenNodesCoordinatorNotReady(t *testing.T) {
+	t.Parallel()
+
+	coordinator := &mock.NodesCoordinatorMock{
+		IsReadyCalled: func() bool { return false },
+	}
+	n := createStartConsensusNode(t, coordinator)
+
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrNodesCoordinatorNotReadyAfterBootstrap, err)
+}
+
+func TestStartConsensus_ReadinessFailureIsNotMaskedByLaterErrors(t *testing.T) {
+	t.Parallel()
+
+	// the readiness check runs immediately after LoadStorage, so a downstream
+	// failure cannot mask the diagnostic that tells an operator the saved state
+	// was not restored
+	coordinator := &mock.NodesCoordinatorMock{
+		IsReadyCalled: func() bool { return false },
+	}
+	n := createStartConsensusNodeWithFailingAccount(t, coordinator)
+
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrNodesCoordinatorNotReadyAfterBootstrap, err)
+}
+
+func TestStartConsensus_PassesReadinessCheckWhenCoordinatorIsReady(t *testing.T) {
+	t.Parallel()
+
+	coordinator := &mock.NodesCoordinatorMock{
+		IsReadyCalled: func() bool { return true },
+	}
+	n := createStartConsensusNode(t, coordinator)
+
+	// the wrapped fork controller does not implement EpochSubscriberHandler, so
+	// reaching ErrWrongTypeAssertion proves the readiness check passed
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
+}
+
+// heartbeatHandlerStub implements node.HeartbeatHandler for StartConsensus tests
+type heartbeatHandlerStub struct {
+	refreshedEpoch *uint32
+}
+
+func (h *heartbeatHandlerStub) Monitor() *heartbeatProcess.Monitor { return nil }
+
+func (h *heartbeatHandlerStub) Sender() *heartbeatProcess.Sender { return nil }
+func (h *heartbeatHandlerStub) RefreshPeerTypeCache(epoch uint32) {
+	*h.refreshedEpoch = epoch
+}
+func (h *heartbeatHandlerStub) Close() error         { return nil }
+func (h *heartbeatHandlerStub) IsInterfaceNil() bool { return h == nil }
+
+func TestStartConsensus_RefreshesPeerTypeCacheWithCurrentEpoch(t *testing.T) {
+	t.Parallel()
+
+	n := createStartConsensusNode(t, &mock.NodesCoordinatorMock{})
+
+	// sentinel start value: the refresh must overwrite it with the genesis
+	// epoch (0), proving RefreshPeerTypeCache was actually called
+	refreshedEpoch := uint32(999)
+	n.SetHeartbeatHandler(&heartbeatHandlerStub{refreshedEpoch: &refreshedEpoch})
+
+	// the wrapped fork controller does not implement EpochSubscriberHandler, so
+	// StartConsensus stops right after the peer type cache refresh
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
+	require.Equal(t, uint32(0), refreshedEpoch)
+}
+
+func TestStartConsensus_RefreshesPeerTypeCacheWithCurrentBlockEpoch(t *testing.T) {
+	t.Parallel()
+
+	// the mid-epoch restart case of issue #88: the restored chain head carries
+	// the real epoch, which is what the peer type cache must be rebuilt for
+	crtHeader := &block.Block{Header: &block.BlockHeader{Epoch: 7}}
+	n := createStartConsensusNode(t, &mock.NodesCoordinatorMock{}, crtHeader)
+
+	refreshedEpoch := uint32(999)
+	n.SetHeartbeatHandler(&heartbeatHandlerStub{refreshedEpoch: &refreshedEpoch})
+
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
+	require.Equal(t, uint32(7), refreshedEpoch)
+}
+
+func TestStartConsensus_SkipsPeerTypeCacheRefreshWithoutHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	n := createStartConsensusNode(t, &mock.NodesCoordinatorMock{})
+
+	// no heartbeat handler set: the refresh is skipped and StartConsensus
+	// proceeds to the fork-controller assertion
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
 }

--- a/sharding/args.go
+++ b/sharding/args.go
@@ -24,4 +24,8 @@ type ArgNodesCoordinator struct {
 	ShuffledOutHandler  ShuffledOutHandler
 	CurrValidatorsInfo  []*state.ValidatorInfo
 	PrevValidatorsInfo  []*state.ValidatorInfo
+	// NodesRestoredFromRegistry marks ElectedNodes/EligibleNodes as coming from a
+	// persisted nodes coordinator registry for Epoch rather than from the genesis
+	// config, which makes the constructor's epoch config authoritative
+	NodesRestoredFromRegistry bool
 }

--- a/sharding/errors.go
+++ b/sharding/errors.go
@@ -47,6 +47,9 @@ var ErrNilInputNodesMap = errors.New("nil input nodes map")
 // ErrEpochNodesConfigDoesNotExist signals that the epoch nodes configuration is missing
 var ErrEpochNodesConfigDoesNotExist = errors.New("epoch nodes configuration does not exist")
 
+// ErrEmptyRestoredRegistry signals that a restored registry holds no epoch configurations
+var ErrEmptyRestoredRegistry = errors.New("restored nodes coordinator registry holds no epoch configurations")
+
 // ErrListSizeZero signals that there are no elements in the list
 var ErrListSizeZero = errors.New("list size zero")
 

--- a/sharding/interface.go
+++ b/sharding/interface.go
@@ -31,6 +31,7 @@ type NodesCoordinator interface {
 	ConsensusGroupSize() int
 	LoadState(key []byte) error
 	IsReady() bool
+	LoadStateFailed() bool
 	GetSavedStateKey() []byte
 	GetOwnPublicKey() []byte
 	GetConsensusWhitelistedNodes(epoch uint32) (map[string]struct{}, error)

--- a/sharding/interface.go
+++ b/sharding/interface.go
@@ -30,6 +30,7 @@ type NodesCoordinator interface {
 	GetValidatorWithPublicKey(publicKey []byte) (validator Validator, err error)
 	ConsensusGroupSize() int
 	LoadState(key []byte) error
+	IsReady() bool
 	GetSavedStateKey() []byte
 	GetOwnPublicKey() []byte
 	GetConsensusWhitelistedNodes(epoch uint32) (map[string]struct{}, error)

--- a/sharding/networksharding/mock_test.go
+++ b/sharding/networksharding/mock_test.go
@@ -90,6 +90,11 @@ func (ncs *nodesCoordinatorStub) LoadState(_ []byte) error {
 	panic("implement me")
 }
 
+// IsReady -
+func (ncs *nodesCoordinatorStub) IsReady() bool {
+	return true
+}
+
 // GetSavedStateKey -
 func (ncs *nodesCoordinatorStub) GetSavedStateKey() []byte {
 	panic("implement me")

--- a/sharding/networksharding/mock_test.go
+++ b/sharding/networksharding/mock_test.go
@@ -95,6 +95,11 @@ func (ncs *nodesCoordinatorStub) IsReady() bool {
 	return true
 }
 
+// LoadStateFailed -
+func (ncs *nodesCoordinatorStub) LoadStateFailed() bool {
+	return false
+}
+
 // GetSavedStateKey -
 func (ncs *nodesCoordinatorStub) GetSavedStateKey() []byte {
 	panic("implement me")

--- a/sharding/networksharding/nodesCoordinatorStub.go
+++ b/sharding/networksharding/nodesCoordinatorStub.go
@@ -145,6 +145,11 @@ func (ncm *NodesCoordinatorStub) IsReady() bool {
 	return true
 }
 
+// LoadStateFailed -
+func (ncm *NodesCoordinatorStub) LoadStateFailed() bool {
+	return false
+}
+
 // SetEpochValidatorsInfo
 func (ncm *NodesCoordinatorStub) SetEpochValidatorsInfo(epoch uint32, validatorsInfo []*state.ValidatorInfo) error {
 	if ncm.SetEpochValidatorsInfoCalled != nil {

--- a/sharding/networksharding/nodesCoordinatorStub.go
+++ b/sharding/networksharding/nodesCoordinatorStub.go
@@ -140,6 +140,11 @@ func (ncm *NodesCoordinatorStub) LoadState(key []byte) error {
 	return nil
 }
 
+// IsReady -
+func (ncm *NodesCoordinatorStub) IsReady() bool {
+	return true
+}
+
 // SetEpochValidatorsInfo
 func (ncm *NodesCoordinatorStub) SetEpochValidatorsInfo(epoch uint32, validatorsInfo []*state.ValidatorInfo) error {
 	if ncm.SetEpochValidatorsInfoCalled != nil {

--- a/sharding/networksharding/nodesCoordinatorStub_test.go
+++ b/sharding/networksharding/nodesCoordinatorStub_test.go
@@ -1,0 +1,16 @@
+package networksharding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodesCoordinatorStub_IsReady(t *testing.T) {
+	t.Parallel()
+
+	stub := &NodesCoordinatorStub{}
+
+	// the stub is always ready: it never restores state
+	require.True(t, stub.IsReady())
+}

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -294,6 +294,7 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ihgs.loadingFromDisk.Store(true)
 	defer ihgs.loadingFromDisk.Store(false)
 
+	ihgs.loadStateFailed.Store(false)
 	loadFailed := true
 	defer func() {
 		if loadFailed {
@@ -329,7 +330,6 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ihgs.savedStateKey = key
 	ihgs.mutSavedStateKey.Unlock()
 
-	ihgs.currentEpoch.Store(config.CurrentEpoch)
 	log.Debug("loaded nodes config", "current epoch", config.CurrentEpoch)
 
 	displayNodesConfigInfo(nodesConfig)
@@ -337,12 +337,13 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
 
 	ihgs.mutNodesConfig.Lock()
+	ihgs.currentEpoch.Store(config.CurrentEpoch)
 	ihgs.nodesConfig = nodesConfig
 	ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
-	ihgs.mutNodesConfig.Unlock()
-
 	ihgs.stateReady.Store(true)
 	ihgs.lookupReady.Store(true)
+	ihgs.mutNodesConfig.Unlock()
+
 	loadFailed = false
 
 	return nil

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -48,12 +48,13 @@ func (v validatorList) Less(i, j int) bool {
 const nodeCoordinatorStoredEpochs = 10
 
 type epochNodesConfig struct {
-	electedList  []Validator
-	eligibleList []Validator
-	waitingList  []Validator
-	selector     RandomSelector
-	leavingList  []Validator
-	mutNodesMaps sync.RWMutex
+	electedList   []Validator
+	eligibleList  []Validator
+	waitingList   []Validator
+	selector      RandomSelector
+	leavingList   []Validator
+	authoritative bool
+	mutNodesMaps  sync.RWMutex
 }
 
 type indexHashedNodesCoordinator struct {
@@ -81,7 +82,8 @@ type indexHashedNodesCoordinator struct {
 	// fast-bootstrap path installs authoritative validators long before
 	// LoadState runs, which must unblock lookups without letting the startup
 	// readiness gate (IsReady) pass while the persisted state is unrestored
-	lookupReady atomic.Bool
+	lookupReady     atomic.Bool
+	loadStateFailed atomic.Bool
 }
 
 type indexHashedNodesCoordinatorWithRater struct {
@@ -98,10 +100,11 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 	nodesConfig := make(map[uint32]*epochNodesConfig, nodeCoordinatorStoredEpochs)
 
 	nodesConfig[arguments.Epoch] = &epochNodesConfig{
-		electedList:  arguments.ElectedNodes,
-		eligibleList: arguments.EligibleNodes,
-		selector:     nil, // TODO:
-		leavingList:  make([]Validator, 0),
+		electedList:   arguments.ElectedNodes,
+		eligibleList:  arguments.EligibleNodes,
+		selector:      nil, // TODO:
+		leavingList:   make([]Validator, 0),
+		authoritative: arguments.StartEpoch == 0,
 	}
 
 	savedKey := arguments.Hasher.Compute(string(arguments.SelfPublicKey))
@@ -122,12 +125,12 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		startEpoch:                    arguments.StartEpoch,
 	}
 	ihgs.currentEpoch.Store(arguments.StartEpoch)
-	// no need to wait for load state, as we have the initial configuration
 	ihgs.stateReady.Store(arguments.StartEpoch == 0)
-	// at genesis the constructor seeding IS the authoritative epoch-0 set;
-	// on any other start the lookup stays gated until SetNodes or LoadState
-	// installs real data
-	ihgs.lookupReady.Store(arguments.StartEpoch == 0)
+	// the genesis seed is approximate but sufficient for peer classification
+	// during bootstrap; SetNodes or LoadState replaces it with authoritative
+	// data, and the authoritative flag on epochNodesConfig prevents stale
+	// genesis entries from shadowing real data in the merged lookup map
+	ihgs.lookupReady.Store(true)
 
 	ihgs.loadingFromDisk.Store(false)
 
@@ -137,7 +140,7 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		indexHashedNodesCoordinator: ihgs,
 	}
 
-	if ihgs.shouldSaveInitialState(arguments.Epoch) {
+	if ihgs.shouldSaveInitialState() {
 		err = ihgs.saveState(ihgs.savedStateKey)
 		if err != nil {
 			log.Error("saving initial nodes coordinator config failed",
@@ -247,6 +250,28 @@ func (ihgs *indexHashedNodesCoordinator) NotifyOrder() uint32 {
 	return core.NodesCoordinatorOrder
 }
 
+func (ihgs *indexHashedNodesCoordinator) shouldSaveInitialState() bool {
+	ncInternalkey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), ihgs.savedStateKey...)
+	storedData, getErr := ihgs.bootStorer.Get(ncInternalkey)
+	if getErr != nil {
+		return true
+	}
+
+	config := &NodesCoordinatorRegistry{}
+	if json.Unmarshal(storedData, config) != nil {
+		return true
+	}
+
+	var maxEpoch uint32
+	for epoch := range ihgs.nodesConfig {
+		if epoch > maxEpoch {
+			maxEpoch = epoch
+		}
+	}
+
+	return maxEpoch > config.CurrentEpoch
+}
+
 func (ihgs *indexHashedNodesCoordinator) saveState(key []byte) error {
 	registry := ihgs.NodesCoordinatorToRegistry()
 	data, err := json.Marshal(registry)
@@ -261,33 +286,6 @@ func (ihgs *indexHashedNodesCoordinator) saveState(key []byte) error {
 	return ihgs.bootStorer.Put(ncInternalkey, data)
 }
 
-// shouldSaveInitialState decides whether the constructor persists its seeded
-// config under hash(selfPubKey). The invariant is "never overwrite a registry
-// that is at least as new as the constructor's own data": a restart within the
-// install epoch must not clobber the registry the previous run saved (LoadState
-// would read genesis data back, causing permanent BLS signature failures), while
-// a stored registry older than the current start epoch (e.g. an epoch-0 registry
-// left behind by a genesis-era run) must be refreshed, or a bootstrap record
-// stamped with this key would silently restore stale data on a later restart
-func (ihgs *indexHashedNodesCoordinator) shouldSaveInitialState(epoch uint32) bool {
-	ncInternalkey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), ihgs.savedStateKey...)
-
-	data, err := ihgs.bootStorer.Get(ncInternalkey)
-	if err != nil {
-		// nothing stored under this key yet: first start on this machine
-		return true
-	}
-
-	config := &NodesCoordinatorRegistry{}
-	err = json.Unmarshal(data, config)
-	if err != nil {
-		// unreadable blob: replace it with a fresh, readable registry
-		return true
-	}
-
-	return epoch > config.CurrentEpoch
-}
-
 func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ncInternalkey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), key...)
 
@@ -295,6 +293,13 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 
 	ihgs.loadingFromDisk.Store(true)
 	defer ihgs.loadingFromDisk.Store(false)
+
+	loadFailed := true
+	defer func() {
+		if loadFailed {
+			ihgs.loadStateFailed.Store(true)
+		}
+	}()
 
 	data, err := ihgs.bootStorer.Get(ncInternalkey)
 	if err != nil {
@@ -312,19 +317,14 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 		return err
 	}
 
-	// a registry that unmarshals cleanly but restores no epoch configs (truncated
-	// write, or a registry saved from a pruned coordinator) must not be installed:
-	// publishing it would replace the seeded lookup with an empty one and mark the
-	// coordinator ready while every validator lookup fails; failing here keeps
-	// stateReady false so the startup readiness gate fires instead
 	if len(nodesConfig) == 0 {
 		return fmt.Errorf("%w key=%x", ErrEmptyRestoredRegistry, key)
 	}
 
-	// savedStateKey and currentEpoch are only mutated after the conversion
-	// succeeded, so a failed restore cannot leave a foreign key or epoch next
-	// to the constructor-seeded configs (a later saveState on that key would
-	// overwrite a still-valid registry with genesis data)
+	for _, nc := range nodesConfig {
+		nc.authoritative = true
+	}
+
 	ihgs.mutSavedStateKey.Lock()
 	ihgs.savedStateKey = key
 	ihgs.mutSavedStateKey.Unlock()
@@ -334,7 +334,6 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 
 	displayNodesConfigInfo(nodesConfig)
 
-	// rebuild the validator lookup from restored configs and publish both atomically
 	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
 
 	ihgs.mutNodesConfig.Lock()
@@ -344,8 +343,16 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 
 	ihgs.stateReady.Store(true)
 	ihgs.lookupReady.Store(true)
+	loadFailed = false
 
 	return nil
+}
+
+// LoadStateFailed returns true when LoadState was called and failed,
+// distinguishing genuine state corruption from the bootstrap recovery path
+// where LoadState is never invoked
+func (ihgs *indexHashedNodesCoordinator) LoadStateFailed() bool {
+	return ihgs.loadStateFailed.Load()
 }
 
 // IsReady returns true once the initial saved state has been restored. It is set
@@ -446,14 +453,18 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 
 // computePublicKeyToValidatorMap merges the elected and eligible validators of
 // all given epoch configs into one lookup map, later epochs taking precedence;
-// single pass: epochs are visited in ascending order and written straight into
-// the result map, so no intermediate per-epoch maps are allocated
+// when authoritative data exists (installed via SetNodes or LoadState),
+// non-authoritative genesis seeds are excluded so they cannot shadow real data
 func (ihgs *indexHashedNodesCoordinator) computePublicKeyToValidatorMap(
 	nodesConfig map[uint32]*epochNodesConfig,
 ) map[string]Validator {
 	epochList := make([]uint32, 0, len(nodesConfig))
+	hasAuthoritative := false
 	for epoch := range nodesConfig {
 		epochList = append(epochList, epoch)
+		if nodesConfig[epoch].authoritative {
+			hasAuthoritative = true
+		}
 	}
 
 	sort.Slice(epochList, func(i, j int) bool {
@@ -463,6 +474,9 @@ func (ihgs *indexHashedNodesCoordinator) computePublicKeyToValidatorMap(
 	publicKeyToValidatorMap := make(map[string]Validator)
 	for _, epoch := range epochList {
 		epochConfig := nodesConfig[epoch]
+		if hasAuthoritative && !epochConfig.authoritative {
+			continue
+		}
 		epochConfig.mutNodesMaps.RLock()
 		for _, validator := range epochConfig.electedList {
 			publicKeyToValidatorMap[string(validator.PubKey())] = validator
@@ -899,37 +913,38 @@ func (ihgs *indexHashedNodesCoordinator) SetNodes(
 		nodesConfig = &epochNodesConfig{}
 	}
 
-	// the epoch config's write lock must be released before the map rebuild
-	// below, because computePublicKeyToValidatorMap re-acquires it as a read
-	// lock per epoch and the RWMutex is not reentrant
 	err := func() error {
 		nodesConfig.mutNodesMaps.Lock()
 		defer nodesConfig.mutNodesMaps.Unlock()
 
-		var errSelector error
-		// nbShards holds number of shards without meta
+		prevElected := nodesConfig.electedList
+		prevEligible := nodesConfig.eligibleList
+		prevWaiting := nodesConfig.waitingList
+		prevSelector := nodesConfig.selector
+
 		nodesConfig.electedList = elected
 		nodesConfig.eligibleList = eligible
 		nodesConfig.waitingList = waiting
+
+		var errSelector error
 		nodesConfig.selector, errSelector = ihgs.createSelector(nodesConfig)
-		return errSelector
+		if errSelector != nil {
+			nodesConfig.electedList = prevElected
+			nodesConfig.eligibleList = prevEligible
+			nodesConfig.waitingList = prevWaiting
+			nodesConfig.selector = prevSelector
+			return errSelector
+		}
+
+		nodesConfig.authoritative = true
+		return nil
 	}()
 	if err != nil {
 		return err
 	}
 
 	ihgs.nodesConfig[epoch] = nodesConfig
-
-	// rebuild the lookup so the validators set here resolve through
-	// GetValidatorWithPublicKey; without this the fast-bootstrap path
-	// (cmd/node calls SetNodes right after construction) leaves the map on
-	// its genesis seeding and the p2p validator-originator gate rejects
-	// every gossiped header
 	ihgs.publicKeyToValidatorMap = ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
-
-	// the lookup now holds authoritative data, so unblock it; stateReady is
-	// deliberately NOT set here: the startup gate (IsReady) must keep failing
-	// until LoadState restores the full persisted state
 	ihgs.lookupReady.Store(true)
 
 	return nil

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -76,13 +76,7 @@ type indexHashedNodesCoordinator struct {
 	currentEpoch                  atomic.Uint32
 	startEpoch                    uint32
 
-	stateReady atomic.Bool
-	// lookupReady tracks whether publicKeyToValidatorMap holds authoritative
-	// data. It is deliberately separate from stateReady: SetNodes on the
-	// fast-bootstrap path installs authoritative validators long before
-	// LoadState runs, which must unblock lookups without letting the startup
-	// readiness gate (IsReady) pass while the persisted state is unrestored
-	lookupReady     atomic.Bool
+	stateReady      atomic.Bool
 	loadStateFailed atomic.Bool
 }
 
@@ -126,14 +120,13 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 	}
 	ihgs.currentEpoch.Store(arguments.StartEpoch)
 	ihgs.stateReady.Store(arguments.StartEpoch == 0)
+
+	ihgs.loadingFromDisk.Store(false)
+
 	// the genesis seed is approximate but sufficient for peer classification
 	// during bootstrap; SetNodes or LoadState replaces it with authoritative
 	// data, and the authoritative flag on epochNodesConfig prevents stale
 	// genesis entries from shadowing real data in the merged lookup map
-	ihgs.lookupReady.Store(true)
-
-	ihgs.loadingFromDisk.Store(false)
-
 	ihgs.fillPublicKeyToValidatorMap()
 
 	ihncr := &indexHashedNodesCoordinatorWithRater{
@@ -341,7 +334,6 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ihgs.nodesConfig = nodesConfig
 	ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
 	ihgs.stateReady.Store(true)
-	ihgs.lookupReady.Store(true)
 	ihgs.mutNodesConfig.Unlock()
 
 	loadFailed = false
@@ -492,19 +484,21 @@ func (ihgs *indexHashedNodesCoordinator) computePublicKeyToValidatorMap(
 }
 
 // GetValidatorWithPublicKey gets the validator with the given public key.
-// The lookup refuses to answer from the constructor's genesis seeding: that
-// would present genesis-era data as authoritative to the p2p peer
-// classification (post-genesis validators reported as not found, rotated-out
-// validators reported as valid). It unblocks as soon as authoritative data is
-// installed, by SetNodes on the fast-bootstrap path or by LoadState, which is
-// earlier than the startup readiness gate (IsReady) that keeps guarding the
-// full restored state
+// The lookup always answers, including from the constructor's genesis seeding
+// before SetNodes or LoadState installs authoritative data. That is a deliberate
+// trade: refusing during the bootstrap window makes the error indistinguishable
+// from ErrValidatorNotFound in PeerShardMapper.getPeerInfoWithNodesCoordinator,
+// so every peer still in the genesis set would be reported as core.UnknownPeer
+// to the antiflood layer and throttled on the validator-only topics the node
+// needs to sync. The accepted cost is that during that window a post-genesis
+// validator still reads as not found and a rotated-out one reads as valid. Both
+// are bounded: every writer of the peerID to pubkey binding verifies a signature
+// first, so a stale answer grants topic access, never consensus membership,
+// which stays gated on IsNodeInConsensusGroup. The authoritative flag on
+// epochNodesConfig keeps the genesis seed from shadowing real data afterwards
 func (ihgs *indexHashedNodesCoordinator) GetValidatorWithPublicKey(publicKey []byte) (Validator, error) {
 	if len(publicKey) == 0 {
 		return nil, ErrNilPubKey
-	}
-	if !ihgs.lookupReady.Load() {
-		return nil, ErrNodesCoordinatorNotReady
 	}
 	ihgs.mutNodesConfig.RLock()
 	v, ok := ihgs.publicKeyToValidatorMap[string(publicKey)]
@@ -946,7 +940,6 @@ func (ihgs *indexHashedNodesCoordinator) SetNodes(
 
 	ihgs.nodesConfig[epoch] = nodesConfig
 	ihgs.publicKeyToValidatorMap = ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
-	ihgs.lookupReady.Store(true)
 
 	return nil
 }

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -551,7 +551,7 @@ func (ihgs *indexHashedNodesCoordinator) ComputeConsensusGroup(
 	epoch uint32,
 ) (validatorsGroup []Validator, err error) {
 	// check if component is ready (previous epoch nodes config is loaded)
-	if !ihgs.lookupReady.Load() {
+	if !ihgs.stateReady.Load() {
 		return nil, ErrNodesCoordinatorNotReady
 	}
 

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -94,11 +94,14 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 	nodesConfig := make(map[uint32]*epochNodesConfig, nodeCoordinatorStoredEpochs)
 
 	nodesConfig[arguments.Epoch] = &epochNodesConfig{
-		electedList:   arguments.ElectedNodes,
-		eligibleList:  arguments.EligibleNodes,
-		selector:      nil, // TODO:
-		leavingList:   make([]Validator, 0),
-		authoritative: arguments.StartEpoch == 0,
+		electedList:  arguments.ElectedNodes,
+		eligibleList: arguments.EligibleNodes,
+		selector:     nil, // TODO:
+		leavingList:  make([]Validator, 0),
+		// genesis config is authoritative for epoch 0, and the fast-bootstrap path
+		// hands over real registry data for Epoch; anything else is the approximate
+		// genesis seeding a later SetNodes or LoadState supersedes
+		authoritative: arguments.StartEpoch == 0 || arguments.NodesRestoredFromRegistry,
 	}
 
 	savedKey := arguments.Hasher.Compute(string(arguments.SelfPublicKey))
@@ -123,10 +126,11 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 
 	ihgs.loadingFromDisk.Store(false)
 
-	// the genesis seed is approximate but sufficient for peer classification
-	// during bootstrap; SetNodes or LoadState replaces it with authoritative
-	// data, and the authoritative flag on epochNodesConfig prevents stale
-	// genesis entries from shadowing real data in the merged lookup map
+	// when the config above is only the genesis seeding it is approximate but
+	// still sufficient for peer classification during bootstrap; SetNodes or
+	// LoadState replaces it with authoritative data, and the authoritative flag
+	// on epochNodesConfig keeps that seeding from shadowing real data once any
+	// arrives
 	ihgs.fillPublicKeyToValidatorMap()
 
 	ihncr := &indexHashedNodesCoordinatorWithRater{

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -76,6 +76,12 @@ type indexHashedNodesCoordinator struct {
 	startEpoch                    uint32
 
 	stateReady atomic.Bool
+	// lookupReady tracks whether publicKeyToValidatorMap holds authoritative
+	// data. It is deliberately separate from stateReady: SetNodes on the
+	// fast-bootstrap path installs authoritative validators long before
+	// LoadState runs, which must unblock lookups without letting the startup
+	// readiness gate (IsReady) pass while the persisted state is unrestored
+	lookupReady atomic.Bool
 }
 
 type indexHashedNodesCoordinatorWithRater struct {
@@ -118,6 +124,10 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 	ihgs.currentEpoch.Store(arguments.StartEpoch)
 	// no need to wait for load state, as we have the initial configuration
 	ihgs.stateReady.Store(arguments.StartEpoch == 0)
+	// at genesis the constructor seeding IS the authoritative epoch-0 set;
+	// on any other start the lookup stays gated until SetNodes or LoadState
+	// installs real data
+	ihgs.lookupReady.Store(arguments.StartEpoch == 0)
 
 	ihgs.loadingFromDisk.Store(false)
 
@@ -127,10 +137,12 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		indexHashedNodesCoordinator: ihgs,
 	}
 
-	err = ihgs.saveState(ihgs.savedStateKey)
-	if err != nil {
-		log.Error("saving initial nodes coordinator config failed",
-			"error", err.Error())
+	if ihgs.shouldSaveInitialState(arguments.Epoch) {
+		err = ihgs.saveState(ihgs.savedStateKey)
+		if err != nil {
+			log.Error("saving initial nodes coordinator config failed",
+				"error", err.Error())
+		}
 	}
 
 	log.Info("new nodes config is set for epoch", "epoch", arguments.Epoch)
@@ -249,6 +261,33 @@ func (ihgs *indexHashedNodesCoordinator) saveState(key []byte) error {
 	return ihgs.bootStorer.Put(ncInternalkey, data)
 }
 
+// shouldSaveInitialState decides whether the constructor persists its seeded
+// config under hash(selfPubKey). The invariant is "never overwrite a registry
+// that is at least as new as the constructor's own data": a restart within the
+// install epoch must not clobber the registry the previous run saved (LoadState
+// would read genesis data back, causing permanent BLS signature failures), while
+// a stored registry older than the current start epoch (e.g. an epoch-0 registry
+// left behind by a genesis-era run) must be refreshed, or a bootstrap record
+// stamped with this key would silently restore stale data on a later restart
+func (ihgs *indexHashedNodesCoordinator) shouldSaveInitialState(epoch uint32) bool {
+	ncInternalkey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), ihgs.savedStateKey...)
+
+	data, err := ihgs.bootStorer.Get(ncInternalkey)
+	if err != nil {
+		// nothing stored under this key yet: first start on this machine
+		return true
+	}
+
+	config := &NodesCoordinatorRegistry{}
+	err = json.Unmarshal(data, config)
+	if err != nil {
+		// unreadable blob: replace it with a fresh, readable registry
+		return true
+	}
+
+	return epoch > config.CurrentEpoch
+}
+
 func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ncInternalkey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), key...)
 
@@ -268,6 +307,24 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 		return err
 	}
 
+	nodesConfig, err := ihgs.registryToNodesCoordinator(config)
+	if err != nil {
+		return err
+	}
+
+	// a registry that unmarshals cleanly but restores no epoch configs (truncated
+	// write, or a registry saved from a pruned coordinator) must not be installed:
+	// publishing it would replace the seeded lookup with an empty one and mark the
+	// coordinator ready while every validator lookup fails; failing here keeps
+	// stateReady false so the startup readiness gate fires instead
+	if len(nodesConfig) == 0 {
+		return fmt.Errorf("%w key=%x", ErrEmptyRestoredRegistry, key)
+	}
+
+	// savedStateKey and currentEpoch are only mutated after the conversion
+	// succeeded, so a failed restore cannot leave a foreign key or epoch next
+	// to the constructor-seeded configs (a later saveState on that key would
+	// overwrite a still-valid registry with genesis data)
 	ihgs.mutSavedStateKey.Lock()
 	ihgs.savedStateKey = key
 	ihgs.mutSavedStateKey.Unlock()
@@ -275,19 +332,31 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	ihgs.currentEpoch.Store(config.CurrentEpoch)
 	log.Debug("loaded nodes config", "current epoch", config.CurrentEpoch)
 
-	nodesConfig, err := ihgs.registryToNodesCoordinator(config)
-	if err != nil {
-		return err
-	}
-
 	displayNodesConfigInfo(nodesConfig)
+
+	// rebuild the validator lookup from restored configs and publish both atomically
+	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
+
 	ihgs.mutNodesConfig.Lock()
 	ihgs.nodesConfig = nodesConfig
+	ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
 	ihgs.mutNodesConfig.Unlock()
 
 	ihgs.stateReady.Store(true)
+	ihgs.lookupReady.Store(true)
 
 	return nil
+}
+
+// IsReady returns true once the initial saved state has been restored. It is set
+// at construction for genesis (startEpoch==0) or after a successful LoadState for
+// non-genesis restarts. LoadState rejects registries that restore no epoch
+// configs, so ready implies a non-empty restored state; it does not imply the
+// restored epochs match the chain's current epoch (a stale-but-valid registry
+// still reports ready and surfaces later as ErrEpochNodesConfigDoesNotExist).
+// EpochStartPrepare does NOT flip this flag.
+func (ihgs *indexHashedNodesCoordinator) IsReady() bool {
+	return ihgs.stateReady.Load()
 }
 
 func displayNodesConfigInfo(config map[uint32]*epochNodesConfig) {
@@ -372,52 +441,55 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 	ihgs.mutNodesConfig.Lock()
 	defer ihgs.mutNodesConfig.Unlock()
 
-	index := 0
-	epochList := make([]uint32, len(ihgs.nodesConfig))
-	mapAllValidators := make(map[uint32]map[string]Validator)
-	for epoch, epochConfig := range ihgs.nodesConfig {
-		epochConfig.mutNodesMaps.RLock()
-		mapAllValidators[epoch] = ihgs.createPublicKeyToValidatorMap(epochConfig.electedList, epochConfig.eligibleList)
-		epochConfig.mutNodesMaps.RUnlock()
+	ihgs.publicKeyToValidatorMap = ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
+}
 
-		epochList[index] = epoch
-		index++
+// computePublicKeyToValidatorMap merges the elected and eligible validators of
+// all given epoch configs into one lookup map, later epochs taking precedence;
+// single pass: epochs are visited in ascending order and written straight into
+// the result map, so no intermediate per-epoch maps are allocated
+func (ihgs *indexHashedNodesCoordinator) computePublicKeyToValidatorMap(
+	nodesConfig map[uint32]*epochNodesConfig,
+) map[string]Validator {
+	epochList := make([]uint32, 0, len(nodesConfig))
+	for epoch := range nodesConfig {
+		epochList = append(epochList, epoch)
 	}
 
 	sort.Slice(epochList, func(i, j int) bool {
 		return epochList[i] < epochList[j]
 	})
 
-	ihgs.publicKeyToValidatorMap = make(map[string]Validator)
-	for _, epoch := range epochList {
-		validatorsForEpoch := mapAllValidators[epoch]
-		for pubKey, vInfo := range validatorsForEpoch {
-			ihgs.publicKeyToValidatorMap[pubKey] = vInfo
-		}
-	}
-}
-
-func (ihgs *indexHashedNodesCoordinator) createPublicKeyToValidatorMap(
-	elected []Validator,
-	eligible []Validator,
-) map[string]Validator {
 	publicKeyToValidatorMap := make(map[string]Validator)
-
-	for i := 0; i < len(elected); i++ {
-		publicKeyToValidatorMap[string(elected[i].PubKey())] = elected[i]
-	}
-
-	for i := 0; i < len(eligible); i++ {
-		publicKeyToValidatorMap[string(eligible[i].PubKey())] = eligible[i]
+	for _, epoch := range epochList {
+		epochConfig := nodesConfig[epoch]
+		epochConfig.mutNodesMaps.RLock()
+		for _, validator := range epochConfig.electedList {
+			publicKeyToValidatorMap[string(validator.PubKey())] = validator
+		}
+		for _, validator := range epochConfig.eligibleList {
+			publicKeyToValidatorMap[string(validator.PubKey())] = validator
+		}
+		epochConfig.mutNodesMaps.RUnlock()
 	}
 
 	return publicKeyToValidatorMap
 }
 
-// GetValidatorWithPublicKey gets the validator with the given public key
+// GetValidatorWithPublicKey gets the validator with the given public key.
+// The lookup refuses to answer from the constructor's genesis seeding: that
+// would present genesis-era data as authoritative to the p2p peer
+// classification (post-genesis validators reported as not found, rotated-out
+// validators reported as valid). It unblocks as soon as authoritative data is
+// installed, by SetNodes on the fast-bootstrap path or by LoadState, which is
+// earlier than the startup readiness gate (IsReady) that keeps guarding the
+// full restored state
 func (ihgs *indexHashedNodesCoordinator) GetValidatorWithPublicKey(publicKey []byte) (Validator, error) {
 	if len(publicKey) == 0 {
 		return nil, ErrNilPubKey
+	}
+	if !ihgs.lookupReady.Load() {
+		return nil, ErrNodesCoordinatorNotReady
 	}
 	ihgs.mutNodesConfig.RLock()
 	v, ok := ihgs.publicKeyToValidatorMap[string(publicKey)]
@@ -479,7 +551,7 @@ func (ihgs *indexHashedNodesCoordinator) ComputeConsensusGroup(
 	epoch uint32,
 ) (validatorsGroup []Validator, err error) {
 	// check if component is ready (previous epoch nodes config is loaded)
-	if !ihgs.stateReady.Load() {
+	if !ihgs.lookupReady.Load() {
 		return nil, ErrNodesCoordinatorNotReady
 	}
 
@@ -773,12 +845,13 @@ func (ihgs *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 		return
 	}
 
+	// SetNodes rebuilds publicKeyToValidatorMap before returning, so no
+	// separate fillPublicKeyToValidatorMap call is needed here
 	err = ihgs.SetNodes(resUpdateNodes.Elected, resUpdateNodes.Eligible, newNodesConfig.waitingList, newEpoch)
 	if err != nil {
 		log.Error("set nodes per shard failed", "error", err.Error())
 	}
 
-	ihgs.fillPublicKeyToValidatorMap()
 	err = ihgs.saveState(randomness)
 	if err != nil {
 		log.Error("saving nodes coordinator config failed", "error", err.Error())
@@ -816,30 +889,48 @@ func (ihgs *indexHashedNodesCoordinator) SetNodes(
 	ihgs.mutNodesConfig.Lock()
 	defer ihgs.mutNodesConfig.Unlock()
 
+	if elected == nil || eligible == nil {
+		return ErrNilInputNodesMap
+	}
+
 	nodesConfig, ok := ihgs.nodesConfig[epoch]
 	if !ok {
 		log.Debug("did not find nodesConfig", "epoch", epoch)
 		nodesConfig = &epochNodesConfig{}
 	}
 
-	nodesConfig.mutNodesMaps.Lock()
-	defer nodesConfig.mutNodesMaps.Unlock()
+	// the epoch config's write lock must be released before the map rebuild
+	// below, because computePublicKeyToValidatorMap re-acquires it as a read
+	// lock per epoch and the RWMutex is not reentrant
+	err := func() error {
+		nodesConfig.mutNodesMaps.Lock()
+		defer nodesConfig.mutNodesMaps.Unlock()
 
-	if elected == nil || eligible == nil {
-		return ErrNilInputNodesMap
-	}
-
-	var err error
-	// nbShards holds number of shards without meta
-	nodesConfig.electedList = elected
-	nodesConfig.eligibleList = eligible
-	nodesConfig.waitingList = waiting
-	nodesConfig.selector, err = ihgs.createSelector(nodesConfig)
+		var errSelector error
+		// nbShards holds number of shards without meta
+		nodesConfig.electedList = elected
+		nodesConfig.eligibleList = eligible
+		nodesConfig.waitingList = waiting
+		nodesConfig.selector, errSelector = ihgs.createSelector(nodesConfig)
+		return errSelector
+	}()
 	if err != nil {
 		return err
 	}
 
 	ihgs.nodesConfig[epoch] = nodesConfig
+
+	// rebuild the lookup so the validators set here resolve through
+	// GetValidatorWithPublicKey; without this the fast-bootstrap path
+	// (cmd/node calls SetNodes right after construction) leaves the map on
+	// its genesis seeding and the p2p validator-originator gate rejects
+	// every gossiped header
+	ihgs.publicKeyToValidatorMap = ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
+
+	// the lookup now holds authoritative data, so unblock it; stateReady is
+	// deliberately NOT set here: the startup gate (IsReady) must keep failing
+	// until LoadState restores the full persisted state
+	ihgs.lookupReady.Store(true)
 
 	return nil
 }

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -1,6 +1,7 @@
 package sharding
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -758,4 +759,642 @@ func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {
 	ihgs3, err := NewNodesCoordinator(arguments)
 	require.Nil(t, err)
 	require.False(t, check.IfNil(ihgs3))
+}
+
+func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *testing.T) {
+	t.Parallel()
+
+	// simulate a restart within the install epoch: the first coordinator
+	// persists the real validators under hash(selfPubKey); a second
+	// coordinator (the restart) is seeded with genesis nodes and must NOT
+	// overwrite that saved state, otherwise LoadState reads genesis data back
+	realElected := createDummyNodesList(4, "realElected")
+	realEligible := createDummyNodesList(1, "realEligible")
+	bootStorer := mock.NewStorerMock()
+
+	firstArgs := createArguments()
+	firstArgs.BootStorer = bootStorer
+	firstArgs.ElectedNodes = realElected
+	firstArgs.EligibleNodes = realEligible
+	firstArgs.Epoch = 5
+	firstArgs.StartEpoch = 5
+	firstCoordinator, err := NewNodesCoordinator(firstArgs)
+	require.Nil(t, err)
+
+	// EpochStartPrepare would rotate the key, but within the install epoch
+	// the key is still hash(selfPubKey); persist under that key
+	err = firstCoordinator.saveState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	// second coordinator (the restart) uses the same bootStorer and same
+	// selfPubKey, so savedStateKey = hash(selfPubKey) is the same; it is
+	// seeded with genesis nodes and StartEpoch > 0
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	secondArgs := createArguments()
+	secondArgs.BootStorer = bootStorer
+	secondArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	secondArgs.Hasher = firstArgs.Hasher
+	secondArgs.ElectedNodes = genesisElected
+	secondArgs.EligibleNodes = genesisEligible
+	secondArgs.Epoch = 5
+	secondArgs.StartEpoch = 5
+	_, err = NewNodesCoordinator(secondArgs)
+	require.Nil(t, err)
+
+	// now LoadState with the same key must return the REAL validators, not
+	// genesis; if the constructor overwrote, this will return genesis data
+	thirdArgs := createArguments()
+	thirdArgs.BootStorer = bootStorer
+	thirdArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	thirdArgs.Hasher = firstArgs.Hasher
+	thirdArgs.ElectedNodes = genesisElected
+	thirdArgs.EligibleNodes = genesisEligible
+	thirdArgs.Epoch = 5
+	thirdArgs.StartEpoch = 5
+	thirdCoordinator, err := NewNodesCoordinator(thirdArgs)
+	require.Nil(t, err)
+
+	err = thirdCoordinator.LoadState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	realPubKey := realElected[0].PubKey()
+	validator, err := thirdCoordinator.GetValidatorWithPublicKey(realPubKey)
+	require.Nil(t, err)
+	require.Equal(t, realPubKey, validator.PubKey())
+
+	genesisPubKey := genesisElected[0].PubKey()
+	_, err = thirdCoordinator.GetValidatorWithPublicKey(genesisPubKey)
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
+func TestNodesCoordinator_ConstructorSavesStateOnGenesisStart(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "genesisElected")
+	eligible := createDummyNodesList(1, "genesisEligible")
+	bootStorer := mock.NewStorerMock()
+
+	args := createArguments()
+	args.BootStorer = bootStorer
+	args.ElectedNodes = elected
+	args.EligibleNodes = eligible
+	args.Epoch = 0
+	args.StartEpoch = 0
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	// a second coordinator loading from the same key must see the saved state;
+	// StartEpoch > 0 so the second constructor does not overwrite what was saved
+	args2 := createArguments()
+	args2.BootStorer = bootStorer
+	args2.SelfPublicKey = args.SelfPublicKey
+	args2.Hasher = args.Hasher
+	args2.ElectedNodes = createDummyNodesList(4, "otherElected")
+	args2.EligibleNodes = createDummyNodesList(1, "otherEligible")
+	args2.StartEpoch = 1
+	coordinator2, err := NewNodesCoordinator(args2)
+	require.Nil(t, err)
+
+	err = coordinator2.LoadState(coordinator.savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := coordinator2.GetValidatorWithPublicKey(elected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, elected[0].PubKey(), validator.PubKey())
+}
+
+func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) {
+	t.Parallel()
+
+	// simulate a mid-epoch restart from storage: the persisted registry holds
+	// the current epoch's validators, while the constructor is seeded from the
+	// genesis nodes file only
+	currentElected := createDummyNodesList(4, "currentElected")
+	currentEligible := createDummyNodesList(1, "currentEligible")
+	bootStorer := mock.NewStorerMock()
+
+	argumentsBeforeRestart := createArguments()
+	argumentsBeforeRestart.BootStorer = bootStorer
+	argumentsBeforeRestart.ElectedNodes = currentElected
+	argumentsBeforeRestart.EligibleNodes = currentEligible
+	nodesCoordinatorBeforeRestart, err := NewNodesCoordinator(argumentsBeforeRestart)
+	require.Nil(t, err)
+
+	// persist the registry under a rotated key, as EpochStartPrepare does; the
+	// constructor-time save under hash(selfPubKey) must not be reused here
+	// because a subsequent constructor overwrites that key
+	savedStateKey := []byte("rotated-saved-state-key")
+	err = nodesCoordinatorBeforeRestart.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	argumentsAfterRestart := createArguments()
+	argumentsAfterRestart.BootStorer = bootStorer
+	argumentsAfterRestart.ElectedNodes = genesisElected
+	argumentsAfterRestart.EligibleNodes = genesisEligible
+	nodesCoordinatorAfterRestart, err := NewNodesCoordinator(argumentsAfterRestart)
+	require.Nil(t, err)
+
+	currentPubKey := currentElected[0].PubKey()
+	_, err = nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(currentPubKey)
+	require.Equal(t, ErrValidatorNotFound, err)
+
+	err = nodesCoordinatorAfterRestart.LoadState(savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(currentPubKey)
+	require.Nil(t, err)
+	require.Equal(t, currentPubKey, validator.PubKey())
+
+	eligiblePubKey := currentEligible[0].PubKey()
+	eligibleValidator, err := nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(eligiblePubKey)
+	require.Nil(t, err)
+	require.Equal(t, eligiblePubKey, eligibleValidator.PubKey())
+
+	// the map is rebuilt wholesale from the restored per-epoch configs, so the
+	// genesis-seeded entries are gone
+	_, err = nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(genesisElected[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
+// countingPutStorer counts Put calls and optionally fails them
+type countingPutStorer struct {
+	*mock.StorerMock
+	puts    int
+	failPut bool
+}
+
+func (c *countingPutStorer) Put(key, val []byte) error {
+	c.puts++
+	if c.failPut {
+		return errors.New("put failed")
+	}
+	return c.StorerMock.Put(key, val)
+}
+
+func TestNodesCoordinator_ConstructorSurvivesFailedInitialSaveOnGenesis(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "genesisElected")
+
+	t.Run("StartEpoch 0 attempts save and survives failure", func(t *testing.T) {
+		t.Parallel()
+		storer := &countingPutStorer{StorerMock: mock.NewStorerMock(), failPut: true}
+
+		args := createArguments()
+		args.Epoch = 0
+		args.StartEpoch = 0
+		args.ElectedNodes = elected
+		args.BootStorer = storer
+
+		coordinator, err := NewNodesCoordinator(args)
+		require.Nil(t, err)
+		require.NotNil(t, coordinator)
+		require.Equal(t, 1, storer.puts)
+
+		validator, err := coordinator.GetValidatorWithPublicKey(elected[0].PubKey())
+		require.Nil(t, err)
+		require.Equal(t, elected[0].PubKey(), validator.PubKey())
+	})
+
+	t.Run("replaces an unreadable stored blob", func(t *testing.T) {
+		t.Parallel()
+		bootStorer := mock.NewStorerMock()
+
+		args := createArguments()
+		args.Epoch = 5
+		args.StartEpoch = 5
+		args.ElectedNodes = elected
+
+		// garbage under hash(selfPubKey) must be overwritten with a fresh,
+		// readable registry
+		savedKey := args.Hasher.Compute(string(args.SelfPublicKey))
+		err := bootStorer.Put(append([]byte(core.NodesCoordinatorRegistryKeyPrefix), savedKey...), []byte("not json"))
+		require.Nil(t, err)
+
+		storer := &countingPutStorer{StorerMock: bootStorer}
+		args.BootStorer = storer
+
+		_, err = NewNodesCoordinator(args)
+		require.Nil(t, err)
+		require.Equal(t, 1, storer.puts)
+	})
+
+	t.Run("skips save when stored registry is at least as new", func(t *testing.T) {
+		t.Parallel()
+		bootStorer := mock.NewStorerMock()
+
+		// a previous run at epoch 5 left its registry under hash(selfPubKey)
+		firstArgs := createArguments()
+		firstArgs.Epoch = 5
+		firstArgs.StartEpoch = 5
+		firstArgs.ElectedNodes = elected
+		firstArgs.BootStorer = bootStorer
+		_, err := NewNodesCoordinator(firstArgs)
+		require.Nil(t, err)
+
+		// the restart at the same epoch must not attempt any write
+		storer := &countingPutStorer{StorerMock: bootStorer, failPut: true}
+		secondArgs := createArguments()
+		secondArgs.SelfPublicKey = firstArgs.SelfPublicKey
+		secondArgs.Hasher = firstArgs.Hasher
+		secondArgs.Epoch = 5
+		secondArgs.StartEpoch = 5
+		secondArgs.ElectedNodes = elected
+		secondArgs.BootStorer = storer
+
+		coordinator, err := NewNodesCoordinator(secondArgs)
+		require.Nil(t, err)
+		require.NotNil(t, coordinator)
+		require.Equal(t, 0, storer.puts)
+	})
+}
+
+func TestNodesCoordinator_ConstructorRefreshesStaleRegistryFromOlderEpoch(t *testing.T) {
+	t.Parallel()
+
+	// a node that once ran at genesis left an epoch-0 registry under
+	// hash(selfPubKey); a restart at epoch 5 must refresh that key, otherwise a
+	// bootstrap record stamped with it would silently restore genesis data on a
+	// later restart and ComputeConsensusGroup would fail indefinitely
+	bootStorer := mock.NewStorerMock()
+
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisArgs := createArguments()
+	genesisArgs.Epoch = 0
+	genesisArgs.StartEpoch = 0
+	genesisArgs.ElectedNodes = genesisElected
+	genesisArgs.BootStorer = bootStorer
+	genesisCoordinator, err := NewNodesCoordinator(genesisArgs)
+	require.Nil(t, err)
+
+	currentElected := createDummyNodesList(4, "currentElected")
+	restartArgs := createArguments()
+	restartArgs.SelfPublicKey = genesisArgs.SelfPublicKey
+	restartArgs.Hasher = genesisArgs.Hasher
+	restartArgs.Epoch = 5
+	restartArgs.StartEpoch = 5
+	restartArgs.ElectedNodes = currentElected
+	restartArgs.BootStorer = bootStorer
+	_, err = NewNodesCoordinator(restartArgs)
+	require.Nil(t, err)
+
+	// loading hash(selfPubKey) must now resolve the epoch-5 validators, not the
+	// stale genesis set
+	loadArgs := createArguments()
+	loadArgs.SelfPublicKey = genesisArgs.SelfPublicKey
+	loadArgs.Hasher = genesisArgs.Hasher
+	loadArgs.Epoch = 5
+	loadArgs.StartEpoch = 5
+	loadArgs.BootStorer = bootStorer
+	loadCoordinator, err := NewNodesCoordinator(loadArgs)
+	require.Nil(t, err)
+
+	err = loadCoordinator.LoadState(genesisCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := loadCoordinator.GetValidatorWithPublicKey(currentElected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, currentElected[0].PubKey(), validator.PubKey())
+	require.Equal(t, uint32(5), loadCoordinator.currentEpoch.Load())
+}
+
+func TestNodesCoordinator_LoadStateRejectsEmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	// a registry blob that unmarshals cleanly but restores no epoch configs must
+	// not be installed: the coordinator would report ready with an empty lookup
+	// and every validator lookup would fail (the exact stall this PR fixes)
+	bootStorer := mock.NewStorerMock()
+	emptyRegistry := &NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*EpochValidators{},
+		CurrentEpoch: 7,
+	}
+	data, err := json.Marshal(emptyRegistry)
+	require.Nil(t, err)
+
+	key := []byte("empty-registry-key")
+	err = bootStorer.Put(append([]byte(core.NodesCoordinatorRegistryKeyPrefix), key...), data)
+	require.Nil(t, err)
+
+	args := createArguments()
+	args.Epoch = 5
+	args.StartEpoch = 5
+	args.BootStorer = bootStorer
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+	require.False(t, coordinator.IsReady())
+
+	keyBefore := coordinator.GetSavedStateKey()
+
+	err = coordinator.LoadState(key)
+	require.ErrorIs(t, err, ErrEmptyRestoredRegistry)
+
+	// the failed restore left no trace: not ready, key and epoch untouched
+	require.False(t, coordinator.IsReady())
+	require.Equal(t, keyBefore, coordinator.GetSavedStateKey())
+	require.Equal(t, uint32(5), coordinator.currentEpoch.Load())
+}
+
+func TestNodesCoordinator_LoadStateConversionFailureLeavesStateUntouched(t *testing.T) {
+	t.Parallel()
+
+	// registryToNodesCoordinator fails on a malformed epoch key; savedStateKey
+	// and currentEpoch must not have been mutated on that path, otherwise a
+	// later saveState would overwrite a still-valid registry under the foreign
+	// key with genesis data
+	bootStorer := mock.NewStorerMock()
+	malformedRegistry := &NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*EpochValidators{
+			"not-a-number": {},
+		},
+		CurrentEpoch: 7,
+	}
+	data, err := json.Marshal(malformedRegistry)
+	require.Nil(t, err)
+
+	key := []byte("malformed-registry-key")
+	err = bootStorer.Put(append([]byte(core.NodesCoordinatorRegistryKeyPrefix), key...), data)
+	require.Nil(t, err)
+
+	args := createArguments()
+	args.Epoch = 5
+	args.StartEpoch = 5
+	args.BootStorer = bootStorer
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	keyBefore := coordinator.GetSavedStateKey()
+
+	err = coordinator.LoadState(key)
+	require.NotNil(t, err)
+
+	require.False(t, coordinator.IsReady())
+	require.Equal(t, keyBefore, coordinator.GetSavedStateKey())
+	require.Equal(t, uint32(5), coordinator.currentEpoch.Load())
+}
+
+func TestNodesCoordinator_SetNodesUnblocksValidatorLookupBeforeLoadState(t *testing.T) {
+	t.Parallel()
+
+	// the fast-bootstrap path (cmd/node) calls SetNodes right after a
+	// non-genesis construction, long before LoadState runs in StartConsensus;
+	// the installed validators are authoritative and must resolve through
+	// GetValidatorWithPublicKey immediately, while the startup readiness gate
+	// (IsReady) must keep failing until LoadState restores the full state
+	restored := createDummyNodesList(4, "restoredElected")
+
+	args := createArguments()
+	args.Epoch = 7
+	args.StartEpoch = 7
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	// before SetNodes the lookup only holds the genesis seeding and must refuse
+	_, err = coordinator.GetValidatorWithPublicKey(restored[0].PubKey())
+	require.Equal(t, ErrNodesCoordinatorNotReady, err)
+
+	err = coordinator.SetNodes(restored, createDummyNodesList(1, "restoredEligible"), make([]Validator, 0), args.Epoch-1)
+	require.Nil(t, err)
+
+	validator, err := coordinator.GetValidatorWithPublicKey(restored[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, restored[0].PubKey(), validator.PubKey())
+
+	// the lookup unblocking must not weaken the startup gate
+	require.False(t, coordinator.IsReady())
+}
+
+func TestNodesCoordinator_GetValidatorWithPublicKeyNotReady(t *testing.T) {
+	t.Parallel()
+
+	// before LoadState a non-genesis coordinator only holds its genesis seeding;
+	// answering from it would present genesis-era data as authoritative to the
+	// p2p peer classification, so the lookup must refuse until ready
+	elected := createDummyNodesList(4, "elected")
+	bootStorer := mock.NewStorerMock()
+
+	firstArgs := createArguments()
+	firstArgs.Epoch = 5
+	firstArgs.StartEpoch = 5
+	firstArgs.ElectedNodes = elected
+	firstArgs.BootStorer = bootStorer
+	firstCoordinator, err := NewNodesCoordinator(firstArgs)
+	require.Nil(t, err)
+
+	savedStateKey := []byte("ready-gate-saved-state-key")
+	err = firstCoordinator.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	secondArgs := createArguments()
+	secondArgs.Epoch = 5
+	secondArgs.StartEpoch = 5
+	secondArgs.ElectedNodes = elected
+	secondArgs.BootStorer = bootStorer
+	coordinator, err := NewNodesCoordinator(secondArgs)
+	require.Nil(t, err)
+
+	_, err = coordinator.GetValidatorWithPublicKey(elected[0].PubKey())
+	require.Equal(t, ErrNodesCoordinatorNotReady, err)
+
+	err = coordinator.LoadState(savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := coordinator.GetValidatorWithPublicKey(elected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, elected[0].PubKey(), validator.PubKey())
+}
+
+func TestNodesCoordinator_LoadStateLaterEpochWinsForSharedPublicKey(t *testing.T) {
+	t.Parallel()
+
+	// the same public key appears in five restored epochs with a different index
+	// in each; computePublicKeyToValidatorMap merges epochs in ascending order,
+	// so the entry from the latest epoch must survive in the lookup.
+	// Go's map iteration randomization picks a start bucket/offset per map
+	// instance, so a single LoadState can accidentally iterate in ascending
+	// order even without the sort. Running 20 iterations (each creating a fresh
+	// map via LoadState) makes the probability of all 20 being accidentally
+	// correct negligible (< 10^-12 at the observed ~25% single-pass rate).
+	sharedPubKey := []byte("sharedPubKey")
+
+	epochs := []uint32{10, 20, 30, 40, 50}
+	configs := make(map[uint32]*epochNodesConfig, len(epochs))
+	var latestValidator Validator
+	for i, epoch := range epochs {
+		v, err := NewValidator([]byte(fmt.Sprintf("owner-epoch-%d", epoch)), sharedPubKey, 1, uint32(i))
+		require.Nil(t, err)
+		configs[epoch] = &epochNodesConfig{
+			electedList:  append(createDummyNodesList(3, fmt.Sprintf("epoch%d", epoch)), v),
+			eligibleList: make([]Validator, 0),
+			leavingList:  make([]Validator, 0),
+		}
+		latestValidator = v
+	}
+
+	bootStorer := mock.NewStorerMock()
+	argsBeforeRestart := createArguments()
+	argsBeforeRestart.BootStorer = bootStorer
+	coordinatorBeforeRestart, err := NewNodesCoordinator(argsBeforeRestart)
+	require.Nil(t, err)
+
+	coordinatorBeforeRestart.nodesConfig = configs
+
+	savedStateKey := []byte("multi-epoch-saved-state-key")
+	err = coordinatorBeforeRestart.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	for attempt := 0; attempt < 20; attempt++ {
+		argsAfterRestart := createArguments()
+		argsAfterRestart.BootStorer = bootStorer
+		coordinatorAfterRestart, err := NewNodesCoordinator(argsAfterRestart)
+		require.Nil(t, err)
+
+		err = coordinatorAfterRestart.LoadState(savedStateKey)
+		require.Nil(t, err)
+
+		validator, err := coordinatorAfterRestart.GetValidatorWithPublicKey(sharedPubKey)
+		require.Nil(t, err)
+		require.Equal(t, latestValidator.Index(), validator.Index(),
+			"attempt %d: expected latest epoch's validator index", attempt)
+	}
+}
+
+func TestNodesCoordinator_SetNodesRebuildsPublicKeyToValidatorMap(t *testing.T) {
+	t.Parallel()
+
+	// the fast-bootstrap path (cmd/node) seeds the coordinator from the genesis
+	// nodes file and then calls SetNodes with the validators restored from the
+	// bootstrap registry; the lookup map must follow that mutation, otherwise
+	// GetValidatorWithPublicKey keeps resolving only genesis keys and the p2p
+	// validator-originator gate rejects every gossiped header
+
+	t.Run("existing epoch config is replaced in the lookup", func(t *testing.T) {
+		t.Parallel()
+		restoredElected := createDummyNodesList(4, "restoredElected")
+		restoredEligible := createDummyNodesList(1, "restoredEligible")
+
+		args := createArguments()
+		coordinator, err := NewNodesCoordinator(args)
+		require.Nil(t, err)
+
+		err = coordinator.SetNodes(restoredElected, restoredEligible, make([]Validator, 0), args.Epoch)
+		require.Nil(t, err)
+
+		validator, err := coordinator.GetValidatorWithPublicKey(restoredElected[0].PubKey())
+		require.Nil(t, err)
+		require.Equal(t, restoredElected[0].PubKey(), validator.PubKey())
+
+		eligibleValidator, err := coordinator.GetValidatorWithPublicKey(restoredEligible[0].PubKey())
+		require.Nil(t, err)
+		require.Equal(t, restoredEligible[0].PubKey(), eligibleValidator.PubKey())
+
+		// the sole epoch config was replaced, so its previous seeding is gone
+		_, err = coordinator.GetValidatorWithPublicKey(args.ElectedNodes[0].PubKey())
+		require.Equal(t, ErrValidatorNotFound, err)
+	})
+
+	t.Run("nil elected or eligible input is rejected", func(t *testing.T) {
+		t.Parallel()
+		args := createArguments()
+		coordinator, err := NewNodesCoordinator(args)
+		require.Nil(t, err)
+
+		err = coordinator.SetNodes(nil, createDummyNodesList(1, "eligible"), nil, args.Epoch)
+		require.Equal(t, ErrNilInputNodesMap, err)
+
+		err = coordinator.SetNodes(createDummyNodesList(4, "elected"), nil, nil, args.Epoch)
+		require.Equal(t, ErrNilInputNodesMap, err)
+	})
+
+	t.Run("new epoch config is added to the lookup", func(t *testing.T) {
+		t.Parallel()
+		restoredElected := createDummyNodesList(4, "restoredElected")
+		restoredEligible := createDummyNodesList(1, "restoredEligible")
+
+		args := createArguments()
+		coordinator, err := NewNodesCoordinator(args)
+		require.Nil(t, err)
+
+		// mirrors node.go: SetNodes targets currentEpoch-1, which may not have
+		// a config yet on this coordinator
+		err = coordinator.SetNodes(restoredElected, restoredEligible, make([]Validator, 0), args.Epoch+3)
+		require.Nil(t, err)
+
+		validator, err := coordinator.GetValidatorWithPublicKey(restoredElected[0].PubKey())
+		require.Nil(t, err)
+		require.Equal(t, restoredElected[0].PubKey(), validator.PubKey())
+	})
+}
+
+func TestNodesCoordinator_IsReadyOnGenesisStart(t *testing.T) {
+	t.Parallel()
+
+	args := createArguments()
+	args.Epoch = 0
+	args.StartEpoch = 0
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	require.True(t, coordinator.IsReady())
+}
+
+func TestNodesCoordinator_IsReadyFalseOnRestartBeforeLoadState(t *testing.T) {
+	t.Parallel()
+
+	args := createArguments()
+	args.StartEpoch = 1
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	require.False(t, coordinator.IsReady())
+}
+
+func TestNodesCoordinator_IsReadyTrueAfterSuccessfulLoadState(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "currentElected")
+	eligible := createDummyNodesList(1, "currentEligible")
+	bootStorer := mock.NewStorerMock()
+
+	argsBeforeRestart := createArguments()
+	argsBeforeRestart.BootStorer = bootStorer
+	argsBeforeRestart.ElectedNodes = elected
+	argsBeforeRestart.EligibleNodes = eligible
+	coordinatorBeforeRestart, err := NewNodesCoordinator(argsBeforeRestart)
+	require.Nil(t, err)
+
+	savedStateKey := []byte("rotated-saved-state-key")
+	err = coordinatorBeforeRestart.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	argsAfterRestart := createArguments()
+	argsAfterRestart.BootStorer = bootStorer
+	argsAfterRestart.StartEpoch = 1
+	coordinatorAfterRestart, err := NewNodesCoordinator(argsAfterRestart)
+	require.Nil(t, err)
+	require.False(t, coordinatorAfterRestart.IsReady())
+
+	err = coordinatorAfterRestart.LoadState(savedStateKey)
+	require.Nil(t, err)
+	require.True(t, coordinatorAfterRestart.IsReady())
+}
+
+func TestNodesCoordinator_IsReadyStaysFalseAfterFailedLoadState(t *testing.T) {
+	t.Parallel()
+
+	args := createArguments()
+	args.StartEpoch = 1
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+	require.False(t, coordinator.IsReady())
+
+	// no registry saved under this key: LoadState fails and must not flip readiness
+	err = coordinator.LoadState([]byte("missing-key"))
+	require.NotNil(t, err)
+	require.False(t, coordinator.IsReady())
 }

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -1170,6 +1170,61 @@ func TestNodesCoordinator_SetNodesInstallsAuthoritativeLookupBeforeLoadState(t *
 	require.False(t, coordinator.IsReady())
 }
 
+func TestNodesCoordinator_SetNodesKeepsRegistryRestoredCurrentEpochResolvable(t *testing.T) {
+	t.Parallel()
+
+	// cmd/node's fast-bootstrap path fills the constructor with the registry's
+	// real validators for the current epoch and only then calls SetNodes for the
+	// previous epoch. Marking that constructor config non-authoritative would let
+	// the SetNodes call evict the current epoch from the lookup, so every
+	// validator elected in this epoch would resolve as not found until LoadState
+	currentElected := createDummyNodesList(4, "currentElected")
+	prevElected := createDummyNodesList(4, "prevElected")
+
+	args := createArguments()
+	args.Epoch = 5
+	args.StartEpoch = 5
+	args.ElectedNodes = currentElected
+	args.NodesRestoredFromRegistry = true
+
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	err = coordinator.SetNodes(prevElected, createDummyNodesList(1, "prevEligible"), make([]Validator, 0), args.Epoch-1)
+	require.Nil(t, err)
+
+	validator, err := coordinator.GetValidatorWithPublicKey(currentElected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, currentElected[0].PubKey(), validator.PubKey())
+
+	validator, err = coordinator.GetValidatorWithPublicKey(prevElected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, prevElected[0].PubKey(), validator.PubKey())
+}
+
+func TestNodesCoordinator_SetNodesEvictsGenesisSeedingOnly(t *testing.T) {
+	t.Parallel()
+
+	// the mirror case: without registry-restored nodes the constructor holds
+	// approximate genesis seeding, which SetNodes must still be able to evict
+	seeded := createArguments().ElectedNodes
+	restored := createDummyNodesList(4, "restoredElected")
+
+	args := createArguments()
+	args.Epoch = 5
+	args.StartEpoch = 5
+	args.NodesRestoredFromRegistry = false
+
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	err = coordinator.SetNodes(restored, createDummyNodesList(1, "restoredEligible"), make([]Validator, 0), args.Epoch-1)
+	require.Nil(t, err)
+
+	_, err = coordinator.GetValidatorWithPublicKey(seeded[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
 func TestNodesCoordinator_GetValidatorWithPublicKeyBeforeAndAfterLoadState(t *testing.T) {
 	t.Parallel()
 

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -1138,7 +1138,7 @@ func TestNodesCoordinator_LoadStateConversionFailureLeavesStateUntouched(t *test
 	require.Equal(t, uint32(5), coordinator.currentEpoch.Load())
 }
 
-func TestNodesCoordinator_SetNodesUnblocksValidatorLookupBeforeLoadState(t *testing.T) {
+func TestNodesCoordinator_SetNodesInstallsAuthoritativeLookupBeforeLoadState(t *testing.T) {
 	t.Parallel()
 
 	// the fast-bootstrap path (cmd/node) calls SetNodes right after a
@@ -1166,7 +1166,7 @@ func TestNodesCoordinator_SetNodesUnblocksValidatorLookupBeforeLoadState(t *test
 	require.Nil(t, err)
 	require.Equal(t, restored[0].PubKey(), validator.PubKey())
 
-	// the lookup unblocking must not weaken the startup gate
+	// installing authoritative lookup data must not weaken the startup gate
 	require.False(t, coordinator.IsReady())
 }
 

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -1154,9 +1154,10 @@ func TestNodesCoordinator_SetNodesUnblocksValidatorLookupBeforeLoadState(t *test
 	coordinator, err := NewNodesCoordinator(args)
 	require.Nil(t, err)
 
-	// before SetNodes the lookup only holds the genesis seeding and must refuse
+	// before SetNodes the lookup only holds the genesis seeding, so a validator
+	// that is not in the seed is not found
 	_, err = coordinator.GetValidatorWithPublicKey(restored[0].PubKey())
-	require.Equal(t, ErrNodesCoordinatorNotReady, err)
+	require.Equal(t, ErrValidatorNotFound, err)
 
 	err = coordinator.SetNodes(restored, createDummyNodesList(1, "restoredEligible"), make([]Validator, 0), args.Epoch-1)
 	require.Nil(t, err)
@@ -1169,19 +1170,21 @@ func TestNodesCoordinator_SetNodesUnblocksValidatorLookupBeforeLoadState(t *test
 	require.False(t, coordinator.IsReady())
 }
 
-func TestNodesCoordinator_GetValidatorWithPublicKeyNotReady(t *testing.T) {
+func TestNodesCoordinator_GetValidatorWithPublicKeyBeforeAndAfterLoadState(t *testing.T) {
 	t.Parallel()
 
-	// before LoadState a non-genesis coordinator only holds its genesis seeding;
-	// answering from it would present genesis-era data as authoritative to the
-	// p2p peer classification, so the lookup must refuse until ready
-	elected := createDummyNodesList(4, "elected")
+	// before LoadState a non-genesis coordinator holds its genesis seeding;
+	// the lookup is available immediately (for peer classification), but once
+	// LoadState installs authoritative data, old seed-only validators that
+	// were not in the authoritative set stop being resolvable
+	seedElected := createDummyNodesList(4, "seedElected")
+	realElected := createDummyNodesList(4, "realElected")
 	bootStorer := mock.NewStorerMock()
 
 	firstArgs := createArguments()
 	firstArgs.Epoch = 5
 	firstArgs.StartEpoch = 5
-	firstArgs.ElectedNodes = elected
+	firstArgs.ElectedNodes = realElected
 	firstArgs.BootStorer = bootStorer
 	firstCoordinator, err := NewNodesCoordinator(firstArgs)
 	require.Nil(t, err)
@@ -1193,20 +1196,25 @@ func TestNodesCoordinator_GetValidatorWithPublicKeyNotReady(t *testing.T) {
 	secondArgs := createArguments()
 	secondArgs.Epoch = 5
 	secondArgs.StartEpoch = 5
-	secondArgs.ElectedNodes = elected
+	secondArgs.ElectedNodes = seedElected
 	secondArgs.BootStorer = bootStorer
 	coordinator, err := NewNodesCoordinator(secondArgs)
 	require.Nil(t, err)
 
-	_, err = coordinator.GetValidatorWithPublicKey(elected[0].PubKey())
-	require.Equal(t, ErrNodesCoordinatorNotReady, err)
+	// before LoadState: seed data is available for peer classification
+	_, err = coordinator.GetValidatorWithPublicKey(seedElected[0].PubKey())
+	require.Nil(t, err)
 
 	err = coordinator.LoadState(savedStateKey)
 	require.Nil(t, err)
 
-	validator, err := coordinator.GetValidatorWithPublicKey(elected[0].PubKey())
+	// after LoadState: authoritative data replaces seed; only real validators resolve
+	validator, err := coordinator.GetValidatorWithPublicKey(realElected[0].PubKey())
 	require.Nil(t, err)
-	require.Equal(t, elected[0].PubKey(), validator.PubKey())
+	require.Equal(t, realElected[0].PubKey(), validator.PubKey())
+
+	_, err = coordinator.GetValidatorWithPublicKey(seedElected[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
 }
 
 func TestNodesCoordinator_LoadStateLaterEpochWinsForSharedPublicKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Any node that is not yet synchronized (fallback/redundancy node, a validator resyncing after a restart or network interruption, or a late-joining node) lost track of the validator set at an epoch transition or mid-epoch restart, stalling into bursty request-driven sync (missing blocks). This PR fixes the four cooperating causes and makes the failure loud when state restoration is incomplete. The base change is one commit on top of current develop, followed by the review fix-up commits.

## The four parts

**1. Nodes coordinator: rebuild `publicKeyToValidatorMap` on restore**
`LoadState` restores the per-epoch validator configs but never rebuilt the pubkey lookup, so after any mid-epoch restart the p2p validator-originator gate rejected every gossiped header until the next epoch boundary. The map is now rebuilt and published atomically with the configs under one write lock. `SetNodes` had the same defect on the fast-bootstrap path and now rebuilds the map before returning (the epoch config's write lock is scoped so the rebuild can re-acquire it as a read lock without deadlocking); the now-redundant rebuild in `EpochStartPrepare` is removed. The constructor's unconditional initial save also overwrote the previous run's registry on a restart within the install epoch (permanent BLS signature failures after `LoadState` read genesis data back); it is now gated behind `StartEpoch == 0`.

**2. Consensus worker: keep learning validators while not synchronized**
`ProcessReceivedMessage` learns the pid to pk mapping before the not-synchronized early return, after the full validity pipeline (including BLS verification), so only proven validator keys enter the `PeerShardMapper`. `EpochStartAction` refreshes the elected set via `GetConsensusWhitelistedNodes` so `IsNodeInConsensusGroup` accepts new-epoch validators while syncing. The redundancy inactivity reset runs only on fully valid messages; anything else would let an attacker replay the public validator key to block a backup takeover. Related hardening in the same area: the per-(pk, slot, msgType) message budget check-and-increment now shares one critical section (`tryAddMessageTypeToPublicKey`), closing a TOCTOU where concurrent duplicates via distinct peers could all pass while signature verification ran between check and add; the epoch-start notifier now sorts its handler slice under the write lock (it mutated the slice under a read lock) and its `EpochStartPrepare` guarded the prepare callback behind the wrong nil check.

**3. Startup: fail loudly when the coordinator is not restored**
`NodesCoordinator` exposes `IsReady`, and `StartConsensus` returns `ErrNodesCoordinatorNotReadyAfterBootstrap` right after `LoadStorage` when saved state was not restored, instead of starting a node that silently cannot validate. The check runs before `LoadAccount` so a later failure cannot mask the diagnostic.

**4. Peer type provider: refresh the cache after bootstrap**
The peer type cache was built once at construction from genesis data; after a storage bootstrap restored a later epoch it stayed stale. `StartConsensus` now refreshes it with the restored epoch through the heartbeat handler. The construction-time seed does not record a cache epoch, so a refresh for an epoch older than construction (storage walk-back) still applies. Backward epoch moves are applied and logged rather than ordered: both writers carry an authoritative epoch (the epoch-start notification is how a revert arrives, and `RefreshCache` carries the epoch the bootstrap actually restored, which is legitimately older than an epoch start that fired earlier during `LoadStorage`), and there is no asynchronous third writer to order against since block syncing only starts after that call site.

## Behaviour changes (release notes)

**Waiting-list validators change their reported node type from observer to validator.**

`createNewCache` in `core/process/peer/peerTypeProvider.go` now also reads `GetAllWaitingValidatorsKeys`, which does not appear in that file on `develop`. As a result a node in the waiting list is classified `core.WaitingList` instead of falling through `ComputeForPubKey`'s miss path as `core.ObserverList`.

What changes on upgrade:

- `/node/status` reports `MetricNodeType=validator` and `MetricPeerType=waiting` for those nodes, where it previously reported `observer`/`observer`. This follows from `Sender.computePeerList` (`node/heartbeat/process/sender.go:180`), which publishes anything that is not `core.ObserverList` as `core.NodeTypeValidator`.
- `Monitor.GetAllPeerTypeInfos` (`node/heartbeat/process/monitor.go`) emits waiting keys in the heartbeat peer-type list, so waiting nodes appear in `/node/heartbeatstatus` even before any heartbeat is received.
- `MetricLiveValidatorNodes` is unaffected, since `heartbeatMessageInfo.GetIsValidator` counts only elected and eligible. The heartbeat list and that counter therefore disagree about waiting nodes.
- `validatorsProvider.createNewCache` still aggregates only elected and eligible, so the validator-statistics API and the heartbeat peer type disagree for the same key.

The classification is correct (waiting-list nodes are validators, just not elected yet) and no caller needs changing, but anything counting validators off these surfaces (dashboards, the explorer's active-validator count) will shift when this ships.

## Verification

- `go build ./...`, `go vet`, goimports: clean
- `go test -race` green on all touched packages, including `core/process/peer`, whose pre-existing test race (validatorsProvider tests writing fields while the constructor's refresh goroutine runs) is fixed in this PR, so the package is race-gateable again
- Changed-line coverage: 178/178 executable changed lines = 100%
- SonarQube (same analyzer as CI) on all changed production files: 0 new issues on changed lines; the one new finding it raised during the audit (cognitive complexity of `ProcessReceivedMessage`) was fixed by extracting `resetRedundancyInactivityOnValidMessage`
- Audited pre-push by three independent agents (security, code review, Go concurrency) plus an adversarial full-diff pass: no Critical/High findings; every Low finding is fixed in this PR

## Notes for reviewers

- The elected-set refresh intentionally swaps in the broad whitelist while syncing; every state-changing consensus path re-validates against the tight consensus group (`ConsensusGroupIndex`, `SetJobDone`), and `initCurrentSlot` re-narrows the set every slot once synchronized. The `EpochStartAction` comment documents the bounded race, including the fork-revert re-fire path.
- Running the validity pipeline while unsynchronized burns the per-key message budget for that message type; bounded (cleared every slot) and intentional, as the alternative would let unverified pubkeys into the `PeerShardMapper`.

Closes #88
Closes #90
Closes #91

Supersedes #85 and #89.
