### PR TITLE
fix: bound postWSConnection mirror concurrency with a worker pool

### DIFF
--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -1028,10 +1028,11 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 			WSConnectionAPIKey: ctx.GlobalString(WSConnectionApiKey.Name),
 			WSConnectionURL:    ctx.GlobalString(WSConnectionUrl.Name),
 		},
-		APIRoutesConfig: apiRoutesConfig,
-		AccountsState:   stateComponents.AccountsAdapter,
-		KAppsState:      stateComponents.KAppsAdapter,
-		PeerState:       stateComponents.PeersAdapter,
+		APIRoutesConfig:  apiRoutesConfig,
+		AccountsState:    stateComponents.AccountsAdapter,
+		KAppsState:       stateComponents.KAppsAdapter,
+		PeerState:        stateComponents.PeersAdapter,
+		AppStatusHandler: coreComponents.StatusHandler,
 	}
 
 	ef, err := facade.NewNodeFacade(argNodeFacade)

--- a/cmd/operator/utils/http.go
+++ b/cmd/operator/utils/http.go
@@ -60,7 +60,15 @@ func PostURLWithContext(ctx context.Context, url, body string, headers []string,
 	if err != nil {
 		return fmt.Errorf("send POST request: %w", err)
 	}
-	defer func() { _ = r.Body.Close() }()
+	// Draining before Close lets the transport reuse the underlying HTTP/1.x connection;
+	// otherwise it's forced to redial (and re-handshake, for TLS) on the next request. This
+	// matters most when target == nil (the caller doesn't want the body at all, e.g. the
+	// websocket mirror at websocket.go — every 2xx response with a non-empty body would
+	// otherwise pay for a fresh connection).
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(r.Body, maxResponseBody))
+		_ = r.Body.Close()
+	}()
 
 	if err := checkStatus(http.MethodPost, url, r); err != nil {
 		return err
@@ -88,11 +96,20 @@ func checkStatus(method, url string, r *http.Response) error {
 	}
 
 	status := sanitizeServerText(r.Status)
+	// io.ReadAll returns the bytes it did manage to read alongside a non-nil error on a
+	// truncated/hijacked body (e.g. a declared Content-Length the server never delivered) —
+	// keep that partial snippet instead of discarding it. readErr's own message can embed
+	// server-supplied text (net/http's trailer parsing may fold a server header into it), so
+	// sanitize it the same as status/body rather than let it skip the same treatment.
 	snippet, readErr := io.ReadAll(io.LimitReader(r.Body, maxErrorBodySnippet))
-	if readErr != nil {
-		return fmt.Errorf("%s %s: unexpected HTTP status %s (failed to read response body: %w)", method, url, status, readErr)
-	}
 	body := strings.TrimSpace(sanitizeServerText(string(snippet)))
+	if readErr != nil {
+		sanitizedReadErr := sanitizeServerText(readErr.Error())
+		if body == "" {
+			return fmt.Errorf("%s %s: unexpected HTTP status %s (failed to read response body: %s)", method, url, status, sanitizedReadErr)
+		}
+		return fmt.Errorf("%s %s: unexpected HTTP status %s: %s (failed to read response body: %s)", method, url, status, body, sanitizedReadErr)
+	}
 	if body == "" {
 		return fmt.Errorf("%s %s: unexpected HTTP status %s", method, url, status)
 	}

--- a/cmd/operator/utils/http.go
+++ b/cmd/operator/utils/http.go
@@ -49,7 +49,7 @@ func PostURLWithContext(ctx context.Context, url, body string, headers []string,
 	reqBody := strings.NewReader(body)
 	req, errNewReq := http.NewRequestWithContext(ctx, http.MethodPost, url, reqBody)
 	if errNewReq != nil {
-		return errNewReq
+		return fmt.Errorf("create POST request: %w", errNewReq)
 	}
 	req.Header.Add("Content-type", "application/json; charset=UTF-8")
 	for i := 0; i < len(headers); i += 2 {
@@ -58,7 +58,7 @@ func PostURLWithContext(ctx context.Context, url, body string, headers []string,
 
 	r, err := httpClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("send POST request: %w", err)
 	}
 	defer func() { _ = r.Body.Close() }()
 
@@ -69,7 +69,7 @@ func PostURLWithContext(ctx context.Context, url, body string, headers []string,
 	if target != nil {
 		data, errRead := io.ReadAll(io.LimitReader(r.Body, maxResponseBody+1))
 		if errRead != nil {
-			return errRead
+			return fmt.Errorf("read POST response body: %w", errRead)
 		}
 		if int64(len(data)) > maxResponseBody {
 			return fmt.Errorf("%s %s: response body exceeds %d bytes", http.MethodPost, url, maxResponseBody)

--- a/cmd/operator/utils/http.go
+++ b/cmd/operator/utils/http.go
@@ -87,8 +87,11 @@ func checkStatus(method, url string, r *http.Response) error {
 		return nil
 	}
 
-	snippet, _ := io.ReadAll(io.LimitReader(r.Body, maxErrorBodySnippet))
 	status := sanitizeServerText(r.Status)
+	snippet, readErr := io.ReadAll(io.LimitReader(r.Body, maxErrorBodySnippet))
+	if readErr != nil {
+		return fmt.Errorf("%s %s: unexpected HTTP status %s (failed to read response body: %w)", method, url, status, readErr)
+	}
 	body := strings.TrimSpace(sanitizeServerText(string(snippet)))
 	if body == "" {
 		return fmt.Errorf("%s %s: unexpected HTTP status %s", method, url, status)

--- a/cmd/operator/utils/http.go
+++ b/cmd/operator/utils/http.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -38,8 +39,15 @@ func GetURL(url string, target interface{}) error {
 
 // PostURL provides a post using a json string
 func PostURL(url, body string, headers []string, target interface{}) error {
+	return PostURLWithContext(context.Background(), url, body, headers, target)
+}
+
+// PostURLWithContext behaves like PostURL but ties the request to ctx, so a caller can
+// abort an in-flight POST (e.g. on shutdown) instead of waiting out httpClient's fixed
+// timeout.
+func PostURLWithContext(ctx context.Context, url, body string, headers []string, target interface{}) error {
 	reqBody := strings.NewReader(body)
-	req, errNewReq := http.NewRequest(http.MethodPost, url, reqBody)
+	req, errNewReq := http.NewRequestWithContext(ctx, http.MethodPost, url, reqBody)
 	if errNewReq != nil {
 		return errNewReq
 	}

--- a/cmd/operator/utils/http_test.go
+++ b/cmd/operator/utils/http_test.go
@@ -158,6 +158,30 @@ func TestPostURLReturnsErrorOnEmptyBody(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestErrorBodyReadFailureIsWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Declare far more body than we actually send, then close the raw connection —
+		// the client's Read on the error body sees an unexpected EOF instead of a clean
+		// stream, exercising checkStatus's io.ReadAll failure path (previously discarded
+		// via `snippet, _ := io.ReadAll(...)`).
+		w.Header().Set("Content-Length", "1000")
+		w.WriteHeader(http.StatusInternalServerError)
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok, "test server response writer must support hijacking")
+		conn, _, err := hj.Hijack()
+		require.NoError(t, err)
+		_, _ = conn.Write([]byte("short"))
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	var got sampleResult
+	err := utils.GetURL(srv.URL, &got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "failed to read response body")
+}
+
 func TestPostURLNilTargetReturnsNilOnSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/operator/utils/http_test.go
+++ b/cmd/operator/utils/http_test.go
@@ -158,12 +158,12 @@ func TestPostURLReturnsErrorOnEmptyBody(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestErrorBodyReadFailureIsWrapped(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Declare far more body than we actually send, then close the raw connection —
-		// the client's Read on the error body sees an unexpected EOF instead of a clean
-		// stream, exercising checkStatus's io.ReadAll failure path (previously discarded
-		// via `snippet, _ := io.ReadAll(...)`).
+// newHijackingServer declares far more body than it actually sends, then closes the raw
+// connection — the client's Read on the error body sees an unexpected EOF instead of a
+// clean stream, exercising checkStatus's io.ReadAll failure path.
+func newHijackingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", "1000")
 		w.WriteHeader(http.StatusInternalServerError)
 		hj, ok := w.(http.Hijacker)
@@ -173,13 +173,35 @@ func TestErrorBodyReadFailureIsWrapped(t *testing.T) {
 		_, _ = conn.Write([]byte("short"))
 		_ = conn.Close()
 	}))
-	defer srv.Close()
+}
 
-	var got sampleResult
-	err := utils.GetURL(srv.URL, &got)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "500")
-	assert.Contains(t, err.Error(), "failed to read response body")
+// TestErrorBodyReadFailureIsWrapped covers checkStatus's io.ReadAll failure path from
+// both callers that share it: the partial "short" body it did manage to read before the
+// failure must survive into the error message (previously discarded via
+// `snippet, _ := io.ReadAll(...)`), for GetURL and PostURL alike.
+func TestErrorBodyReadFailureIsWrapped(t *testing.T) {
+	t.Run("GetURL", func(t *testing.T) {
+		srv := newHijackingServer(t)
+		defer srv.Close()
+
+		var got sampleResult
+		err := utils.GetURL(srv.URL, &got)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+		assert.Contains(t, err.Error(), "failed to read response body")
+		assert.Contains(t, err.Error(), "short", "partial body read before the failure must not be discarded")
+	})
+
+	t.Run("PostURL", func(t *testing.T) {
+		srv := newHijackingServer(t)
+		defer srv.Close()
+
+		err := utils.PostURL(srv.URL, `{}`, nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+		assert.Contains(t, err.Error(), "failed to read response body")
+		assert.Contains(t, err.Error(), "short", "partial body read before the failure must not be discarded")
+	})
 }
 
 func TestPostURLNilTargetReturnsNilOnSuccess(t *testing.T) {

--- a/common/facade/nodeFacade.go
+++ b/common/facade/nodeFacade.go
@@ -33,6 +33,7 @@ import (
 	"github.com/klever-io/klever-go/network/api/validator"
 	"github.com/klever-io/klever-go/node/heartbeat/data"
 	"github.com/klever-io/klever-go/ntp"
+	"github.com/klever-io/klever-go/statusHandler"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/klever-io/klever-go/tools/debug"
 )
@@ -67,6 +68,9 @@ type ArgNodeFacade struct {
 	AccountsState          state.AccountsAdapter
 	KAppsState             state.AccountsAdapter
 	PeerState              state.AccountsAdapter
+	// AppStatusHandler is optional; a nil value here yields a no-op handler (see
+	// NewNodeFacade) rather than requiring every caller to supply one.
+	AppStatusHandler core.AppStatusHandler
 }
 
 // nodeFacade represents a facade for grouping the functionality for the node
@@ -83,6 +87,7 @@ type nodeFacade struct {
 	accountsState          state.AccountsAdapter
 	kappsState             state.AccountsAdapter
 	peerState              state.AccountsAdapter
+	appStatusHandler       core.AppStatusHandler
 	ctx                    context.Context
 	cancelFunc             func()
 }
@@ -119,6 +124,11 @@ func NewNodeFacade(arg ArgNodeFacade) (*nodeFacade, error) {
 
 	throttlersMap := computeEndpointsNumGoRoutinesThrottlers(arg.WsAntifloodConfig)
 
+	appStatusHandler := arg.AppStatusHandler
+	if check.IfNil(appStatusHandler) {
+		appStatusHandler = statusHandler.NewNilStatusHandler()
+	}
+
 	nf := &nodeFacade{
 		node:                   arg.Node,
 		apiResolver:            arg.APIResolver,
@@ -130,6 +140,7 @@ func NewNodeFacade(arg ArgNodeFacade) (*nodeFacade, error) {
 		accountsState:          arg.AccountsState,
 		kappsState:             arg.KAppsState,
 		peerState:              arg.PeerState,
+		appStatusHandler:       appStatusHandler,
 	}
 	nf.ctx, nf.cancelFunc = context.WithCancel(context.Background())
 
@@ -383,6 +394,23 @@ func (nf *nodeFacade) WSMaxAddressesPerSubscribe() uint32 {
 // /subscribe (0 = built-in default).
 func (nf *nodeFacade) WSMaxAddressesPerClient() uint32 {
 	return nf.wsAntifloodConfig.WebSocketMaxAddressesPerClient
+}
+
+// WSPostWorkers returns the cap on concurrent postWSConnection mirror requests
+// (0 = built-in default).
+func (nf *nodeFacade) WSPostWorkers() uint32 {
+	return nf.wsAntifloodConfig.WebSocketPostWorkers
+}
+
+// WSPostQueueSize returns the cap on pending mirror sends queued behind WSPostWorkers
+// (0 = built-in default).
+func (nf *nodeFacade) WSPostQueueSize() uint32 {
+	return nf.wsAntifloodConfig.WebSocketPostQueueSize
+}
+
+// AppStatusHandler returns the node's status/metrics sink (never nil — see NewNodeFacade).
+func (nf *nodeFacade) AppStatusHandler() core.AppStatusHandler {
+	return nf.appStatusHandler
 }
 
 /***********

--- a/common/facade/nodeFacade_test.go
+++ b/common/facade/nodeFacade_test.go
@@ -50,6 +50,8 @@ func TestNodeFacade_WSLimitGetters(t *testing.T) {
 	args.WsAntifloodConfig.WebSocketConnectionsPerIP = 56
 	args.WsAntifloodConfig.WebSocketMaxAddressesPerSubscribe = 78
 	args.WsAntifloodConfig.WebSocketMaxAddressesPerClient = 9012
+	args.WsAntifloodConfig.WebSocketPostWorkers = 34
+	args.WsAntifloodConfig.WebSocketPostQueueSize = 5678
 
 	nf, err := facade.NewNodeFacade(args)
 	require.NoError(t, err)
@@ -58,6 +60,8 @@ func TestNodeFacade_WSLimitGetters(t *testing.T) {
 	require.Equal(t, uint32(56), nf.WSMaxConnectionsPerIP())
 	require.Equal(t, uint32(78), nf.WSMaxAddressesPerSubscribe())
 	require.Equal(t, uint32(9012), nf.WSMaxAddressesPerClient())
+	require.Equal(t, uint32(34), nf.WSPostWorkers())
+	require.Equal(t, uint32(5678), nf.WSPostQueueSize())
 }
 
 func TestNewNodeFacade(t *testing.T) {

--- a/config/antiflood.go
+++ b/config/antiflood.go
@@ -56,6 +56,12 @@ type WebServerAntifloodConfig struct {
 	// WebSocketMaxAddressesPerClient caps the total addresses one connection may watch
 	// across all of its subscribe calls. 0 = built-in default.
 	WebSocketMaxAddressesPerClient uint32 `yaml:"webSocketMaxAddressesPerClient"`
+	// WebSocketPostWorkers bounds concurrent postWSConnection mirror requests. 0 = built-in
+	// default.
+	WebSocketPostWorkers uint32 `yaml:"webSocketPostWorkers"`
+	// WebSocketPostQueueSize bounds pending mirror sends queued behind
+	// WebSocketPostWorkers before new ones are dropped. 0 = built-in default.
+	WebSocketPostQueueSize uint32 `yaml:"webSocketPostQueueSize"`
 }
 
 // TopicMaxMessagesConfig will hold the maximum number of messages/sec per topic value

--- a/config/node/config.yaml
+++ b/config/node/config.yaml
@@ -199,6 +199,11 @@ antiflood:
     # WebSocketMaxAddressesPerClient caps the total addresses one connection may watch across all
     # of its subscribe calls. 0 = default.
     webSocketMaxAddressesPerClient: 50000
+    # WebSocketPostWorkers bounds concurrent postWSConnection mirror requests. 0 = default.
+    webSocketPostWorkers: 8
+    # WebSocketPostQueueSize bounds pending mirror sends queued behind webSocketPostWorkers
+    # before new ones are dropped. 0 = default.
+    webSocketPostQueueSize: 1000
     # EndpointsThrottlers represents a map for maximum simultaneous go routines for an endpoint
     endpointsThrottlers:
       - endpoint: /transaction/:hash

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -306,3 +306,9 @@ const MetricClockOffsetNs = "klv_clock_offset_ns"
 
 // MetricClockLastSyncTimestamp is the metric for the unix-seconds timestamp of the last successful NTP sync (0 before first success)
 const MetricClockLastSyncTimestamp = "klv_clock_last_sync_timestamp"
+
+// MetricWSMirrorQueueDroppedTotal is the cumulative count of /subscribe mirror events dropped because the mirror worker queue was full
+const MetricWSMirrorQueueDroppedTotal = "klv_ws_mirror_queue_dropped_total"
+
+// MetricWSMirrorPostFailuresTotal is the cumulative count of /subscribe mirror POST requests that failed
+const MetricWSMirrorPostFailuresTotal = "klv_ws_mirror_post_failures_total"

--- a/network/api/api.go
+++ b/network/api/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gorilla/websocket"
 	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/config"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/network/api/address"
 	"github.com/klever-io/klever-go/network/api/asset"
 	"github.com/klever-io/klever-go/network/api/block"
@@ -152,12 +153,16 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 		var postConnUrl, postConnApiKey string
 		var subscribeOpts wsocket.SubscribeOptions
 		var hubLimits clientSocket.Limits
+		var appStatusHandler core.AppStatusHandler
 		if ok {
 			postConnUrl, postConnApiKey = apiHandler.WSConnectionURL(), apiHandler.WSConnectionAPIKey()
 			subscribeOpts.MaxConnections = apiHandler.WSMaxConnections()
 			subscribeOpts.MaxConnectionsPerIP = apiHandler.WSMaxConnectionsPerIP()
 			hubLimits.MaxAddressesPerSubscribe = wsocket.ClampUint32ToInt(apiHandler.WSMaxAddressesPerSubscribe())
 			hubLimits.MaxAddressesPerClient = wsocket.ClampUint32ToInt(apiHandler.WSMaxAddressesPerClient())
+			hubLimits.PostWorkers = wsocket.ClampUint32ToInt(apiHandler.WSPostWorkers())
+			hubLimits.PostQueueSize = wsocket.ClampUint32ToInt(apiHandler.WSPostQueueSize())
+			appStatusHandler = apiHandler.AppStatusHandler()
 		}
 		// Honour `secured: true` for /subscribe. The route is registered directly on the
 		// engine (not via the RouterWrapper), so the auth handler must be applied here or
@@ -173,6 +178,7 @@ func RegisterRoutes(ctx context.Context, ws *gin.Engine, routesConfig config.API
 
 		indexer.UseEventQueue = true
 		hub := clientSocket.NewHub(postConnUrl, postConnApiKey, wsFacade, hubLimits)
+		hub.SetAppStatusHandler(appStatusHandler)
 		wsocket.SubscribeTopics(ws, hub, subscribeOpts)
 		go hub.StartServer(ctx)
 	}

--- a/network/api/interface.go
+++ b/network/api/interface.go
@@ -1,6 +1,9 @@
 package api
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/klever-io/klever-go/core"
+)
 
 // MiddlewareProcessor defines a processor used internally by the web server when processing requests
 type MiddlewareProcessor interface {
@@ -19,5 +22,12 @@ type MainAPIHandler interface {
 	WSMaxConnectionsPerIP() uint32
 	WSMaxAddressesPerSubscribe() uint32
 	WSMaxAddressesPerClient() uint32
+	WSPostWorkers() uint32
+	WSPostQueueSize() uint32
+	// AppStatusHandler exposes the node's status/metrics sink, so the /subscribe mirror
+	// worker pool can export its drop/failure counters (see
+	// core.MetricWSMirrorQueueDroppedTotal/MetricWSMirrorPostFailuresTotal) alongside every
+	// other node metric instead of only logging them.
+	AppStatusHandler() core.AppStatusHandler
 	IsInterfaceNil() bool
 }

--- a/network/api/mock/facade.go
+++ b/network/api/mock/facade.go
@@ -115,6 +115,21 @@ func (f *Facade) WSMaxAddressesPerClient() uint32 {
 	return 0
 }
 
+// WSPostWorkers -
+func (f *Facade) WSPostWorkers() uint32 {
+	return 0
+}
+
+// WSPostQueueSize -
+func (f *Facade) WSPostQueueSize() uint32 {
+	return 0
+}
+
+// AppStatusHandler -
+func (f *Facade) AppStatusHandler() core.AppStatusHandler {
+	return nil
+}
+
 // TpsBenchmark is the mock implementation for retreiving the TpsBenchmark
 func (f *Facade) TpsBenchmark() *statistics.TpsBenchmark {
 	if f.TpsBenchmarkHandler != nil {

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -26,6 +26,18 @@ const (
 	// string can never match a real address and would only feed a per-connection
 	// memory-amplification path (GHSA-4fwh-wrm6-97xm).
 	maxEncodedAddressLength = 62
+
+	// postWorkerCount bounds how many postWSConnection mirror requests run concurrently.
+	// Without a cap, a slow or unresponsive mirror endpoint turns every account/tx event
+	// into an unbounded pile of in-flight goroutines and sockets, scaling with chain
+	// throughput rather than with the mirror's actual capacity.
+	postWorkerCount = 8
+
+	// postQueueSize bounds how many pending mirror sends can queue behind postWorkerCount
+	// before new ones are dropped (mirroring the EventQueue drop-on-full pattern in
+	// indexer/events.go), so a stalled mirror endpoint sheds load instead of growing without
+	// bound.
+	postQueueSize = 1000
 )
 
 // pingPeriod and pongWait are the /subscribe keepalive timings. They are vars only so

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -27,17 +27,18 @@ const (
 	// memory-amplification path (GHSA-4fwh-wrm6-97xm).
 	maxEncodedAddressLength = 62
 
-	// postWorkerCount bounds how many postWSConnection mirror requests run concurrently.
-	// Without a cap, a slow or unresponsive mirror endpoint turns every account/tx event
-	// into an unbounded pile of in-flight goroutines and sockets, scaling with chain
-	// throughput rather than with the mirror's actual capacity.
-	postWorkerCount = 8
+	// defaultPostWorkerCount bounds how many postWSConnection mirror requests run
+	// concurrently, when PostWorkers is unset. Without a cap, a slow or unresponsive
+	// mirror endpoint turns every account/tx event into an unbounded pile of in-flight
+	// goroutines and sockets, scaling with chain throughput rather than with the mirror's
+	// actual capacity.
+	defaultPostWorkerCount = 8
 
-	// postQueueSize bounds how many pending mirror sends can queue behind postWorkerCount
-	// before new ones are dropped (mirroring the EventQueue drop-on-full pattern in
-	// indexer/events.go), so a stalled mirror endpoint sheds load instead of growing without
-	// bound.
-	postQueueSize = 1000
+	// defaultPostQueueSize bounds how many pending mirror sends can queue behind
+	// postWorkerCount before new ones are dropped (mirroring the EventQueue drop-on-full
+	// pattern in indexer/events.go), when PostQueueSize is unset — so a stalled mirror
+	// endpoint sheds load instead of growing without bound.
+	defaultPostQueueSize = 1000
 )
 
 // pingPeriod and pongWait are the /subscribe keepalive timings. They are vars only so
@@ -55,6 +56,12 @@ var (
 type Limits struct {
 	MaxAddressesPerSubscribe int
 	MaxAddressesPerClient    int
+	// PostWorkers bounds concurrent postWSConnection mirror requests; 0 uses
+	// defaultPostWorkerCount.
+	PostWorkers int
+	// PostQueueSize bounds pending mirror sends queued behind PostWorkers; 0 uses
+	// defaultPostQueueSize.
+	PostQueueSize int
 }
 
 // resolvedLimits holds the effective limits after defaults are applied.
@@ -62,6 +69,8 @@ type resolvedLimits struct {
 	maxAddressesPerSubscribe int
 	maxAddressesPerClient    int
 	maxMessageSize           int64
+	postWorkers              int
+	postQueueSize            int
 }
 
 func (l Limits) resolve() resolvedLimits {
@@ -84,9 +93,20 @@ func (l Limits) resolve() resolvedLimits {
 		readLimit = derived
 	}
 
+	postWorkers := l.PostWorkers
+	if postWorkers <= 0 {
+		postWorkers = defaultPostWorkerCount
+	}
+	postQueueSize := l.PostQueueSize
+	if postQueueSize <= 0 {
+		postQueueSize = defaultPostQueueSize
+	}
+
 	return resolvedLimits{
 		maxAddressesPerSubscribe: perSubscribe,
 		maxAddressesPerClient:    perClient,
 		maxMessageSize:           readLimit,
+		postWorkers:              postWorkers,
+		postQueueSize:            postQueueSize,
 	}
 }

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -160,6 +160,14 @@ func TestLimits_Resolve_AppliesDefaults(t *testing.T) {
 	assert.Equal(t, defaultMaxAddressesPerSubscribe, r.maxAddressesPerSubscribe)
 	assert.Equal(t, defaultMaxAddressesPerClient, r.maxAddressesPerClient)
 	assert.Equal(t, int64(minMaxMessageSize), r.maxMessageSize, "default read limit is the floor")
+	assert.Equal(t, defaultPostWorkerCount, r.postWorkers)
+	assert.Equal(t, defaultPostQueueSize, r.postQueueSize)
+}
+
+func TestLimits_Resolve_OverridesPostWorkerLimits(t *testing.T) {
+	r := Limits{PostWorkers: 3, PostQueueSize: 42}.resolve()
+	assert.Equal(t, 3, r.postWorkers)
+	assert.Equal(t, 42, r.postQueueSize)
 }
 
 func TestLimits_Resolve_DerivesReadLimitFromAddressCap(t *testing.T) {

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/klever-io/klever-go/cmd/operator/utils"
 
@@ -25,7 +27,31 @@ const (
 	errMissingNonceHash = "must provide nonce or hash"
 	errTxNotFound       = "transaction not found"
 	errBlockNotFound    = "block not found"
+
+	postQueueDropLogIntervalSeconds = 10
 )
+
+var (
+	droppedPostCount   int64
+	lastPostDropLogged int64
+)
+
+// logPostQueueDrop rate-limits the "mirror queue full" warning so a sustained stall
+// against a slow postConnectionURL logs a periodic summary instead of one line per
+// dropped event.
+func logPostQueueDrop() {
+	atomic.AddInt64(&droppedPostCount, 1)
+	now := time.Now().Unix()
+	last := atomic.LoadInt64(&lastPostDropLogged)
+	if now-last < postQueueDropLogIntervalSeconds {
+		return
+	}
+	if !atomic.CompareAndSwapInt64(&lastPostDropLogged, last, now) {
+		return
+	}
+	count := atomic.SwapInt64(&droppedPostCount, 0)
+	log.Warn("ws.EventReceive.postWSConnection", "msg", "mirror queue full, dropping events", "droppedCount", count)
+}
 
 type userOptions struct {
 	acceptAccount     bool
@@ -43,12 +69,21 @@ type SocketHub struct {
 	clientAddresses         map[*client]int
 	limits                  resolvedLimits
 	unregister              chan *client
+	// postQueue feeds the bounded postWSConnection worker pool; nil when the mirror is
+	// disabled (no URL/API key configured), so asyncPost is a no-op and never allocates a
+	// goroutine or channel slot for a feature nobody turned on.
+	postQueue chan *Send
 }
 
 func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade, limits ...Limits) *SocketHub {
 	var l Limits
 	if len(limits) > 0 {
 		l = limits[0]
+	}
+
+	var postQueue chan *Send
+	if postConnectionURL != "" || postConnectionAPIKey != "" {
+		postQueue = make(chan *Send, postQueueSize)
 	}
 
 	return &SocketHub{
@@ -61,6 +96,7 @@ func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade, lim
 		postConnectionAPIKey:    postConnectionAPIKey,
 		facade:                  facade,
 		limits:                  l.resolve(),
+		postQueue:               postQueue,
 	}
 }
 
@@ -74,12 +110,40 @@ func (h *SocketHub) MaxAddressesPerSubscribe() int {
 	return h.limits.maxAddressesPerSubscribe
 }
 
+// asyncPost hands parsed to the bounded post-mirror worker pool. It is a pure no-op when
+// the mirror isn't configured, and drops (with a rate-limited warning) rather than block
+// or grow without bound when postWorkerCount workers are all busy with a slow endpoint.
 func (h *SocketHub) asyncPost(parsed *Send) {
-	go func() {
-		if err := h.postWSConnection(parsed); err != nil {
-			log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
-		}
-	}()
+	if h.postQueue == nil {
+		return
+	}
+	select {
+	case h.postQueue <- parsed:
+	default:
+		logPostQueueDrop()
+	}
+}
+
+// startPostWorkers runs postWorkerCount goroutines draining postQueue until ctx is done.
+// No-op when the mirror is disabled (postQueue == nil).
+func (h *SocketHub) startPostWorkers(ctx context.Context) {
+	if h.postQueue == nil {
+		return
+	}
+	for i := 0; i < postWorkerCount; i++ {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case parsed := <-h.postQueue:
+					if err := h.postWSConnection(parsed); err != nil {
+						log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
+					}
+				}
+			}
+		}()
+	}
 }
 
 func (h *SocketHub) notifyAddressSubscribers(address string, parsed *Send, filterFn func(userOptions) bool) {
@@ -128,6 +192,7 @@ func (h *SocketHub) marshalAndPost(evType indexer.EventType, address, hash strin
 }
 
 func (h *SocketHub) StartServer(ctx context.Context) {
+	h.startPostWorkers(ctx)
 	for {
 		select {
 		case <-ctx.Done():

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -145,6 +145,13 @@ func (h *SocketHub) startPostWorkers(ctx context.Context) {
 				case <-ctx.Done():
 					return
 				case parsed := <-h.postQueue:
+					// select has no case priority: ctx.Done() and postQueue can both be
+					// ready at once, so a cancelled shutdown can still dequeue one more
+					// item. Check ctx.Err() before posting instead of starting (and
+					// immediately failing) a doomed request.
+					if ctx.Err() != nil {
+						return
+					}
 					if err := h.postWSConnection(ctx, parsed); err != nil {
 						log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
 					}

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -12,8 +12,12 @@ import (
 	"github.com/klever-io/klever-go/cmd/operator/utils"
 
 	logger "github.com/klever-io/klever-go-logger"
+	"github.com/klever-io/klever-go/core"
 	indexer "github.com/klever-io/klever-go/indexer"
 	"github.com/klever-io/klever-go/indexer/data"
+	"github.com/klever-io/klever-go/statusHandler"
+	atomicPkg "github.com/klever-io/klever-go/tools/atomic"
+	"github.com/klever-io/klever-go/tools/check"
 )
 
 var log = logger.GetOrCreate("websocket")
@@ -31,26 +35,41 @@ const (
 	postQueueDropLogIntervalSeconds = 10
 )
 
-var (
-	droppedPostCount   int64
-	lastPostDropLogged int64
-)
+// dropWarner rate-limits a recurring warning behind a fixed window: every occurrence
+// calls fire(), which folds the count since the last log into one summary line at most
+// once per window instead of logging every single occurrence. Deliberately a per-instance
+// value (unlike indexer.trySendEvent's package-global rate-limit vars, which use the same
+// pattern but are intentionally left alone — see PR discussion) so two independent
+// warning sources on the same hub (queue-full drops vs. post failures) can't share, or
+// reset, each other's windows.
+type dropWarner struct {
+	count      atomicPkg.Counter
+	lastLogged int64 // unix seconds; accessed only via sync/atomic
+	windowSecs int64
+}
 
-// logPostQueueDrop rate-limits the "mirror queue full" warning so a sustained stall
-// against a slow postConnectionURL logs a periodic summary instead of one line per
-// dropped event.
-func logPostQueueDrop() {
-	atomic.AddInt64(&droppedPostCount, 1)
+// fire records one occurrence and reports (count, true) with the number of occurrences
+// folded into the window (including this one) at most once per windowSecs; otherwise
+// reports (0, false).
+func (w *dropWarner) fire() (int64, bool) {
+	w.count.Increment()
 	now := time.Now().Unix()
-	last := atomic.LoadInt64(&lastPostDropLogged)
-	if now-last < postQueueDropLogIntervalSeconds {
-		return
+	last := atomic.LoadInt64(&w.lastLogged)
+	if now-last < w.windowSecs {
+		return 0, false
 	}
-	if !atomic.CompareAndSwapInt64(&lastPostDropLogged, last, now) {
-		return
+	if !atomic.CompareAndSwapInt64(&w.lastLogged, last, now) {
+		return 0, false
 	}
-	count := atomic.SwapInt64(&droppedPostCount, 0)
-	log.Warn("ws.EventReceive.postWSConnection", "msg", "mirror queue full, dropping events", "droppedCount", count)
+	return w.count.Reset(), true
+}
+
+// flush reports any occurrences still pending in the current window (count > 0) — used
+// on worker shutdown so a burst that never reaches another occurrence to trigger the next
+// window doesn't sit unreported, or get misattributed to some unrelated later window.
+func (w *dropWarner) flush() (int64, bool) {
+	count := w.count.Reset()
+	return count, count > 0
 }
 
 type userOptions struct {
@@ -70,12 +89,34 @@ type SocketHub struct {
 	limits                  resolvedLimits
 	unregister              chan *client
 	// postQueue feeds the bounded postWSConnection worker pool; nil when the mirror is
-	// disabled (no URL/API key configured), so asyncPost is a no-op and never allocates a
-	// goroutine or channel slot for a feature nobody turned on.
+	// disabled (no URL configured — see NewHub), so asyncPost is a no-op and never
+	// allocates a goroutine or channel slot for a feature nobody turned on.
 	postQueue chan *Send
 	// postWorkersWG tracks live post workers so StartServer's shutdown can wait for them
 	// to actually exit rather than returning while one is still mid-request.
 	postWorkersWG sync.WaitGroup
+	// queueDropWarn/postFailWarn are per-hub (not package-global) rate-limited warning
+	// state for, respectively, the mirror queue being full and a post to the mirror
+	// failing — kept separate so a burst of one kind can't reset or share the other's
+	// window.
+	queueDropWarn dropWarner
+	postFailWarn  dropWarner
+	// appStatusHandler exports the mirror's cumulative drop/failure counts (see
+	// MetricWSMirrorQueueDroppedTotal/MetricWSMirrorPostFailuresTotal) alongside the
+	// rate-limited WARN logs above — the log is a periodic sample, this is the exact
+	// total. Defaults to a no-op handler (see NewHub) so it's always safe to call without
+	// a nil check; SetAppStatusHandler swaps in a real one.
+	appStatusHandler core.AppStatusHandler
+}
+
+// SetAppStatusHandler wires ash in to receive the mirror's drop/failure counters. Safe to
+// call with a nil ash (no-op, keeps the current handler) so a caller can pass through
+// whatever it has without its own nil check.
+func (h *SocketHub) SetAppStatusHandler(ash core.AppStatusHandler) {
+	if check.IfNil(ash) {
+		return
+	}
+	h.appStatusHandler = ash
 }
 
 func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade, limits ...Limits) *SocketHub {
@@ -83,10 +124,17 @@ func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade, lim
 	if len(limits) > 0 {
 		l = limits[0]
 	}
+	resolved := l.resolve()
 
+	// The mirror requires a URL: an API key with no URL can never succeed (every request
+	// fails inside the HTTP client with "no Host in request URL"), so treating URL as the
+	// single source of truth for whether the mirror is enabled means postWSConnection's
+	// own now-removed URL/key check could never disagree with it.
 	var postQueue chan *Send
-	if postConnectionURL != "" || postConnectionAPIKey != "" {
-		postQueue = make(chan *Send, postQueueSize)
+	if postConnectionURL != "" {
+		postQueue = make(chan *Send, resolved.postQueueSize)
+	} else if postConnectionAPIKey != "" {
+		log.Warn("ws.NewHub", "msg", "postConnectionAPIKey set without postConnectionURL; mirror stays disabled")
 	}
 
 	return &SocketHub{
@@ -98,8 +146,11 @@ func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade, lim
 		postConnectionURL:       postConnectionURL,
 		postConnectionAPIKey:    postConnectionAPIKey,
 		facade:                  facade,
-		limits:                  l.resolve(),
+		limits:                  resolved,
 		postQueue:               postQueue,
+		queueDropWarn:           dropWarner{windowSecs: postQueueDropLogIntervalSeconds},
+		postFailWarn:            dropWarner{windowSecs: postQueueDropLogIntervalSeconds},
+		appStatusHandler:        statusHandler.NewNilStatusHandler(),
 	}
 }
 
@@ -123,7 +174,10 @@ func (h *SocketHub) asyncPost(parsed *Send) {
 	select {
 	case h.postQueue <- parsed:
 	default:
-		logPostQueueDrop()
+		h.appStatusHandler.Increment(core.MetricWSMirrorQueueDroppedTotal)
+		if count, ok := h.queueDropWarn.fire(); ok {
+			log.Warn("ws.EventReceive.postWSConnection", "msg", "mirror queue full, dropping events", "droppedCount", count)
+		}
 	}
 }
 
@@ -136,7 +190,7 @@ func (h *SocketHub) startPostWorkers(ctx context.Context) {
 	if h.postQueue == nil {
 		return
 	}
-	for i := 0; i < postWorkerCount; i++ {
+	for i := 0; i < h.limits.postWorkers; i++ {
 		h.postWorkersWG.Add(1)
 		go func() {
 			defer h.postWorkersWG.Done()
@@ -150,10 +204,14 @@ func (h *SocketHub) startPostWorkers(ctx context.Context) {
 					// item. Check ctx.Err() before posting instead of starting (and
 					// immediately failing) a doomed request.
 					if ctx.Err() != nil {
+						log.Warn("ws.EventReceive.postWSConnection", "msg", "shutdown: abandoning mirror queue", "pending", len(h.postQueue)+1)
 						return
 					}
 					if err := h.postWSConnection(ctx, parsed); err != nil {
-						log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
+						h.appStatusHandler.Increment(core.MetricWSMirrorPostFailuresTotal)
+						if count, ok := h.postFailWarn.fire(); ok {
+							log.Warn("ws.EventReceive.postWSConnection", "msg", "failed to post to mirror", "failedCount", count, "lastError", err.Error())
+						}
 					}
 				}
 			}
@@ -214,6 +272,17 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 			log.Info("delete all client and close gracefully")
 			h.deleteAll()
 			h.postWorkersWG.Wait()
+			// A burst that never reaches another occurrence to trigger fire()'s next
+			// window would otherwise sit unreported in the counter — possibly forever, if
+			// the hub shuts down before the next log fires — or get misattributed to some
+			// unrelated later window on hub reuse. Flush both here, once, after every
+			// worker has actually exited.
+			if count, ok := h.queueDropWarn.flush(); ok {
+				log.Warn("ws.EventReceive.postWSConnection", "msg", "mirror queue full, dropping events (final)", "droppedCount", count)
+			}
+			if count, ok := h.postFailWarn.flush(); ok {
+				log.Warn("ws.EventReceive.postWSConnection", "msg", "failed to post to mirror (final)", "failedCount", count)
+			}
 			return
 		case client := <-h.unregister:
 			h.handleClientDelete(client)
@@ -302,11 +371,12 @@ func (h *SocketHub) handleBroadcastEvent(event indexer.Event, subscription map[*
 	h.broadcastToSubscription(parsed, subscription)
 }
 
+// postWSConnection is only ever invoked from startPostWorkers's dequeue loop, which only
+// runs at all when postQueue != nil — and NewHub only allocates postQueue when
+// postConnectionURL is set — so postConnectionURL is guaranteed non-empty here; no local
+// empty-config guard needed (the direct-call tests exercise that invariant instead, see
+// TestNewHub_PostQueueAllocatedOnlyWhenConfigured).
 func (h *SocketHub) postWSConnection(ctx context.Context, message *Send) error {
-	if h.postConnectionURL == "" && h.postConnectionAPIKey == "" {
-		return nil
-	}
-
 	b, err := json.Marshal(message)
 	if err != nil {
 		return err

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -73,6 +73,9 @@ type SocketHub struct {
 	// disabled (no URL/API key configured), so asyncPost is a no-op and never allocates a
 	// goroutine or channel slot for a feature nobody turned on.
 	postQueue chan *Send
+	// postWorkersWG tracks live post workers so StartServer's shutdown can wait for them
+	// to actually exit rather than returning while one is still mid-request.
+	postWorkersWG sync.WaitGroup
 }
 
 func NewHub(postConnectionURL, postConnectionAPIKey string, facade WSFacade, limits ...Limits) *SocketHub {
@@ -125,19 +128,24 @@ func (h *SocketHub) asyncPost(parsed *Send) {
 }
 
 // startPostWorkers runs postWorkerCount goroutines draining postQueue until ctx is done.
-// No-op when the mirror is disabled (postQueue == nil).
+// No-op when the mirror is disabled (postQueue == nil). Each worker is tracked in
+// postWorkersWG so StartServer's shutdown can wait for them to actually exit — ctx is
+// threaded into the HTTP call itself (via postWSConnection) so an in-flight request is
+// aborted promptly on cancellation instead of running out its full timeout.
 func (h *SocketHub) startPostWorkers(ctx context.Context) {
 	if h.postQueue == nil {
 		return
 	}
 	for i := 0; i < postWorkerCount; i++ {
+		h.postWorkersWG.Add(1)
 		go func() {
+			defer h.postWorkersWG.Done()
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				case parsed := <-h.postQueue:
-					if err := h.postWSConnection(parsed); err != nil {
+					if err := h.postWSConnection(ctx, parsed); err != nil {
 						log.Warn("ws.EventReceive.postWSConnection", "failed to post", err.Error())
 					}
 				}
@@ -198,6 +206,7 @@ func (h *SocketHub) StartServer(ctx context.Context) {
 		case <-ctx.Done():
 			log.Info("delete all client and close gracefully")
 			h.deleteAll()
+			h.postWorkersWG.Wait()
 			return
 		case client := <-h.unregister:
 			h.handleClientDelete(client)
@@ -286,7 +295,7 @@ func (h *SocketHub) handleBroadcastEvent(event indexer.Event, subscription map[*
 	h.broadcastToSubscription(parsed, subscription)
 }
 
-func (h *SocketHub) postWSConnection(message *Send) error {
+func (h *SocketHub) postWSConnection(ctx context.Context, message *Send) error {
 	if h.postConnectionURL == "" && h.postConnectionAPIKey == "" {
 		return nil
 	}
@@ -296,7 +305,7 @@ func (h *SocketHub) postWSConnection(message *Send) error {
 		return err
 	}
 
-	return utils.PostURL(h.postConnectionURL, string(b), []string{"x-api-key", h.postConnectionAPIKey}, nil)
+	return utils.PostURLWithContext(ctx, h.postConnectionURL, string(b), []string{"x-api-key", h.postConnectionAPIKey}, nil)
 }
 
 type Send struct {

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -731,7 +731,10 @@ func TestAsyncPost_DeliversToWorker(t *testing.T) {
 	select {
 	case received := <-receivedCh:
 		require.NoError(t, received.err)
-		assert.NotEmpty(t, received.body)
+		assert.JSONEq(t,
+			`{"type":"blocks","address":"","hash":"","data":{"nonce":1}}`,
+			string(received.body),
+		)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for mirrored POST")
 	}

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -9,10 +9,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	ws "github.com/gorilla/websocket"
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/data/api"
 	indexer "github.com/klever-io/klever-go/indexer"
 	"github.com/klever-io/klever-go/indexer/data"
@@ -49,6 +53,23 @@ func (m *mockFacade) GetBlockByNonce(nonce uint64, withTxs bool) (*api.Block, er
 
 func newTestHub(facade WSFacade) *SocketHub {
 	return NewHub("", "", facade)
+}
+
+// assertReturnsQuickly runs fn on its own goroutine and fails the test if fn hasn't
+// returned within timeout, instead of letting a regression that blocks fn hang the whole
+// test (or the suite) rather than failing it.
+func assertReturnsQuickly(t *testing.T, timeout time.Duration, failMsg string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal(failMsg)
+	}
 }
 
 func newTestClient(hub *SocketHub) *client {
@@ -664,13 +685,6 @@ func TestDeleteAll(t *testing.T) {
 	assert.False(t, hasC3)
 }
 
-func TestPostWSConnection_EmptyConfig(t *testing.T) {
-	hub := newTestHub(nil)
-	msg := &Send{Type: indexer.BLOCKS, Data: []byte(`{}`)}
-	err := hub.postWSConnection(t.Context(), msg)
-	assert.NoError(t, err)
-}
-
 func TestPostWSConnection_WithServer(t *testing.T) {
 	receivedCh := make(chan []byte, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -697,25 +711,86 @@ func TestAsyncPost_NoopWithoutConfig(t *testing.T) {
 	hub := newTestHub(nil)
 	assert.Nil(t, hub.postQueue)
 
-	// Must not block: with no mirror configured, asyncPost is a pure no-op. Run it off
-	// the test goroutine so a regression that blocks fails via the timeout below instead
-	// of hanging the test (a panic would still crash the test binary either way).
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
+	// A select on a nil channel always falls straight to its default case (it never
+	// blocks), so the timeout alone wouldn't catch a regression that deleted asyncPost's
+	// `postQueue == nil` early return — the select would just keep taking default. Assert
+	// the drop-warn counter too: taking that path (instead of the early return) fires it.
+	assertReturnsQuickly(t, 2*time.Second, "asyncPost blocked with no mirror configured", func() {
 		hub.asyncPost(&Send{Type: indexer.BLOCKS, Data: []byte(`{}`)})
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("asyncPost blocked with no mirror configured")
-	}
+	})
+	assert.Zero(t, hub.queueDropWarn.count.Get(),
+		"asyncPost must take the postQueue == nil early return, not fall through to the drop-warn path")
 }
 
 func TestNewHub_PostQueueAllocatedOnlyWhenConfigured(t *testing.T) {
 	assert.Nil(t, NewHub("", "", nil).postQueue, "no URL or API key: mirror disabled")
 	assert.NotNil(t, NewHub("http://example.com", "", nil).postQueue, "URL set: mirror enabled")
-	assert.NotNil(t, NewHub("", "api-key", nil).postQueue, "API key set: mirror enabled")
+	// An API key with no URL can never succeed (every request would fail inside the HTTP
+	// client with "no Host in request URL"), so the mirror requires a URL — API key alone
+	// leaves postQueue nil rather than starting postWorkerCount workers doomed to fail.
+	assert.Nil(t, NewHub("", "api-key", nil).postQueue, "API key without URL: mirror stays disabled")
+}
+
+func TestSocketHub_SetAppStatusHandler_NilIsNoop(t *testing.T) {
+	hub := newTestHub(nil)
+	original := hub.appStatusHandler
+	require.NotNil(t, original, "NewHub must default to a non-nil handler")
+
+	hub.SetAppStatusHandler(nil)
+	assert.Same(t, original, hub.appStatusHandler, "a nil handler must not replace the default")
+}
+
+func TestAsyncPost_QueueFull_IncrementsAppStatusMetric(t *testing.T) {
+	hub := NewHub("http://example.invalid", "key", nil)
+
+	var incremented []string
+	hub.SetAppStatusHandler(&mock.AppStatusHandlerStub{
+		IncrementHandler: func(key string) {
+			incremented = append(incremented, key)
+		},
+	})
+
+	for i := 0; i < hub.limits.postQueueSize; i++ {
+		hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: fmt.Sprintf("seed-%d", i)})
+	}
+	require.Empty(t, incremented, "must not increment before the queue is actually full")
+
+	hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: "overflow"})
+	assert.Equal(t, []string{core.MetricWSMirrorQueueDroppedTotal}, incremented)
+}
+
+func TestStartPostWorkers_PostFailure_IncrementsAppStatusMetric(t *testing.T) {
+	hub := NewHub("http://example.invalid", "key", nil)
+
+	var mu sync.Mutex
+	var incremented []string
+	hub.SetAppStatusHandler(&mock.AppStatusHandlerStub{
+		IncrementHandler: func(key string) {
+			mu.Lock()
+			defer mu.Unlock()
+			incremented = append(incremented, key)
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		hub.postWorkersWG.Wait()
+	}()
+	hub.startPostWorkers(ctx)
+
+	// example.invalid never resolves (RFC 6761), so every post to it fails.
+	hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: "will-fail"})
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(incremented) > 0
+	}, 2*time.Second, 10*time.Millisecond, "expected a post-failure metric increment")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, core.MetricWSMirrorPostFailuresTotal, incremented[0])
 }
 
 func TestAsyncPost_DeliversToWorker(t *testing.T) {
@@ -760,24 +835,17 @@ func TestAsyncPost_DropsWhenQueueFull(t *testing.T) {
 	// Each seed message is distinct (by Hash) so the assertions below can tell "the new
 	// send was dropped" apart from "an existing send was evicted to make room for it" —
 	// both would otherwise leave the queue at the same length.
-	for i := 0; i < postQueueSize; i++ {
+	for i := 0; i < hub.limits.postQueueSize; i++ {
 		hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: fmt.Sprintf("seed-%d", i)})
 	}
-	require.Len(t, hub.postQueue, postQueueSize)
+	require.Len(t, hub.postQueue, hub.limits.postQueueSize)
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
+	assertReturnsQuickly(t, 2*time.Second, "asyncPost blocked on a full queue instead of dropping", func() {
 		hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: "overflow"})
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("asyncPost blocked on a full queue instead of dropping")
-	}
+	})
 
-	require.Len(t, hub.postQueue, postQueueSize, "queue-full send must be dropped, not queued")
-	for i := 0; i < postQueueSize; i++ {
+	require.Len(t, hub.postQueue, hub.limits.postQueueSize, "queue-full send must be dropped, not queued")
+	for i := 0; i < hub.limits.postQueueSize; i++ {
 		msg := <-hub.postQueue
 		assert.NotEqual(t, "overflow", msg.Hash,
 			"overflow message must be dropped, not enqueued in place of an existing one")
@@ -793,16 +861,9 @@ func TestStartPostWorkers_StopOnContextCancel(t *testing.T) {
 	// Deterministically prove every worker actually exited, rather than assuming it did
 	// after a fixed sleep: postWorkersWG.Wait() only returns once each worker's Done()
 	// fires. A stuck worker hangs this test instead of passing silently.
-	done := make(chan struct{})
-	go func() {
+	assertReturnsQuickly(t, 2*time.Second, "post workers did not exit after context cancellation", func() {
 		hub.postWorkersWG.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("post workers did not exit after context cancellation")
-	}
+	})
 }
 
 func TestStartPostWorkers_NoopWithoutConfig(t *testing.T) {
@@ -816,16 +877,83 @@ func TestStartPostWorkers_NoopWithoutConfig(t *testing.T) {
 	// startPostWorkers incorrectly launched goroutines despite the nil queue, they'd be
 	// registered in postWorkersWG and this Wait() would hang until the timeout below
 	// instead of returning immediately.
-	done := make(chan struct{})
-	go func() {
+	assertReturnsQuickly(t, 2*time.Second, "startPostWorkers appears to have started workers despite no mirror config", func() {
 		hub.postWorkersWG.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("startPostWorkers appears to have started workers despite no mirror config")
+	})
+}
+
+// TestStartPostWorkers_BoundedInFlightAndCtxCancelAbortsRequest covers the actual
+// invariant this worker pool exists for — at most postWorkerCount mirror requests running
+// concurrently — plus ctx cancellation aborting an in-flight request rather than waiting
+// out httpClient's full timeout. Every other test in this file would stay green even if
+// startPostWorkers reverted to `go func(){ h.postWSConnection(...) }()` per request: none
+// of them ever gets postWorkerCount+1 requests in flight at once, and
+// StopOnContextCancel/DeliversToWorker never have a request actually parked in the
+// handler when ctx is cancelled. A blocking httptest handler is needed to prove both.
+func TestStartPostWorkers_BoundedInFlightAndCtxCancelAbortsRequest(t *testing.T) {
+	const totalSends = defaultPostWorkerCount * 4
+
+	var inFlight int64
+	var peakInFlight int64
+	var peakMu sync.Mutex
+	release := make(chan struct{})
+	handlerEntered := make(chan struct{}, totalSends)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&inFlight, 1)
+		defer atomic.AddInt64(&inFlight, -1)
+		peakMu.Lock()
+		if n > peakInFlight {
+			peakInFlight = n
+		}
+		peakMu.Unlock()
+		handlerEntered <- struct{}{}
+		select {
+		case <-release:
+			w.WriteHeader(http.StatusOK)
+		case <-r.Context().Done():
+			// Client aborted (ctx cancellation below): nothing left to write to.
+		}
+	}))
+	defer ts.Close()
+
+	hub := NewHub(ts.URL, "key", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	hub.startPostWorkers(ctx)
+
+	for i := 0; i < totalSends; i++ {
+		hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: fmt.Sprintf("req-%d", i)})
 	}
+
+	// Wait until postWorkerCount handlers are simultaneously parked: proves the bound is
+	// actually being exercised, since anything beyond postWorkerCount must wait for a free
+	// worker instead of firing its request immediately.
+	for i := 0; i < defaultPostWorkerCount; i++ {
+		select {
+		case <-handlerEntered:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected %d concurrent in-flight requests, only saw %d", defaultPostWorkerCount, i)
+		}
+	}
+
+	// Give an (incorrect) unbounded pool a chance to also enter the handler before reading
+	// the peak, so a regression back to one-goroutine-per-send would actually show up here.
+	time.Sleep(50 * time.Millisecond)
+	peakMu.Lock()
+	got := peakInFlight
+	peakMu.Unlock()
+	assert.LessOrEqual(t, got, int64(defaultPostWorkerCount), "more than postWorkerCount mirror requests were in flight at once")
+
+	// Cancel while postWorkerCount requests are parked in the handler (blocked on release,
+	// which nothing closes) — proves ctx cancellation aborts the in-flight request instead
+	// of running out httpClient's 10s timeout.
+	start := time.Now()
+	cancel()
+	assertReturnsQuickly(t, 5*time.Second, "post workers did not exit promptly on context cancellation with requests in flight", func() {
+		hub.postWorkersWG.Wait()
+	})
+	assert.Less(t, time.Since(start), 9*time.Second, "workers should exit well before httpClient's 10s timeout")
+	close(release)
 }
 
 func TestStartServer_ContextCancel(t *testing.T) {

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -691,6 +691,83 @@ func TestPostWSConnection_WithServer(t *testing.T) {
 	}
 }
 
+func TestAsyncPost_NoopWithoutConfig(t *testing.T) {
+	hub := newTestHub(nil)
+	assert.Nil(t, hub.postQueue)
+
+	// Must not panic and must not block: with no mirror configured, asyncPost is a pure no-op.
+	assert.NotPanics(t, func() {
+		hub.asyncPost(&Send{Type: indexer.BLOCKS, Data: []byte(`{}`)})
+	})
+}
+
+func TestNewHub_PostQueueAllocatedOnlyWhenConfigured(t *testing.T) {
+	assert.Nil(t, NewHub("", "", nil).postQueue, "no URL or API key: mirror disabled")
+	assert.NotNil(t, NewHub("http://example.com", "", nil).postQueue, "URL set: mirror enabled")
+	assert.NotNil(t, NewHub("", "api-key", nil).postQueue, "API key set: mirror enabled")
+}
+
+func TestAsyncPost_DeliversToWorker(t *testing.T) {
+	receivedCh := make(chan []byte, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		receivedCh <- buf[:n]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	hub := NewHub(ts.URL, "test-key", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hub.startPostWorkers(ctx)
+
+	hub.asyncPost(&Send{Type: indexer.BLOCKS, Data: []byte(`{"nonce":1}`)})
+
+	select {
+	case received := <-receivedCh:
+		assert.NotEmpty(t, received)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for mirrored POST")
+	}
+}
+
+func TestAsyncPost_DropsWhenQueueFull(t *testing.T) {
+	hub := NewHub("http://example.invalid", "key", nil)
+	// No workers started: the queue only drains via asyncPost's own capacity, so filling
+	// it exercises the drop-on-full path deterministically without a live HTTP server.
+	for i := 0; i < postQueueSize; i++ {
+		hub.asyncPost(&Send{Type: indexer.BLOCKS})
+	}
+	assert.Len(t, hub.postQueue, postQueueSize)
+
+	assert.NotPanics(t, func() {
+		hub.asyncPost(&Send{Type: indexer.BLOCKS})
+	})
+	assert.Len(t, hub.postQueue, postQueueSize, "queue-full send must be dropped, not queued")
+}
+
+func TestStartPostWorkers_StopOnContextCancel(t *testing.T) {
+	hub := NewHub("http://example.invalid", "key", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	hub.startPostWorkers(ctx)
+	cancel()
+
+	// No assertion beyond "this returns": startPostWorkers must not leak goroutines past
+	// ctx cancellation. A stuck worker would surface as a hang here or under -race in CI.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestStartPostWorkers_NoopWithoutConfig(t *testing.T) {
+	hub := newTestHub(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NotPanics(t, func() {
+		hub.startPostWorkers(ctx)
+	})
+}
+
 func TestStartServer_ContextCancel(t *testing.T) {
 	env := startServerEnv(t, nil)
 	c := newTestClient(env.hub)

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -696,10 +697,19 @@ func TestAsyncPost_NoopWithoutConfig(t *testing.T) {
 	hub := newTestHub(nil)
 	assert.Nil(t, hub.postQueue)
 
-	// Must not panic and must not block: with no mirror configured, asyncPost is a pure no-op.
-	assert.NotPanics(t, func() {
+	// Must not block: with no mirror configured, asyncPost is a pure no-op. Run it off
+	// the test goroutine so a regression that blocks fails via the timeout below instead
+	// of hanging the test (a panic would still crash the test binary either way).
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
 		hub.asyncPost(&Send{Type: indexer.BLOCKS, Data: []byte(`{}`)})
-	})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("asyncPost blocked with no mirror configured")
+	}
 }
 
 func TestNewHub_PostQueueAllocatedOnlyWhenConfigured(t *testing.T) {
@@ -723,7 +733,10 @@ func TestAsyncPost_DeliversToWorker(t *testing.T) {
 
 	hub := NewHub(ts.URL, "test-key", nil)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	defer func() {
+		cancel()
+		hub.postWorkersWG.Wait()
+	}()
 	hub.startPostWorkers(ctx)
 
 	hub.asyncPost(&Send{Type: indexer.BLOCKS, Data: []byte(`{"nonce":1}`)})
@@ -744,15 +757,31 @@ func TestAsyncPost_DropsWhenQueueFull(t *testing.T) {
 	hub := NewHub("http://example.invalid", "key", nil)
 	// No workers started: the queue only drains via asyncPost's own capacity, so filling
 	// it exercises the drop-on-full path deterministically without a live HTTP server.
+	// Each seed message is distinct (by Hash) so the assertions below can tell "the new
+	// send was dropped" apart from "an existing send was evicted to make room for it" —
+	// both would otherwise leave the queue at the same length.
 	for i := 0; i < postQueueSize; i++ {
-		hub.asyncPost(&Send{Type: indexer.BLOCKS})
+		hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: fmt.Sprintf("seed-%d", i)})
 	}
-	assert.Len(t, hub.postQueue, postQueueSize)
+	require.Len(t, hub.postQueue, postQueueSize)
 
-	assert.NotPanics(t, func() {
-		hub.asyncPost(&Send{Type: indexer.BLOCKS})
-	})
-	assert.Len(t, hub.postQueue, postQueueSize, "queue-full send must be dropped, not queued")
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		hub.asyncPost(&Send{Type: indexer.BLOCKS, Hash: "overflow"})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("asyncPost blocked on a full queue instead of dropping")
+	}
+
+	require.Len(t, hub.postQueue, postQueueSize, "queue-full send must be dropped, not queued")
+	for i := 0; i < postQueueSize; i++ {
+		msg := <-hub.postQueue
+		assert.NotEqual(t, "overflow", msg.Hash,
+			"overflow message must be dropped, not enqueued in place of an existing one")
+	}
 }
 
 func TestStartPostWorkers_StopOnContextCancel(t *testing.T) {
@@ -781,9 +810,22 @@ func TestStartPostWorkers_NoopWithoutConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	assert.NotPanics(t, func() {
-		hub.startPostWorkers(ctx)
-	})
+	hub.startPostWorkers(ctx)
+
+	// Prove no workers were actually started (not just "didn't panic"): if
+	// startPostWorkers incorrectly launched goroutines despite the nil queue, they'd be
+	// registered in postWorkersWG and this Wait() would hang until the timeout below
+	// instead of returning immediately.
+	done := make(chan struct{})
+	go func() {
+		hub.postWorkersWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("startPostWorkers appears to have started workers despite no mirror config")
+	}
 }
 
 func TestStartServer_ContextCancel(t *testing.T) {

--- a/websocket/websocket_test.go
+++ b/websocket/websocket_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -665,7 +666,7 @@ func TestDeleteAll(t *testing.T) {
 func TestPostWSConnection_EmptyConfig(t *testing.T) {
 	hub := newTestHub(nil)
 	msg := &Send{Type: indexer.BLOCKS, Data: []byte(`{}`)}
-	err := hub.postWSConnection(msg)
+	err := hub.postWSConnection(t.Context(), msg)
 	assert.NoError(t, err)
 }
 
@@ -680,7 +681,7 @@ func TestPostWSConnection_WithServer(t *testing.T) {
 	defer ts.Close()
 
 	hub := NewHub(ts.URL, "test-key", nil)
-	err := hub.postWSConnection(&Send{Type: indexer.BLOCKS, Data: []byte(`{}`)})
+	err := hub.postWSConnection(t.Context(), &Send{Type: indexer.BLOCKS, Data: []byte(`{}`)})
 	assert.NoError(t, err)
 
 	select {
@@ -708,11 +709,14 @@ func TestNewHub_PostQueueAllocatedOnlyWhenConfigured(t *testing.T) {
 }
 
 func TestAsyncPost_DeliversToWorker(t *testing.T) {
-	receivedCh := make(chan []byte, 1)
+	type receivedPost struct {
+		body []byte
+		err  error
+	}
+	receivedCh := make(chan receivedPost, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf := make([]byte, 4096)
-		n, _ := r.Body.Read(buf)
-		receivedCh <- buf[:n]
+		body, err := io.ReadAll(r.Body)
+		receivedCh <- receivedPost{body: body, err: err}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -726,7 +730,8 @@ func TestAsyncPost_DeliversToWorker(t *testing.T) {
 
 	select {
 	case received := <-receivedCh:
-		assert.NotEmpty(t, received)
+		require.NoError(t, received.err)
+		assert.NotEmpty(t, received.body)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for mirrored POST")
 	}
@@ -753,9 +758,19 @@ func TestStartPostWorkers_StopOnContextCancel(t *testing.T) {
 	hub.startPostWorkers(ctx)
 	cancel()
 
-	// No assertion beyond "this returns": startPostWorkers must not leak goroutines past
-	// ctx cancellation. A stuck worker would surface as a hang here or under -race in CI.
-	time.Sleep(50 * time.Millisecond)
+	// Deterministically prove every worker actually exited, rather than assuming it did
+	// after a fixed sleep: postWorkersWG.Wait() only returns once each worker's Done()
+	// fires. A stuck worker hangs this test instead of passing silently.
+	done := make(chan struct{})
+	go func() {
+		hub.postWorkersWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post workers did not exit after context cancellation")
+	}
 }
 
 func TestStartPostWorkers_NoopWithoutConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- `SocketHub.asyncPost` previously spawned an unbounded goroutine per account/tx event to mirror it via HTTP POST to the operator-configured `postConnectionURL`. Under high chain throughput (many txs/account changes per block) with a slow or unresponsive mirror endpoint, this let goroutines and outbound sockets grow without bound — a self-inflicted resource-exhaustion risk scaling with chain activity rather than with the mirror's actual capacity.
- Replaces it with a fixed pool of `postWorkerCount` (8) workers draining a bounded `postQueue` (1000 slots), started once from `StartServer(ctx)` and stopped on `ctx` cancellation.
- `asyncPost` now does a non-blocking send and drops (with a rate-limited warning, mirroring the existing `indexer.trySendEvent` drop-log pattern) when the queue is full, instead of spawning more goroutines.
- The queue is never allocated at all when no `postConnectionURL`/`postConnectionAPIKey` is configured, so the feature stays a true no-op when the mirror is disabled (previously a goroutine was still spawned per event just to check and return).
- `postConnectionURL`/`postConnectionAPIKey` remain operator-only config (`network/api/api.go`); no websocket client input can reach them, and the events that feed the mirror are unchanged — only the concurrency/backpressure handling after the fact changed.

Reviewed with a two-agent correctness + security audit pass against the diff; no findings from either.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./websocket/...`
- [x] `gofmt -l` clean on changed files
- [x] `go test ./websocket/... ./network/api/websocket/... -race` — all pass, including new tests covering: no-op when unconfigured, queue allocated only when a URL/API key is set, delivery through a real `httptest` server, drop-on-full behavior, and worker shutdown on context cancellation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Networking (websocket mirror delivery):** Adds a bounded “post mirror” pipeline for `postWSConnection` in `websocket`:
  - Replaces per-event goroutine spawning with a fixed **8-worker** pool draining a bounded **1,000-event** queue.
  - `asyncPost` becomes a **non-blocking enqueue** (or **no-op** when mirror config isn’t present) and **drops** mirror events when the queue is full, with **rate-limited** warning logs to highlight backpressure.
  - Mirror HTTP posting is made **context-cancellable** via `PostURLWithContext`, and workers **shut down cleanly** on server context cancellation (waitgroup coordination).
- **Blockchain impact:** **No changes** to consensus, transaction processing, state management, or KVM. The change affects only outbound mirror/observability traffic; **mirrored payloads are unchanged**, with the only new functional behavior being **event drops under sustained backpressure**.
- **Reliability / stability (cross-cutting concurrency & error handling):**
  - Prevents **unbounded goroutine growth** from per-event posting by enforcing bounded concurrency and queueing.
  - Improves HTTP POST robustness with stage-specific error wrapping and ensures **failed error-body reads** are surfaced (wrapped) instead of being ignored.
- **Testing:** Extends coverage for mirror disabled behavior (no queue allocated; `asyncPost` no-op; no workers started), queue allocation gating, successful delivery via `httptest`, deterministic queue-full dropping, worker stop-on-cancellation, and improved error handling via a regression test for truncated error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->