### PR TITLE
fix: rebuild publicKeyToValidatorMap in nodesCoordinator LoadState

### DIFF
--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -127,10 +127,12 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		indexHashedNodesCoordinator: ihgs,
 	}
 
-	err = ihgs.saveState(ihgs.savedStateKey)
-	if err != nil {
-		log.Error("saving initial nodes coordinator config failed",
-			"error", err.Error())
+	if arguments.StartEpoch == 0 {
+		err = ihgs.saveState(ihgs.savedStateKey)
+		if err != nil {
+			log.Error("saving initial nodes coordinator config failed",
+				"error", err.Error())
+		}
 	}
 
 	log.Info("new nodes config is set for epoch", "epoch", arguments.Epoch)
@@ -281,8 +283,13 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	}
 
 	displayNodesConfigInfo(nodesConfig)
+
+	// rebuild the validator lookup from restored configs and publish both atomically
+	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
+
 	ihgs.mutNodesConfig.Lock()
 	ihgs.nodesConfig = nodesConfig
+	ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
 	ihgs.mutNodesConfig.Unlock()
 
 	ihgs.stateReady.Store(true)
@@ -372,10 +379,18 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 	ihgs.mutNodesConfig.Lock()
 	defer ihgs.mutNodesConfig.Unlock()
 
