### PR TITLE
[KLC-2574] perf(indexer): skip ES force-refresh during import-db

### DIFF
--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -320,7 +320,7 @@ func (ei *elasticProcessor) SaveHeader(
 		Index:      blockIndex,
 		DocumentID: hex.EncodeToString(headerHash),
 		Body:       bytes.NewReader(buff.Bytes()),
-		Refresh:    "true",
+		Refresh:    ei.indexRefresh(),
 	}
 
 	if err := ei.elasticClient.DoRequest(req); err != nil {
@@ -1848,7 +1848,7 @@ func (ei *elasticProcessor) indexEpochInfo(epoch uint32, epochInfo *data.EpochIn
 		Index:      epochIndex,
 		DocumentID: fmt.Sprint(epoch),
 		Body:       bytes.NewReader(buff.Bytes()),
-		Refresh:    "true",
+		Refresh:    ei.indexRefresh(),
 	}
 
 	return ei.elasticClient.DoRequest(req)
@@ -1857,6 +1857,16 @@ func (ei *elasticProcessor) indexEpochInfo(epoch uint32, epochInfo *data.EpochIn
 func (ei *elasticProcessor) isIndexEnabled(index string) bool {
 	_, isEnabled := ei.enabledIndexes[index]
 	return isEnabled
+}
+
+// indexRefresh returns the Elasticsearch IndexRequest refresh policy.
+// Live mode forces refresh so docs are immediately searchable; import-db
+// skips force-refresh to speed full-chain ES backfill.
+func (ei *elasticProcessor) indexRefresh() string {
+	if ei != nil && ei.txDatabaseProcessor != nil && ei.isInImportMode {
+		return "false"
+	}
+	return "true"
 }
 
 func getTemplateByName(templateName string, templateList map[string]*bytes.Buffer) *bytes.Buffer {

--- a/indexer/elasticProcessor_test.go
+++ b/indexer/elasticProcessor_test.go
@@ -1599,6 +1599,71 @@ func TestBuildAccountInfo(t *testing.T) {
 	})
 }
 
+func TestElasticProcessor_indexRefresh(t *testing.T) {
+	t.Parallel()
+
+	t.Run("live mode forces refresh", func(t *testing.T) {
+		t.Parallel()
+		args := createMockElasticProcessorArgs()
+		args.IsInImportDBMode = false
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		require.Equal(t, "true", ep.indexRefresh())
+	})
+
+	t.Run("import-db mode disables force refresh", func(t *testing.T) {
+		t.Parallel()
+		args := createMockElasticProcessorArgs()
+		args.IsInImportDBMode = true
+		ep := newTestElasticSearchDatabase(&imock.DatabaseWriterStub{}, args)
+		require.Equal(t, "false", ep.indexRefresh())
+	})
+}
+
+func TestElasticProcessor_SaveHeader_RefreshPolicy(t *testing.T) {
+	t.Parallel()
+
+	header := &dataBlock.Block{
+		Header: &dataBlock.BlockHeader{Nonce: 1},
+	}
+	signer := []byte("signer")
+
+	t.Run("live mode sets refresh true", func(t *testing.T) {
+		t.Parallel()
+		var captured *esapi.IndexRequest
+		args := createMockElasticProcessorArgs()
+		args.IsInImportDBMode = false
+		args.EnabledIndexes = map[string]struct{}{blockIndex: {}}
+		dbWriter := &imock.DatabaseWriterStub{
+			DoRequestCalled: func(req *esapi.IndexRequest) error {
+				captured = req
+				return nil
+			},
+		}
+		ep := newTestElasticSearchDatabase(dbWriter, args)
+		require.NoError(t, ep.SaveHeader(header, signer, 1, []string{}))
+		require.NotNil(t, captured)
+		require.Equal(t, "true", captured.Refresh)
+	})
+
+	t.Run("import-db mode sets refresh false", func(t *testing.T) {
+		t.Parallel()
+		var captured *esapi.IndexRequest
+		args := createMockElasticProcessorArgs()
+		args.IsInImportDBMode = true
+		args.EnabledIndexes = map[string]struct{}{blockIndex: {}}
+		dbWriter := &imock.DatabaseWriterStub{
+			DoRequestCalled: func(req *esapi.IndexRequest) error {
+				captured = req
+				return nil
+			},
+		}
+		ep := newTestElasticSearchDatabase(dbWriter, args)
+		require.NoError(t, ep.SaveHeader(header, signer, 1, []string{}))
+		require.NotNil(t, captured)
+		require.Equal(t, "false", captured.Refresh)
+	})
+}
+
 func TestElasticProcessor_SaveEpochInfo(t *testing.T) {
 	t.Parallel()
 
@@ -1613,8 +1678,9 @@ func TestElasticProcessor_SaveEpochInfo(t *testing.T) {
 		return raw
 	}
 
-	newEpochProcessor := func(t *testing.T, stakingRecords map[string][]byte, capture **esapi.IndexRequest) *elasticProcessor {
+	newEpochProcessor := func(t *testing.T, stakingRecords map[string][]byte, capture **esapi.IndexRequest, importDB bool) *elasticProcessor {
 		args := createMockElasticProcessorArgs()
+		args.IsInImportDBMode = importDB
 		args.EnabledIndexes = map[string]struct{}{epochIndex: {}}
 
 		kdaRecords := map[string][]byte{
@@ -1653,12 +1719,13 @@ func TestElasticProcessor_SaveEpochInfo(t *testing.T) {
 		ep := newEpochProcessor(t, map[string][]byte{
 			klvKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 5_000}),
 			kfiKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 800}),
-		}, &captured)
+		}, &captured, false)
 
 		require.NoError(t, ep.SaveEpochInfo(7, nil))
 		require.NotNil(t, captured)
 		require.Equal(t, epochIndex, captured.Index)
 		require.Equal(t, "7", captured.DocumentID)
