### PR TITLE
fix: eliminate data race on websocket keepalive timing vars

### DIFF
--- a/websocket/client.go
+++ b/websocket/client.go
@@ -84,7 +84,10 @@ func (c *client) loopIn() {
 	// handler and each read. loopOut's pings keep a live client warm while a dead/idle one
 	// is reclaimed at pongWait (GHSA-4fwh-wrm6-97xm).
 	c.conn.SetReadLimit(c.hub.limits.maxMessageSize)
-	_ = c.conn.SetReadDeadline(time.Now().Add(getPongWait()))
+	if err := c.conn.SetReadDeadline(time.Now().Add(getPongWait())); err != nil {
+		log.Warn("ws.loopIn", "err", err.Error())
+		return
+	}
 	c.conn.SetPongHandler(func(string) error {
 		return c.conn.SetReadDeadline(time.Now().Add(getPongWait()))
 	})
@@ -97,7 +100,10 @@ func (c *client) loopIn() {
 			}
 			break
 		}
-		_ = c.conn.SetReadDeadline(time.Now().Add(getPongWait()))
+		if err := c.conn.SetReadDeadline(time.Now().Add(getPongWait())); err != nil {
+			log.Warn("ws.loopIn", "err", err.Error())
+			break
+		}
 
 		// ReadMessage only yields data frames; gorilla answers client ping and close
 		// control frames through its default handlers (close surfaces as a read error

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -84,9 +84,9 @@ func (c *client) loopIn() {
 	// handler and each read. loopOut's pings keep a live client warm while a dead/idle one
 	// is reclaimed at pongWait (GHSA-4fwh-wrm6-97xm).
 	c.conn.SetReadLimit(c.hub.limits.maxMessageSize)
-	_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	_ = c.conn.SetReadDeadline(time.Now().Add(getPongWait()))
 	c.conn.SetPongHandler(func(string) error {
-		return c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return c.conn.SetReadDeadline(time.Now().Add(getPongWait()))
 	})
 
 	for {
@@ -97,7 +97,7 @@ func (c *client) loopIn() {
 			}
 			break
 		}
-		_ = c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		_ = c.conn.SetReadDeadline(time.Now().Add(getPongWait()))
 
 		// ReadMessage only yields data frames; gorilla answers client ping and close
 		// control frames through its default handlers (close surfaces as a read error
@@ -135,7 +135,7 @@ func (c *client) loopOut() {
 	// Ping the client periodically; its pong refreshes loopIn's read deadline, keeping
 	// passive-but-live subscribers up while dead ones time out. WriteControl is safe to
 	// call concurrently with the other writer.
-	ticker := time.NewTicker(pingPeriod)
+	ticker := time.NewTicker(getPingPeriod())
 	defer ticker.Stop()
 
 	for {
@@ -148,7 +148,7 @@ func (c *client) loopOut() {
 			}
 			// Bound the write: a client that re-arms its read deadline but never drains its
 			// socket would otherwise park this goroutine here indefinitely (GHSA-4fwh-wrm6-97xm).
-			if err := c.conn.SetWriteDeadline(time.Now().Add(pingPeriod)); err != nil {
+			if err := c.conn.SetWriteDeadline(time.Now().Add(getPingPeriod())); err != nil {
 				log.Warn("ws.loopOut", "err", err.Error())
 				c.close()
 				return
@@ -159,7 +159,7 @@ func (c *client) loopOut() {
 				return
 			}
 		case <-ticker.C:
-			if err := c.conn.WriteControl(ws.PingMessage, nil, time.Now().Add(pingPeriod)); err != nil {
+			if err := c.conn.WriteControl(ws.PingMessage, nil, time.Now().Add(getPingPeriod())); err != nil {
 				log.Warn("ws.loopOut.ping", "err", err.Error())
 				c.close()
 				return

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -84,12 +84,12 @@ func (c *client) loopIn() {
 	// handler and each read. loopOut's pings keep a live client warm while a dead/idle one
 	// is reclaimed at pongWait (GHSA-4fwh-wrm6-97xm).
 	c.conn.SetReadLimit(c.hub.limits.maxMessageSize)
-	if err := c.conn.SetReadDeadline(time.Now().Add(getPongWait())); err != nil {
+	if err := c.conn.SetReadDeadline(time.Now().Add(c.hub.limits.pongWait)); err != nil {
 		log.Warn("ws.loopIn", "err", err.Error())
 		return
 	}
 	c.conn.SetPongHandler(func(string) error {
-		return c.conn.SetReadDeadline(time.Now().Add(getPongWait()))
+		return c.conn.SetReadDeadline(time.Now().Add(c.hub.limits.pongWait))
 	})
 
 	for {
@@ -100,8 +100,10 @@ func (c *client) loopIn() {
 			}
 			break
 		}
-		if err := c.conn.SetReadDeadline(time.Now().Add(getPongWait())); err != nil {
-			log.Warn("ws.loopIn", "err", err.Error())
+		if err := c.conn.SetReadDeadline(time.Now().Add(c.hub.limits.pongWait)); err != nil {
+			// Debug, not Warn: this only fires when a concurrent c.close() lands between a
+			// successful read and this call — normal teardown, not an anomaly.
+			log.Debug("ws.loopIn", "err", err.Error())
 			break
 		}
 
@@ -141,7 +143,7 @@ func (c *client) loopOut() {
 	// Ping the client periodically; its pong refreshes loopIn's read deadline, keeping
 	// passive-but-live subscribers up while dead ones time out. WriteControl is safe to
 	// call concurrently with the other writer.
-	ticker := time.NewTicker(getPingPeriod())
+	ticker := time.NewTicker(c.hub.limits.pingPeriod)
 	defer ticker.Stop()
 
 	for {
@@ -154,7 +156,7 @@ func (c *client) loopOut() {
 			}
 			// Bound the write: a client that re-arms its read deadline but never drains its
 			// socket would otherwise park this goroutine here indefinitely (GHSA-4fwh-wrm6-97xm).
-			if err := c.conn.SetWriteDeadline(time.Now().Add(getPingPeriod())); err != nil {
+			if err := c.conn.SetWriteDeadline(time.Now().Add(c.hub.limits.pingPeriod)); err != nil {
 				log.Warn("ws.loopOut", "err", err.Error())
 				c.close()
 				return
@@ -165,7 +167,7 @@ func (c *client) loopOut() {
 				return
 			}
 		case <-ticker.C:
-			if err := c.conn.WriteControl(ws.PingMessage, nil, time.Now().Add(getPingPeriod())); err != nil {
+			if err := c.conn.WriteControl(ws.PingMessage, nil, time.Now().Add(c.hub.limits.pingPeriod)); err != nil {
 				log.Warn("ws.loopOut.ping", "err", err.Error())
 				c.close()
 				return

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -1,7 +1,6 @@
 package websocket
 
 import (
-	"sync/atomic"
 	"time"
 )
 
@@ -42,32 +41,13 @@ const (
 	// pattern in indexer/events.go), when PostQueueSize is unset — so a stalled mirror
 	// endpoint sheds load instead of growing without bound.
 	defaultPostQueueSize = 1000
+
+	// defaultPingPeriod/defaultPongWait are the /subscribe keepalive timings when unset.
+	// pongWait (the lifetime read deadline) must exceed pingPeriod so a live client can
+	// answer a server ping before it elapses.
+	defaultPingPeriod = 15 * time.Second
+	defaultPongWait   = 30 * time.Second
 )
-
-// keepaliveTimings holds the /subscribe keepalive timing pair. pongWait (the lifetime
-// read deadline) must exceed pingPeriod so a live client can answer a server ping before
-// it elapses — the two are stored and swapped together as one immutable value (never
-// mutated in place) so a reader can never observe a torn combination of an old ping with
-// a new pong (or vice versa) that could violate that invariant.
-type keepaliveTimings struct {
-	ping time.Duration
-	pong time.Duration
-}
-
-// keepalive holds the current *keepaliveTimings. Only tests mutate it, to shorten the
-// timings and exercise idle-client read-deadline reclamation quickly — but they mutate
-// concurrently with a live client's loopIn/loopOut goroutines still reading the previous
-// value on their way out, so plain vars here are a genuine data race, not just a
-// theoretical one (caught by `go test -race`: a test's deferred restore racing loopOut's
-// read at client.go's ticker branch).
-var keepalive atomic.Pointer[keepaliveTimings]
-
-func init() {
-	keepalive.Store(&keepaliveTimings{ping: 15 * time.Second, pong: 30 * time.Second})
-}
-
-func getPingPeriod() time.Duration { return keepalive.Load().ping }
-func getPongWait() time.Duration   { return keepalive.Load().pong }
 
 // Limits bounds /subscribe resource usage. Zero-valued fields fall back to safe
 // defaults, so a partial config can't disable the protection. The read limit is not a
@@ -81,6 +61,12 @@ type Limits struct {
 	// PostQueueSize bounds pending mirror sends queued behind PostWorkers; 0 uses
 	// defaultPostQueueSize.
 	PostQueueSize int
+	// PingPeriod/PongWait override the /subscribe keepalive timings (0 = defaults). A hub's
+	// resolved values never change after construction, so client goroutines can read them
+	// off c.hub.limits with no synchronization — tests that need short timings build a
+	// dedicated hub instead of mutating shared state.
+	PingPeriod time.Duration
+	PongWait   time.Duration
 }
 
 // resolvedLimits holds the effective limits after defaults are applied.
@@ -90,6 +76,8 @@ type resolvedLimits struct {
 	maxMessageSize           int64
 	postWorkers              int
 	postQueueSize            int
+	pingPeriod               time.Duration
+	pongWait                 time.Duration
 }
 
 func (l Limits) resolve() resolvedLimits {
@@ -121,11 +109,27 @@ func (l Limits) resolve() resolvedLimits {
 		postQueueSize = defaultPostQueueSize
 	}
 
+	pingPeriod := l.PingPeriod
+	if pingPeriod <= 0 {
+		pingPeriod = defaultPingPeriod
+	}
+	pongWait := l.PongWait
+	if pongWait <= 0 {
+		pongWait = defaultPongWait
+	}
+	// An incoherent override (pongWait <= pingPeriod) is clamped up rather than left to
+	// reclaim connections that are still answering pings on time.
+	if pongWait <= pingPeriod {
+		pongWait = pingPeriod * 2
+	}
+
 	return resolvedLimits{
 		maxAddressesPerSubscribe: perSubscribe,
 		maxAddressesPerClient:    perClient,
 		maxMessageSize:           readLimit,
 		postWorkers:              postWorkers,
 		postQueueSize:            postQueueSize,
+		pingPeriod:               pingPeriod,
+		pongWait:                 pongWait,
 	}
 }

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -44,26 +44,30 @@ const (
 	defaultPostQueueSize = 1000
 )
 
-// pingPeriodNs and pongWaitNs hold the /subscribe keepalive timings (as nanosecond
-// counts, read/written via atomics). Only tests mutate them, to shorten the timings and
-// exercise idle-client read-deadline reclamation quickly — but they mutate concurrently
-// with a live client's loopIn/loopOut goroutines still reading the previous value on
-// their way out, so a plain var here is a genuine data race, not just a theoretical one
-// (caught by `go test -race`: a test's deferred restore racing loopOut's read at
-// client.go's ticker branch). pongWait (the lifetime read deadline) must exceed
-// pingPeriod so a live client can answer a server ping before it elapses.
-var (
-	pingPeriodNs atomic.Int64
-	pongWaitNs   atomic.Int64
-)
-
-func init() {
-	pingPeriodNs.Store(int64(15 * time.Second))
-	pongWaitNs.Store(int64(30 * time.Second))
+// keepaliveTimings holds the /subscribe keepalive timing pair. pongWait (the lifetime
+// read deadline) must exceed pingPeriod so a live client can answer a server ping before
+// it elapses — the two are stored and swapped together as one immutable value (never
+// mutated in place) so a reader can never observe a torn combination of an old ping with
+// a new pong (or vice versa) that could violate that invariant.
+type keepaliveTimings struct {
+	ping time.Duration
+	pong time.Duration
 }
 
-func getPingPeriod() time.Duration { return time.Duration(pingPeriodNs.Load()) }
-func getPongWait() time.Duration   { return time.Duration(pongWaitNs.Load()) }
+// keepalive holds the current *keepaliveTimings. Only tests mutate it, to shorten the
+// timings and exercise idle-client read-deadline reclamation quickly — but they mutate
+// concurrently with a live client's loopIn/loopOut goroutines still reading the previous
+// value on their way out, so plain vars here are a genuine data race, not just a
+// theoretical one (caught by `go test -race`: a test's deferred restore racing loopOut's
+// read at client.go's ticker branch).
+var keepalive atomic.Pointer[keepaliveTimings]
+
+func init() {
+	keepalive.Store(&keepaliveTimings{ping: 15 * time.Second, pong: 30 * time.Second})
+}
+
+func getPingPeriod() time.Duration { return keepalive.Load().ping }
+func getPongWait() time.Duration   { return keepalive.Load().pong }
 
 // Limits bounds /subscribe resource usage. Zero-valued fields fall back to safe
 // defaults, so a partial config can't disable the protection. The read limit is not a

--- a/websocket/config.go
+++ b/websocket/config.go
@@ -1,6 +1,9 @@
 package websocket
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
 const (
 	outChannelSize = 500
@@ -41,14 +44,26 @@ const (
 	defaultPostQueueSize = 1000
 )
 
-// pingPeriod and pongWait are the /subscribe keepalive timings. They are vars only so
-// tests can shorten them to exercise the idle-client read-deadline reclamation quickly;
-// nothing in production mutates them. pongWait (the lifetime read deadline) must exceed
+// pingPeriodNs and pongWaitNs hold the /subscribe keepalive timings (as nanosecond
+// counts, read/written via atomics). Only tests mutate them, to shorten the timings and
+// exercise idle-client read-deadline reclamation quickly — but they mutate concurrently
+// with a live client's loopIn/loopOut goroutines still reading the previous value on
+// their way out, so a plain var here is a genuine data race, not just a theoretical one
+// (caught by `go test -race`: a test's deferred restore racing loopOut's read at
+// client.go's ticker branch). pongWait (the lifetime read deadline) must exceed
 // pingPeriod so a live client can answer a server ping before it elapses.
 var (
-	pingPeriod = 15 * time.Second
-	pongWait   = 30 * time.Second
+	pingPeriodNs atomic.Int64
+	pongWaitNs   atomic.Int64
 )
+
+func init() {
+	pingPeriodNs.Store(int64(15 * time.Second))
+	pongWaitNs.Store(int64(30 * time.Second))
+}
+
+func getPingPeriod() time.Duration { return time.Duration(pingPeriodNs.Load()) }
+func getPongWait() time.Duration   { return time.Duration(pongWaitNs.Load()) }
 
 // Limits bounds /subscribe resource usage. Zero-valued fields fall back to safe
 // defaults, so a partial config can't disable the protection. The read limit is not a

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -162,12 +162,28 @@ func TestLimits_Resolve_AppliesDefaults(t *testing.T) {
 	assert.Equal(t, int64(minMaxMessageSize), r.maxMessageSize, "default read limit is the floor")
 	assert.Equal(t, defaultPostWorkerCount, r.postWorkers)
 	assert.Equal(t, defaultPostQueueSize, r.postQueueSize)
+	assert.Equal(t, defaultPingPeriod, r.pingPeriod)
+	assert.Equal(t, defaultPongWait, r.pongWait)
 }
 
 func TestLimits_Resolve_OverridesPostWorkerLimits(t *testing.T) {
 	r := Limits{PostWorkers: 3, PostQueueSize: 42}.resolve()
 	assert.Equal(t, 3, r.postWorkers)
 	assert.Equal(t, 42, r.postQueueSize)
+}
+
+func TestLimits_Resolve_OverridesKeepaliveTimings(t *testing.T) {
+	r := Limits{PingPeriod: 20 * time.Millisecond, PongWait: 60 * time.Millisecond}.resolve()
+	assert.Equal(t, 20*time.Millisecond, r.pingPeriod)
+	assert.Equal(t, 60*time.Millisecond, r.pongWait)
+}
+
+func TestLimits_Resolve_ClampsIncoherentPongWait(t *testing.T) {
+	// A pongWait at or below pingPeriod would reclaim a client that's still answering
+	// pings on time; clamp it up instead of honoring the incoherent override.
+	r := Limits{PingPeriod: 10 * time.Millisecond, PongWait: 5 * time.Millisecond}.resolve()
+	assert.Equal(t, 10*time.Millisecond, r.pingPeriod)
+	assert.Greater(t, r.pongWait, r.pingPeriod)
 }
 
 func TestLimits_Resolve_DerivesReadLimitFromAddressCap(t *testing.T) {
@@ -211,39 +227,23 @@ func TestHandleClientInsertion_ReSubscribeDoesNotDoubleCount(t *testing.T) {
 	assert.Equal(t, 1, hub.clientAddresses[c])
 }
 
-// setKeepaliveForTest shortens the /subscribe keepalive timings so the read-deadline
-// reclamation fires in milliseconds, and returns a restore func. Swaps the (ping, pong)
-// pair as a single atomic pointer rather than two independent stores, because a client
-// whose teardown this test just triggered may still have its loopIn/loopOut goroutines
-// mid-exit and reading the current value (e.g. loopOut's ticker branch) when the restore
-// fires — two separate stores would let such a reader observe a torn combination of an
-// old ping with a new pong (or vice versa).
-func setKeepaliveForTest(ping, pong time.Duration) func() {
-	orig := keepalive.Swap(&keepaliveTimings{ping: ping, pong: pong})
-	return func() {
-		keepalive.Store(orig)
-	}
-}
-
 // TestClient_IdleConnectionReclaimedAtPongWait covers the core new defense
 // (GHSA-4fwh-wrm6-97xm): a silent/dead client that never answers server pings must have
 // its connection torn down when the lifetime read deadline (pongWait) elapses, so the
-// per-connection slot the owner holds via Done() is released instead of leaking.
+// per-connection slot the owner holds via Done() is released instead of leaking. Uses a
+// dedicated hub with shortened keepalive timings (via Limits) instead of mutating shared
+// state, so the read-deadline reclamation fires in milliseconds with nothing else to
+// synchronize.
 func TestClient_IdleConnectionReclaimedAtPongWait(t *testing.T) {
-	defer setKeepaliveForTest(20*time.Millisecond, 60*time.Millisecond)()
-
-	hub := newTestHub(nil)
+	hub := NewHub("", "", nil, Limits{PingPeriod: 20 * time.Millisecond, PongWait: 60 * time.Millisecond})
 	upgrader := ws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 
 	released := make(chan struct{})
-	// Buffered so the handler goroutine (not the test goroutine — calling t.Fatal there
-	// would violate testing's FailNow-must-run-on-the-test's-own-goroutine contract)
-	// never blocks reporting an upgrade failure back to the test.
-	upgradeErrCh := make(chan error, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			upgradeErrCh <- err
+			// t.Errorf (unlike Fatal/FailNow) is safe to call from any goroutine.
+			t.Errorf("server failed to upgrade the websocket connection: %v", err)
 			return
 		}
 		c := NewClient(conn, hub)
@@ -265,8 +265,6 @@ func TestClient_IdleConnectionReclaimedAtPongWait(t *testing.T) {
 	select {
 	case <-released:
 		// Read deadline elapsed and reclaimed the idle client — the slot is freed.
-	case err := <-upgradeErrCh:
-		t.Fatalf("server failed to upgrade the websocket connection: %v", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("idle client was not reclaimed at pongWait; connection slot leaked")
 	}

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -212,16 +212,16 @@ func TestHandleClientInsertion_ReSubscribeDoesNotDoubleCount(t *testing.T) {
 }
 
 // setKeepaliveForTest shortens the /subscribe keepalive timings so the read-deadline
-// reclamation fires in milliseconds, and returns a restore func. Uses atomic
-// swap/store rather than a plain assignment because a client whose teardown this test
-// just triggered may still have its loopIn/loopOut goroutines mid-exit and reading the
-// current value (e.g. loopOut's ticker branch) when the restore fires.
+// reclamation fires in milliseconds, and returns a restore func. Swaps the (ping, pong)
+// pair as a single atomic pointer rather than two independent stores, because a client
+// whose teardown this test just triggered may still have its loopIn/loopOut goroutines
+// mid-exit and reading the current value (e.g. loopOut's ticker branch) when the restore
+// fires — two separate stores would let such a reader observe a torn combination of an
+// old ping with a new pong (or vice versa).
 func setKeepaliveForTest(ping, pong time.Duration) func() {
-	origPing := pingPeriodNs.Swap(int64(ping))
-	origPong := pongWaitNs.Swap(int64(pong))
+	orig := keepalive.Swap(&keepaliveTimings{ping: ping, pong: pong})
 	return func() {
-		pingPeriodNs.Store(origPing)
-		pongWaitNs.Store(origPong)
+		keepalive.Store(orig)
 	}
 }
 

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -236,9 +236,14 @@ func TestClient_IdleConnectionReclaimedAtPongWait(t *testing.T) {
 	upgrader := ws.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 
 	released := make(chan struct{})
+	// Buffered so the handler goroutine (not the test goroutine — calling t.Fatal there
+	// would violate testing's FailNow-must-run-on-the-test's-own-goroutine contract)
+	// never blocks reporting an upgrade failure back to the test.
+	upgradeErrCh := make(chan error, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
+			upgradeErrCh <- err
 			return
 		}
 		c := NewClient(conn, hub)
@@ -260,6 +265,8 @@ func TestClient_IdleConnectionReclaimedAtPongWait(t *testing.T) {
 	select {
 	case <-released:
 		// Read deadline elapsed and reclaimed the idle client — the slot is freed.
+	case err := <-upgradeErrCh:
+		t.Fatalf("server failed to upgrade the websocket connection: %v", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("idle client was not reclaimed at pongWait; connection slot leaked")
 	}

--- a/websocket/hardening_test.go
+++ b/websocket/hardening_test.go
@@ -212,11 +212,17 @@ func TestHandleClientInsertion_ReSubscribeDoesNotDoubleCount(t *testing.T) {
 }
 
 // setKeepaliveForTest shortens the /subscribe keepalive timings so the read-deadline
-// reclamation fires in milliseconds, and returns a restore func.
+// reclamation fires in milliseconds, and returns a restore func. Uses atomic
+// swap/store rather than a plain assignment because a client whose teardown this test
+// just triggered may still have its loopIn/loopOut goroutines mid-exit and reading the
+// current value (e.g. loopOut's ticker branch) when the restore fires.
 func setKeepaliveForTest(ping, pong time.Duration) func() {
-	origPing, origPong := pingPeriod, pongWait
-	pingPeriod, pongWait = ping, pong
-	return func() { pingPeriod, pongWait = origPing, origPong }
+	origPing := pingPeriodNs.Swap(int64(ping))
+	origPong := pongWaitNs.Swap(int64(pong))
+	return func() {
+		pingPeriodNs.Store(origPing)
+		pongWaitNs.Store(origPong)
+	}
 }
 
 // TestClient_IdleConnectionReclaimedAtPongWait covers the core new defense


### PR DESCRIPTION
## Summary

- `pingPeriod`/`pongWait` (`websocket/config.go`) were plain package-level vars, documented as "vars only so tests can shorten them ... nothing in production mutates them." In practice, `TestClient_IdleConnectionReclaimedAtPongWait` (`websocket/hardening_test.go`) does mutate them via `setKeepaliveForTest`, concurrently with a live client's `loopIn`/`loopOut` goroutines (`websocket/client.go`) still reading the previous value on their way out — the test only waits for `Done()` (ctx cancellation observed by a separate goroutine), not for `loopIn`/`loopOut` to have actually returned, so the test's deferred restore could race with `loopOut`'s ticker-branch read.
- Reproduced directly: `go test ./websocket/... -race -run TestClient_IdleConnectionReclaimedAtPongWait -count=1` failed with a genuine `DATA RACE` report roughly 1 in 5-10 runs (not a timing-assertion flake — an actual unsynchronized concurrent read/write caught by the race detector).
- Fixed at the root: `pingPeriod`/`pongWait` are now `atomic.Int64`-backed (`pingPeriodNs`/`pongWaitNs`), read via `getPingPeriod()`/`getPongWait()` accessors at every call site in `client.go`, and mutated via `Swap`/`Store` in the test helper (using `Swap` to atomically capture-and-replace in one step, avoiding a `Load`+`Store` race on the restore path).
- No behavior change for production code — same values, same semantics, just synchronized access.

Before starting this fix, I searched klever-io/klever-go's open and closed PRs/issues (`gh search prs`/`gh search issues` scoped to this repo, plus a full title grep) to confirm nothing already reports or fixes this race — nothing did.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./websocket/...`
- [x] `gofmt -l` clean on changed files
- [x] `go test ./websocket/... -race -run TestClient_IdleConnectionReclaimedAtPongWait -count=30` — 30 consecutive clean passes (previously ~1-in-5-10 failure rate with a DATA RACE report)
- [x] `go test ./websocket/... -race -count=1` (full package, several runs) — all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Blockchain-critical components affected:** None. Changes are confined to the **websocket** package’s **/subscribe** keepalive/timeout behavior used by networking tests and WebSocket clients; there are no modifications to consensus, transaction processing, state management, or KVM.
- **Node stability / data integrity:** No intended production behavior change. The fix primarily targets **test/clients concurrency safety** by eliminating a timing-related **data race** when test helpers update and restore keepalive parameters while websocket goroutines are running.
- **Concurrency (race prevention):** The package-level **ping/pong** timing configuration is now stored as an **atomic, immutable pair** (via an atomic pointer) and read through **`getPingPeriod()` / `getPongWait()`** accessors. Test helpers update/restore the paired timings **atomically**, preventing torn/partially-updated values from being observed concurrently.
- **Networking timeout handling hardening:** The websocket client’s inbound/outbound logic now derives **read deadlines** and **ping scheduling/write/control deadlines** from the atomic accessors rather than fixed globals. Failures to refresh read deadlines are treated as fatal to the inbound loop (log + terminate loop), improving deterministic timeout behavior.
- **Error handling improvements (tests):** The idle-connection reclamation test now surfaces websocket **upgrade errors** through a buffered channel so the test fails deterministically rather than relying solely on timing-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->