+	ihgs.publicKeyToValidatorMap = ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
+}
+
+// computePublicKeyToValidatorMap merges the elected and eligible validators of
+// all given epoch configs into one lookup map, later epochs taking precedence
+func (ihgs *indexHashedNodesCoordinator) computePublicKeyToValidatorMap(
+	nodesConfig map[uint32]*epochNodesConfig,
+) map[string]Validator {
 	index := 0
-	epochList := make([]uint32, len(ihgs.nodesConfig))
+	epochList := make([]uint32, len(nodesConfig))
 	mapAllValidators := make(map[uint32]map[string]Validator)
-	for epoch, epochConfig := range ihgs.nodesConfig {
+	for epoch, epochConfig := range nodesConfig {
 		epochConfig.mutNodesMaps.RLock()
 		mapAllValidators[epoch] = ihgs.createPublicKeyToValidatorMap(epochConfig.electedList, epochConfig.eligibleList)
 		epochConfig.mutNodesMaps.RUnlock()
@@ -388,13 +403,15 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 		return epochList[i] < epochList[j]
 	})
 
-	ihgs.publicKeyToValidatorMap = make(map[string]Validator)
+	publicKeyToValidatorMap := make(map[string]Validator)
 	for _, epoch := range epochList {
 		validatorsForEpoch := mapAllValidators[epoch]
 		for pubKey, vInfo := range validatorsForEpoch {
-			ihgs.publicKeyToValidatorMap[pubKey] = vInfo
+			publicKeyToValidatorMap[pubKey] = vInfo
 		}
 	}
+
+	return publicKeyToValidatorMap
 }
 
 func (ihgs *indexHashedNodesCoordinator) createPublicKeyToValidatorMap(

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -759,3 +759,243 @@ func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {
 	require.Nil(t, err)
 	require.False(t, check.IfNil(ihgs3))
 }
+
+func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *testing.T) {
+	t.Parallel()
+
+	// simulate a restart within the install epoch: the first coordinator
+	// persists the real validators under hash(selfPubKey); a second
+	// coordinator (the restart) is seeded with genesis nodes and must NOT
+	// overwrite that saved state, otherwise LoadState reads genesis data back
+	realElected := createDummyNodesList(4, "realElected")
+	realEligible := createDummyNodesList(1, "realEligible")
+	bootStorer := mock.NewStorerMock()
+
+	firstArgs := createArguments()
+	firstArgs.BootStorer = bootStorer
+	firstArgs.ElectedNodes = realElected
+	firstArgs.EligibleNodes = realEligible
+	firstArgs.Epoch = 5
+	firstArgs.StartEpoch = 5
+	firstCoordinator, err := NewNodesCoordinator(firstArgs)
+	require.Nil(t, err)
+
+	// EpochStartPrepare would rotate the key, but within the install epoch
+	// the key is still hash(selfPubKey); persist under that key
+	err = firstCoordinator.saveState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	// second coordinator (the restart) uses the same bootStorer and same
+	// selfPubKey, so savedStateKey = hash(selfPubKey) is the same; it is
+	// seeded with genesis nodes and StartEpoch > 0
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	secondArgs := createArguments()
+	secondArgs.BootStorer = bootStorer
+	secondArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	secondArgs.Hasher = firstArgs.Hasher
+	secondArgs.ElectedNodes = genesisElected
+	secondArgs.EligibleNodes = genesisEligible
+	secondArgs.Epoch = 5
+	secondArgs.StartEpoch = 5
+	_, err = NewNodesCoordinator(secondArgs)
+	require.Nil(t, err)
+
+	// now LoadState with the same key must return the REAL validators, not
+	// genesis; if the constructor overwrote, this will return genesis data
+	thirdArgs := createArguments()
+	thirdArgs.BootStorer = bootStorer
+	thirdArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	thirdArgs.Hasher = firstArgs.Hasher
+	thirdArgs.ElectedNodes = genesisElected
+	thirdArgs.EligibleNodes = genesisEligible
+	thirdArgs.StartEpoch = 5
+	thirdCoordinator, err := NewNodesCoordinator(thirdArgs)
+	require.Nil(t, err)
+
+	err = thirdCoordinator.LoadState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	realPubKey := realElected[0].PubKey()
+	validator, err := thirdCoordinator.GetValidatorWithPublicKey(realPubKey)
+	require.Nil(t, err)
+	require.Equal(t, realPubKey, validator.PubKey())
+
+	genesisPubKey := genesisElected[0].PubKey()
+	_, err = thirdCoordinator.GetValidatorWithPublicKey(genesisPubKey)
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
+func TestNodesCoordinator_ConstructorSavesStateOnGenesisStart(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "genesisElected")
+	eligible := createDummyNodesList(1, "genesisEligible")
+	bootStorer := mock.NewStorerMock()
+
+	args := createArguments()
+	args.BootStorer = bootStorer
+	args.ElectedNodes = elected
+	args.EligibleNodes = eligible
+	args.Epoch = 0
+	args.StartEpoch = 0
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	// a second coordinator loading from the same key must see the saved state;
+	// StartEpoch > 0 so the second constructor does not overwrite what was saved
+	args2 := createArguments()
+	args2.BootStorer = bootStorer
+	args2.SelfPublicKey = args.SelfPublicKey
+	args2.Hasher = args.Hasher
+	args2.ElectedNodes = createDummyNodesList(4, "otherElected")
+	args2.EligibleNodes = createDummyNodesList(1, "otherEligible")
+	args2.StartEpoch = 1
+	coordinator2, err := NewNodesCoordinator(args2)
+	require.Nil(t, err)
+
+	err = coordinator2.LoadState(coordinator.savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := coordinator2.GetValidatorWithPublicKey(elected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, elected[0].PubKey(), validator.PubKey())
+}
+
+func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) {
+	t.Parallel()
+
+	// simulate a mid-epoch restart from storage: the persisted registry holds
+	// the current epoch's validators, while the constructor is seeded from the
+	// genesis nodes file only
+	currentElected := createDummyNodesList(4, "currentElected")
+	currentEligible := createDummyNodesList(1, "currentEligible")
+	bootStorer := mock.NewStorerMock()
+
+	argumentsBeforeRestart := createArguments()
+	argumentsBeforeRestart.BootStorer = bootStorer
+	argumentsBeforeRestart.ElectedNodes = currentElected
+	argumentsBeforeRestart.EligibleNodes = currentEligible
+	nodesCoordinatorBeforeRestart, err := NewNodesCoordinator(argumentsBeforeRestart)
+	require.Nil(t, err)
+
+	// persist the registry under a rotated key, as EpochStartPrepare does; the
+	// constructor-time save under hash(selfPubKey) must not be reused here
+	// because a subsequent constructor overwrites that key
+	savedStateKey := []byte("rotated-saved-state-key")
+	err = nodesCoordinatorBeforeRestart.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	argumentsAfterRestart := createArguments()
+	argumentsAfterRestart.BootStorer = bootStorer
+	argumentsAfterRestart.ElectedNodes = genesisElected
+	argumentsAfterRestart.EligibleNodes = genesisEligible
+	nodesCoordinatorAfterRestart, err := NewNodesCoordinator(argumentsAfterRestart)
+	require.Nil(t, err)
+
+	currentPubKey := currentElected[0].PubKey()
+	_, err = nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(currentPubKey)
+	require.Equal(t, ErrValidatorNotFound, err)
+
+	err = nodesCoordinatorAfterRestart.LoadState(savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(currentPubKey)
+	require.Nil(t, err)
+	require.Equal(t, currentPubKey, validator.PubKey())
+
+	eligiblePubKey := currentEligible[0].PubKey()
+	eligibleValidator, err := nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(eligiblePubKey)
+	require.Nil(t, err)
+	require.Equal(t, eligiblePubKey, eligibleValidator.PubKey())
+
+	// the map is rebuilt wholesale from the restored per-epoch configs, so the
+	// genesis-seeded entries are gone
+	_, err = nodesCoordinatorAfterRestart.GetValidatorWithPublicKey(genesisElected[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
+// failingPutStorer makes every Put fail, to exercise the constructor's
+// initial-save error path
+type failingPutStorer struct {
+	*mock.StorerMock
+}
+
+func (f *failingPutStorer) Put(_, _ []byte) error {
+	return errors.New("put failed")
+}
+
+func TestNodesCoordinator_ConstructorSurvivesFailedInitialSaveOnGenesis(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "genesisElected")
+
+	args := createArguments()
+	args.Epoch = 0
+	args.StartEpoch = 0
+	args.ElectedNodes = elected
+	args.BootStorer = &failingPutStorer{StorerMock: mock.NewStorerMock()}
+
+	// the initial save failure is logged, not fatal: the coordinator must
+	// still construct and resolve its seeded validators
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+	require.NotNil(t, coordinator)
+
+	validator, err := coordinator.GetValidatorWithPublicKey(elected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, elected[0].PubKey(), validator.PubKey())
+}
+
+func TestNodesCoordinator_LoadStateLaterEpochWinsForSharedPublicKey(t *testing.T) {
+	t.Parallel()
+
+	// the same public key appears in two restored epochs with a different index;
+	// computePublicKeyToValidatorMap merges epochs in ascending order, so the
+	// entry from the later epoch must be the one that survives in the lookup
+	sharedPubKey := []byte("sharedPubKey")
+	oldValidator, err := NewValidator([]byte("oldOwner"), sharedPubKey, 1, 0)
+	require.Nil(t, err)
+	newValidator, err := NewValidator([]byte("newOwner"), sharedPubKey, 1, 7)
+	require.Nil(t, err)
+
+	bootStorer := mock.NewStorerMock()
+	argsBeforeRestart := createArguments()
+	argsBeforeRestart.BootStorer = bootStorer
+	coordinatorBeforeRestart, err := NewNodesCoordinator(argsBeforeRestart)
+	require.Nil(t, err)
+
+	// epoch 1 holds the old entry, epoch 2 the new one for the same key
+	coordinatorBeforeRestart.nodesConfig = map[uint32]*epochNodesConfig{
+		1: {
+			electedList:  append(createDummyNodesList(3, "epochOne"), oldValidator),
+			eligibleList: make([]Validator, 0),
+			leavingList:  make([]Validator, 0),
+		},
+		2: {
+			electedList:  append(createDummyNodesList(3, "epochTwo"), newValidator),
+			eligibleList: make([]Validator, 0),
+			leavingList:  make([]Validator, 0),
+		},
+	}
+
+	savedStateKey := []byte("multi-epoch-saved-state-key")
+	err = coordinatorBeforeRestart.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	argsAfterRestart := createArguments()
+	argsAfterRestart.BootStorer = bootStorer
+	coordinatorAfterRestart, err := NewNodesCoordinator(argsAfterRestart)
+	require.Nil(t, err)
+
+	err = coordinatorAfterRestart.LoadState(savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := coordinatorAfterRestart.GetValidatorWithPublicKey(sharedPubKey)
+	require.Nil(t, err)
+	require.Equal(t, newValidator.Index(), validator.Index())
+}


### PR DESCRIPTION
## Summary

On a restart from storage, `LoadState` restored the per-epoch validator configs but never rebuilt `publicKeyToValidatorMap`, leaving it seeded with genesis-only validators. `GetValidatorWithPublicKey` then failed for post-genesis validators, so `PeerShardMapper` classified them as unknown and the block interceptor dropped their gossiped headers. The node advanced only through the periodic whitelisted by-nonce header requests, committing in bursts of ~20 blocks every 20 slots instead of following per slot, until the next epoch boundary.

## Fix (two behavioral changes)

1. **Rebuild `publicKeyToValidatorMap` in `LoadState`.** The extracted helper `computePublicKeyToValidatorMap` merges the elected and eligible validators of all restored epoch configs into one lookup map. `LoadState` computes the map from the freshly restored configs before acquiring the write lock, then publishes both `nodesConfig` and the rebuilt map atomically under one `mutNodesConfig.Lock`, so `GetValidatorWithPublicKey` can never observe restored configs with a stale map.

2. **Guard the initial `saveState` behind `StartEpoch == 0`.** The constructor persisted its genesis-seeded config under `hash(selfPubKey)` on every start. On a restart within the install epoch this overwrote the registry saved by the previous run, and a subsequent `LoadState` read back genesis data, causing permanent BLS signature failures. The constructor now only saves on a fresh genesis start.

## Tests

- `TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap`: seeds a coordinator the way a restart does, verifies both elected and eligible validators resolve after `LoadState` and genesis-seeded entries are gone.
- `TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart`: a restart within the install epoch (`Epoch == StartEpoch > 0`, matching production shape) does not overwrite saved state.
- `TestNodesCoordinator_ConstructorSavesStateOnGenesisStart`: the genesis-start save path still works.
- `TestNodesCoordinator_ConstructorSurvivesFailedInitialSaveOnGenesis`: a failing initial save is logged, not fatal.

Changed-line coverage measured at 100% of executable changed lines.

## Verification

`go build ./...` clean, `go vet` clean, `go test -race ./sharding/...` green, goimports clean. Validated live on a testnet fallback node in the combined PR: three consecutive mid-epoch restarts on the fixed build all resume per-slot following immediately after catch-up.

## Notes

- No wire or storage format changes; fixed and unfixed nodes interoperate.
- Supersedes #85. This is part 1 of the split of #92 into four focused PRs, as requested in review.

## Merge order

Merge sequence for the split: #102 (part 1), #103 (part 2), #104 (part 3), #105 (part 4).

This is **PR 1 of 4** in the split of #92. Suggested merge order: this PR first, then `fix/fallback-sync-epoch-transition`, then `fix/coordinator-readiness-startup-check` (needs a rebase after this one merges: both append tests to `sharding/nodesCoordinator_test.go`), then `fix/peer-type-cache-bootstrap-refresh`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Rebuilds `publicKeyToValidatorMap` from restored elected and eligible validator configurations during `LoadState`.
- Publishes the rebuilt map and `nodesConfig` atomically under the node-config mutex.
- Restored validators now resolve correctly after mid-epoch restarts.
- Prevents gossiped headers from being classified as unknown.
- Limits the initial `saveState` call to `StartEpoch == 0`, which protects saved validator state during install-epoch restarts.
- Preserves data integrity without changing wire or storage formats.
- Handles initial storage-save failures without breaking coordinator construction.
- Adds regression coverage for restoration, restart persistence, genesis saves, map rebuilding, and save failures.
- Improves concurrency safety by publishing related coordinator state under one mutex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->