+		require.Equal(t, "true", captured.Refresh)
 
 		body, err := io.ReadAll(captured.Body)
 		require.NoError(t, err)
@@ -1675,9 +1742,23 @@ func TestElasticProcessor_SaveEpochInfo(t *testing.T) {
 		var captured *esapi.IndexRequest
 		ep := newEpochProcessor(t, map[string][]byte{
 			klvKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 5_000}),
-		}, &captured)
+		}, &captured, false)
 
 		require.ErrorIs(t, ep.SaveEpochInfo(7, nil), common.ErrEmptyString)
 		require.Nil(t, captured)
+	})
+
+	t.Run("import-db mode sets refresh false on epoch index", func(t *testing.T) {
+		t.Parallel()
+		var captured *esapi.IndexRequest
+		ep := newEpochProcessor(t, map[string][]byte{
+			klvKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 5_000}),
+			kfiKey: mustMarshal(t, &kapps.StakingData{TotalStaked: 800}),
+		}, &captured, true)
+
+		require.NoError(t, ep.SaveEpochInfo(7, nil))
+		require.NotNil(t, captured)
+		require.Equal(t, epochIndex, captured.Index)
+		require.Equal(t, "false", captured.Refresh)
 	})
 }


### PR DESCRIPTION
## Summary
Disable Elasticsearch force-refresh on single-document index writes while the node is in import-db mode, so from-scratch ES reindex is much faster without hurting live searchability.

> **Note:** Replaces accidentally merged [#100](https://github.com/klever-io/klever-go/pull/100). `develop` was force-reset to `d85f4b42` (pre-merge tip); this is a history rollback, not a revert commit.

## Problem
Full-chain Elasticsearch backfill via import-db can take on the order of 10–15 days. Block and epoch paths hard-coded `Refresh: "true"` on every `esapi.IndexRequest`, forcing a Lucene refresh on each write. That is correct for live indexing (immediate search visibility) but is a major bottleneck during import-db reindex.

## Solution
Gate the refresh policy on `IsInImportDBMode` (already plumbed into the indexer as `isInImportMode`):

- **Live:** `Refresh: "true"` (unchanged behavior)
- **Import-db:** `Refresh: "false"` so ES uses normal refresh behavior instead of per-write force-refresh

A small `indexRefresh()` helper is used by both `SaveHeader` (`blockIndex`) and `indexEpochInfo` (`epochIndex`). Bulk index paths already do not force refresh.

## Key Changes
- **Updated:** `indexer/elasticProcessor.go` — `indexRefresh()`; block and epoch `IndexRequest` call sites
- **Updated:** `indexer/elasticProcessor_test.go` — unit + `SaveHeader` / `SaveEpochInfo` coverage for live vs import-db

## Testing
- [x] New tests added for new functionality
- [x] Targeted: `go test ./indexer/ -run 'TestElasticProcessor_indexRefresh|TestElasticProcessor_SaveHeader_RefreshPolicy|TestElasticProcessor_SaveEpochInfo'`
- [ ] All existing tests pass (`make tests`)
- [ ] Manual testing performed: import-db reindex throughput comparison (optional post-merge)

## Configuration Changes
None. Uses existing `--import-db` / `IsInImportDBMode` plumbing.

## Breaking Changes
None. Live indexing behavior is unchanged. During import-db only, newly written docs may not be immediately searchable until ES’s normal refresh interval.

## Related Issues
Fixes KLC-2574
Related to KLC-28 (historical import-db slow sync investigation)

## Checklist
- [x] Code follows project style guidelines (`make goimports`)
- [x] Tests added/updated and passing
- [ ] Documentation updated (README, CLAUDE.md, code comments)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unnecessary files included
- [x] Breaking changes documented above
- [x] Configuration changes documented above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Elasticsearch refresh behavior for block and epoch writes.
- Live indexing uses `Refresh: "true"`.
- `import-db` indexing uses `Refresh: "false"` to avoid a forced Lucene refresh on every write.
- Added shared `indexRefresh()` logic and test coverage for both modes.

## Blockchain impact

- Transaction processing changes only affect Elasticsearch indexing during `import-db`.
- Consensus, state management, KVM, and networking are unchanged.
- The change does not alter blockchain data integrity or node stability.
- Imported documents may remain temporarily unavailable to searches until the normal Elasticsearch refresh interval.
- No concurrency, error-handling, configuration, or public API changes were introduced.
- Full-chain reindex performance should improve because Elasticsearch performs fewer forced refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->