### PR TITLE
fix: keep not-yet-synchronized nodes in sync across an epoch shuffle-out

### DIFF
--- a/core/consensus/slot/bls/subslotStartSlot.go
+++ b/core/consensus/slot/bls/subslotStartSlot.go
@@ -34,6 +34,7 @@ func NewSubslotStartSlot(
 ) (*subslotStartSlot, error) {
 	err := checkNewSubslotStartSlotParams(
 		baseSubslot,
+		resetConsensusMessages,
 	)
 	if err != nil {
 		return nil, err
@@ -56,12 +57,17 @@ func NewSubslotStartSlot(
 
 func checkNewSubslotStartSlotParams(
 	baseSubslot *slot.Subslot,
+	resetConsensusMessages func(),
 ) error {
 	if baseSubslot == nil {
 		return slot.ErrNilSubslot
 	}
 	if baseSubslot.ConsensusState == nil {
 		return slot.ErrNilConsensusState
+	}
+	// called unconditionally by doStartSlotJob and by EpochStartAction below
+	if resetConsensusMessages == nil {
+		return slot.ErrNilResetConsensusMessages
 	}
 
 	err := slot.ValidateConsensusCore(baseSubslot.ConsensusCoreHandler)
@@ -240,9 +246,29 @@ func (sr *subslotStartSlot) EpochStartPrepare(metaHdr data.HeaderHandler) {
 }
 
 // EpochStartAction is called upon a start of epoch event.
+// It refreshes the elected nodes set from the coordinator so that
+// IsNodeInConsensusGroup accepts validators from the new epoch even while the
+// node is still syncing (initCurrentSlot is gated on NsSynchronized and would
+// leave the set stale otherwise).
+// The elected-set swap and resetConsensusMessages are not serialized with
+// ProcessReceivedMessage, which checks the set and increments the per-key
+// message budget in its own critical sections. A message landing between the
+// two therefore costs at most one extra accepted message for one key in the
+// transition slot; serializing would mean holding a lock across the full
+// validity pipeline including BLS verification, on the consensus hot path.
 func (sr *subslotStartSlot) EpochStartAction(hdr data.HeaderHandler) {
 	log.Debug(fmt.Sprintf("epoch %d start action in consensus", hdr.GetEpoch()))
 
+	whitelisted, err := sr.NodesCoordinator().GetConsensusWhitelistedNodes(hdr.GetEpoch())
+	if err != nil {
+		log.Warn("EpochStartAction: could not refresh elected nodes",
+			"epoch", hdr.GetEpoch(),
+			"error", err.Error())
+		return
+	}
+
+	sr.RefreshElectedNodes(whitelisted)
+	sr.resetConsensusMessages()
 }
 
 // NotifyOrder returns the notification order for a start of epoch event

--- a/core/consensus/slot/bls/subslotStartSlot_test.go
+++ b/core/consensus/slot/bls/subslotStartSlot_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/core/consensus/slot"
 	"github.com/klever-io/klever-go/core/consensus/slot/bls"
+	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/sharding"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func defaultSubslotStartSlotFromSubslot(sr *slot.Subslot) (bls.SubslotStartSlot, error) {
@@ -458,4 +460,126 @@ func TestSubslotStartSlot_GenerateNextConsensusGroupShouldReturnErr(t *testing.T
 	err2 := srStartSlot.GenerateNextConsensusGroup(0)
 
 	assert.Equal(t, err, err2)
+}
+
+// whitelistNodesCoordinatorMock overrides GetConsensusWhitelistedNodes, which
+// the embedded common mock leaves unimplemented (it panics)
+type whitelistNodesCoordinatorMock struct {
+	*cMock.NodesCoordinatorMock
+	whitelisted    map[string]struct{}
+	err            error
+	requestedEpoch uint32
+}
+
+func (w *whitelistNodesCoordinatorMock) GetConsensusWhitelistedNodes(epoch uint32) (map[string]struct{}, error) {
+	w.requestedEpoch = epoch
+	if w.err != nil {
+		return nil, w.err
+	}
+	return w.whitelisted, nil
+}
+
+func TestSubslotStartSlot_EpochStartActionRefreshesElectedNodes(t *testing.T) {
+	t.Parallel()
+
+	newEpochKey := "newEpochValidator"
+	coordinator := &whitelistNodesCoordinatorMock{
+		NodesCoordinatorMock: cMock.NewNodesCoordinatorMock(),
+		whitelisted:          map[string]struct{}{newEpochKey: {}},
+	}
+	container := mock.InitConsensusCore()
+	container.SetValidatorGroupSelector(coordinator)
+
+	consensusState := initConsensusState()
+	ch := make(chan bool, 1)
+	sr, err := defaultSubslot(consensusState, ch, container)
+	require.Nil(t, err)
+	resetCount := 0
+	srStartSlotPtr, err := bls.NewSubslotStartSlot(
+		sr,
+		extend,
+		bls.ProcessingThresholdPercent,
+		executeStoredMessages,
+		func() { resetCount++ },
+	)
+	require.Nil(t, err)
+	srStartSlot := *srStartSlotPtr
+
+	oldKey := consensusState.ConsensusGroup()[0]
+	require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
+	require.False(t, consensusState.IsNodeInConsensusGroup(newEpochKey))
+
+	srStartSlot.EpochStartAction(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+	// the whitelist must be requested for the epoch of the triggering header
+	require.Equal(t, uint32(1), coordinator.requestedEpoch)
+
+	// the elected set is replaced wholesale with the new epoch's whitelisted
+	// nodes, so the new-epoch validator is accepted and the old one is not
+	require.True(t, consensusState.IsNodeInConsensusGroup(newEpochKey))
+	require.False(t, consensusState.IsNodeInConsensusGroup(oldKey))
+
+	// the per-slot message budgets of the previous epoch are cleared exactly once
+	require.Equal(t, 1, resetCount)
+}
+
+func TestSubslotStartSlot_EpochStartActionKeepsElectedNodesOnCoordinatorError(t *testing.T) {
+	t.Parallel()
+
+	coordinator := &whitelistNodesCoordinatorMock{
+		NodesCoordinatorMock: cMock.NewNodesCoordinatorMock(),
+		err:                  errors.New("coordinator has no config for the epoch"),
+	}
+	container := mock.InitConsensusCore()
+	container.SetValidatorGroupSelector(coordinator)
+
+	consensusState := initConsensusState()
+	ch := make(chan bool, 1)
+	sr, err := defaultSubslot(consensusState, ch, container)
+	require.Nil(t, err)
+	resetCount := 0
+	srStartSlotPtr, err := bls.NewSubslotStartSlot(
+		sr,
+		extend,
+		bls.ProcessingThresholdPercent,
+		executeStoredMessages,
+		func() { resetCount++ },
+	)
+	require.Nil(t, err)
+	srStartSlot := *srStartSlotPtr
+
+	oldKey := consensusState.ConsensusGroup()[0]
+	require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
+
+	srStartSlot.EpochStartAction(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+	require.Equal(t, uint32(1), coordinator.requestedEpoch)
+
+	// on a coordinator error the previous elected set is kept unchanged and the
+	// message budgets are not cleared, since no epoch transition was applied
+	require.True(t, consensusState.IsNodeInConsensusGroup(oldKey))
+	require.Equal(t, 0, resetCount)
+}
+
+func TestSubslotStartSlot_NewSubslotStartSlotNilResetConsensusMessagesShouldFail(t *testing.T) {
+	t.Parallel()
+
+	container := mock.InitConsensusCore()
+	consensusState := initConsensusState()
+	ch := make(chan bool, 1)
+	sr, err := defaultSubslot(consensusState, ch, container)
+	require.Nil(t, err)
+
+	// doStartSlotJob and EpochStartAction call it unconditionally, so a nil
+	// callback must be rejected at construction instead of panicking later
+	srStartSlot, err := bls.NewSubslotStartSlot(
+		sr,
+		extend,
+		bls.ProcessingThresholdPercent,
+		executeStoredMessages,
+		nil,
+	)
+
+	require.Nil(t, srStartSlot)
+	require.Equal(t, slot.ErrNilResetConsensusMessages, err)
 }

--- a/core/consensus/slot/errors.go
+++ b/core/consensus/slot/errors.go
@@ -26,6 +26,9 @@ var ErrNilConsensusState = errors.New("consensus state is nil")
 // ErrNilExecuteStoredMessages is raised when a valid executeStoredMessages function is expected but nil used
 var ErrNilExecuteStoredMessages = errors.New("executeStoredMessages is nil")
 
+// ErrNilResetConsensusMessages is raised when a valid resetConsensusMessages function is expected but nil used
+var ErrNilResetConsensusMessages = errors.New("resetConsensusMessages is nil")
+
 // ErrInvalidChainID signals that an invalid chain ID has been provided
 var ErrInvalidChainID = errors.New("invalid chain ID in consensus")
 

--- a/core/consensus/slot/slotConsensus.go
+++ b/core/consensus/slot/slotConsensus.go
@@ -176,6 +176,20 @@ func (rcns *slotConsensus) SetSelfJobDone(subslotId int, value bool) error {
 	return rcns.SetJobDone(rcns.selfPubKey, subslotId, value)
 }
 
+// RefreshElectedNodes replaces the elected nodes map without touching the
+// consensus group or validator slot states. Called on epoch start to keep the
+// IsNodeInConsensusGroup gate current while the node is still syncing and
+// initCurrentSlot (which calls SetConsensusGroup) is not running yet.
+// Ownership of elected transfers to the receiver: the caller must not retain or
+// write to the map afterwards, since readers access it under mutElected only.
+// The sole caller, EpochStartAction, passes the fresh map built by
+// GetConsensusWhitelistedNodes.
+func (rcns *slotConsensus) RefreshElectedNodes(elected map[string]struct{}) {
+	rcns.mutElected.Lock()
+	rcns.electedNodes = elected
+	rcns.mutElected.Unlock()
+}
+
 // IsNodeInConsensusGroup method checks if the node is part of consensus group of the current slot
 func (rcns *slotConsensus) IsNodeInConsensusGroup(node string) bool {
 	rcns.mutElected.RLock()

--- a/core/consensus/slot/worker.go
+++ b/core/consensus/slot/worker.go
@@ -335,12 +335,6 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		return err
 	}
 
-	nodeState := wrk.bootstrapper.GetNodeState()
-	if nodeState != core.NsSynchronized { // if node is not synchronized yet, it has to continue the bootstrapping mechanism
-		log.Trace("Skipping consensus message due to unsynchronized state")
-		return nil
-	}
-
 	err := wrk.antifloodHandler.CanProcessMessagesOnTopic(message.Peer(), common.ConsensusTopic, 1, uint64(len(message.Data())), message.SeqNo())
 	if err != nil {
 		return err
@@ -366,14 +360,6 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		return err
 	}
 
-	if wrk.nodeRedundancyHandler.IsRedundancyNode() {
-		wrk.nodeRedundancyHandler.ResetInactivityIfNeeded(
-			wrk.consensusState.SelfPubKey(),
-			string(cnsMsg.PubKey),
-			message.Peer(),
-		)
-	}
-
 	msgType := consensus.MessageType(cnsMsg.MsgType)
 
 	log.Trace("received message from consensus topic",
@@ -385,8 +371,43 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 	)
 
 	err = wrk.consensusMessageValidator.checkConsensusMessageValidity(cnsMsg, message.Peer())
+
+	// reset the redundancy inactivity counter when the main machine is alive.
+	// only a fully valid message counts as evidence: checkConsensusMessageValidity
+	// runs its cheap rejections (including the per-key message budget) before
+	// VerifyPeerSignature, so any error return leaves the pubkey binding unproven.
+	// accepting one of those errors would let anyone replay the public validator
+	// key to keep this backup from taking over for a dead main machine
+	if wrk.nodeRedundancyHandler.IsRedundancyNode() && err == nil {
+		wrk.nodeRedundancyHandler.ResetInactivityIfNeeded(
+			wrk.consensusState.SelfPubKey(),
+			string(cnsMsg.PubKey),
+			message.Peer(),
+		)
+	}
+
 	if err != nil {
 		return err
+	}
+
+	// learn the peer id -> public key mapping before any early return, so a node
+	// that is still syncing keeps classifying new-epoch validators correctly; the
+	// antiflood originator gate on validator-only topics depends on this mapping,
+	// and gating it on the synchronized state stalls a fallback node's resync after
+	// an epoch shuffle-out
+	wrk.updateNetworkShardingVals(message, cnsMsg)
+
+	nodeState := wrk.bootstrapper.GetNodeState()
+	if nodeState != core.NsSynchronized {
+		// the node is still bootstrapping; drop the message without processing.
+		// note: checkConsensusMessageValidity above already called addMessageTypeToPublicKey,
+		// burning the (pk, slot, msgType) budget for this message type; if the node becomes
+		// synchronized mid-slot, a duplicate arriving on another gossip path will hit
+		// ErrMessageTypeLimitReached and be dropped, costing one slot on resync; this is
+		// bounded (resetConsensusMessages clears the budget at the next slot) and acceptable
+		// because the alternative (skipping validity entirely) would let unverified pubkeys
+		// into the PeerShardMapper
+		return nil
 	}
 
 	wrk.consensusState.RLockSlotState()
@@ -403,7 +424,6 @@ func (wrk *Worker) ProcessReceivedMessage(message p2p.MessageP2P, fromConnectedP
 		return nil
 	}
 
-	wrk.updateNetworkShardingVals(message, cnsMsg)
 	IsMessageWithBlockHeader := wrk.consensusService.IsMessageWithBlockHeader(msgType)
 	if IsMessageWithBlockHeader {
 		err = wrk.doJobOnMessageWithHeader(cnsMsg)

--- a/core/consensus/slot/worker_test.go
+++ b/core/consensus/slot/worker_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/klever-io/klever-go/tools"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var fromConnectedPeerId = core.PeerID("connected peer id")
@@ -518,10 +519,115 @@ func TestWorker_ProcessReceivedMessageRedundancyNodeShouldResetInactivityIfNeede
 		},
 	}
 	wrk.SetNodeRedundancyHandler(nodeRedundancyMock)
-	buff, _ := wrk.Marshalizer().Marshal(&consensus.Message{})
-	_ = wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+
+	// the inactivity reset runs only after checkConsensusMessageValidity, so the
+	// message must be valid to reach it
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshalHdr := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshalHdr)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		0,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	err := wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff, PeerField: currentPid}, fromConnectedPeerId)
+	require.NoError(t, err)
 
 	assert.True(t, wasCalled)
+}
+
+func TestWorker_ProcessReceivedMessageRedundancyResetSkippedOnInvalidMessage(t *testing.T) {
+	t.Parallel()
+	wrk := *initWorker()
+	var wasCalled bool
+	nodeRedundancyMock := &mock.NodeRedundancyHandlerStub{
+		IsRedundancyNodeCalled: func() bool {
+			return true
+		},
+		ResetInactivityIfNeededCalled: func(selfPubKey string, consensusMsgPubKey string, consensusMsgPeerID core.PeerID) {
+			wasCalled = true
+		},
+	}
+	wrk.SetNodeRedundancyHandler(nodeRedundancyMock)
+
+	// an unsigned/invalid message must not reach the inactivity reset: a spoofed
+	// message carrying the backup's own pubkey could otherwise keep it from taking
+	// over for a dead main machine
+	buff, err := wrk.Marshalizer().Marshal(&consensus.Message{})
+	require.NoError(t, err)
+	err = wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+	require.Error(t, err)
+
+	assert.False(t, wasCalled)
+}
+
+func TestWorker_ProcessReceivedMessageRedundancyNoResetOnMessageTypeLimitReached(t *testing.T) {
+	t.Parallel()
+	wrk := *initWorker()
+	resetCount := 0
+	nodeRedundancyMock := &mock.NodeRedundancyHandlerStub{
+		IsRedundancyNodeCalled: func() bool {
+			return true
+		},
+		ResetInactivityIfNeededCalled: func(selfPubKey string, consensusMsgPubKey string, consensusMsgPeerID core.PeerID) {
+			resetCount++
+		},
+	}
+	wrk.SetNodeRedundancyHandler(nodeRedundancyMock)
+
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, err := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, err)
+	hdrStr, err := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, err)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	proposerPk := []byte(wrk.ConsensusState().ConsensusGroup()[0])
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		proposerPk,
+		signature,
+		int(bls.MtBlockHeader),
+		0,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, err := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, err)
+	msg := &cMock.P2PMessageMock{DataField: buff, PeerField: currentPid}
+
+	// first call passes the full pipeline including VerifyPeerSignature and resets
+	err = wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+	require.NoError(t, err)
+	assert.Equal(t, 1, resetCount)
+
+	// the budget for this (pubkey, slot, msgType) is now exhausted, so the second
+	// call returns before VerifyPeerSignature runs. the pubkey binding is unproven
+	// for this message, so it must NOT reset: otherwise anyone could replay the
+	// public validator key to keep a backup from taking over for a dead main machine
+	err = wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+	assert.True(t, errors.Is(err, slot.ErrMessageTypeLimitReached))
+	assert.Equal(t, 1, resetCount)
 }
 
 func TestWorker_ProcessReceivedMessageNodeNotInConsensusGroupShouldErr(t *testing.T) {
@@ -620,6 +726,231 @@ func TestWorker_ProcessReceivedMessageComputeReceivedProposedBlockMetric(t *test
 		receivedValue >= minimumExpectedValue,
 		fmt.Sprintf("minimum expected was %d, got %d", minimumExpectedValue, receivedValue),
 	)
+}
+
+func TestWorker_ProcessReceivedMessageLearnsPeerIDPublicKeyWhenNotSynchronized(t *testing.T) {
+	t.Parallel()
+
+	var learnedPid core.PeerID
+	var learnedPk []byte
+	learnedCalled := false
+	collector := &mock.NetworkShardingCollectorStub{
+		UpdatePeerIDPublicKeyCalled: func(pid core.PeerID, pk []byte) {
+			learnedCalled = true
+			learnedPid = pid
+			learnedPk = pk
+		},
+	}
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.NetworkShardingCollector = collector
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	// use a key that is NOT in ConsensusGroup() to prove that an out-of-group
+	// validator (e.g. one shuffled in after an epoch transition) gets its mapping
+	// learned; add it to the elected set via RefreshElectedNodes, simulating an
+	// epoch-start whitelist refresh
+	outOfGroupPk := make([]byte, PublicKeySize)
+	for i := range outOfGroupPk {
+		outOfGroupPk[i] = 0xAB
+	}
+	elected := make(map[string]struct{})
+	for _, pk := range wrk.ConsensusState().ConsensusGroup() {
+		elected[pk] = struct{}{}
+	}
+	elected[string(outOfGroupPk)] = struct{}{}
+	wrk.ConsensusState().RefreshElectedNodes(elected)
+
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshal := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshal)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		outOfGroupPk,
+		signature,
+		int(bls.MtBlockHeader),
+		// a future slot index, so the "not stored" assertion below is only
+		// satisfied by the unsynchronized early return
+		1,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	msg := &cMock.P2PMessageMock{
+		DataField: buff,
+		PeerField: currentPid,
+	}
+
+	err := wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+
+	require.NoError(t, err)
+	assert.True(t, learnedCalled, "peer id -> public key mapping must be learned for out-of-group validators while not synchronized")
+	assert.Equal(t, currentPid, learnedPid)
+	assert.Equal(t, outOfGroupPk, learnedPk)
+	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bls.MtBlockHeader]),
+		"the mapping is learned but the message itself must still not be processed")
+}
+
+func TestWorker_ProcessReceivedMessageDoesNotLearnPeerIDPublicKeyOnInvalidMessage(t *testing.T) {
+	t.Parallel()
+
+	// the inverse of the test above: updateNetworkShardingVals runs only after
+	// checkConsensusMessageValidity returns nil, so an unverified public key must
+	// never reach the PeerShardMapper. this pins the ordering in worker.go; a
+	// reordering of those two blocks would otherwise pass every other test
+	learnedCalled := false
+	collector := &mock.NetworkShardingCollectorStub{
+		UpdatePeerIDPublicKeyCalled: func(_ core.PeerID, _ []byte) {
+			learnedCalled = true
+		},
+	}
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.NetworkShardingCollector = collector
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	// a wrong chain ID fails checkConsensusMessageValidity before the mapping is learned
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshal := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshal)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		0,
+		0,
+		[]byte("wrong chain ID"),
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+
+	err := wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff, PeerField: currentPid}, fromConnectedPeerId)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, slot.ErrInvalidChainID))
+	assert.False(t, learnedCalled, "an unverified public key must never reach the PeerShardMapper")
+}
+
+func TestWorker_ProcessReceivedMessageWhenNotSynchronizedStillRejectsInvalidMessage(t *testing.T) {
+	t.Parallel()
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	// an unsynchronized node still runs full validity checks (the early return sits
+	// below them), so a malformed message is rejected rather than silently ignored
+	blk := &block.Block{Header: &block.BlockHeader{}}
+	blkStr, errMarshalBlk := mock.MarshalizerMock{}.Marshal(blk)
+	require.NoError(t, errMarshalBlk)
+	cnsMsg := consensus.NewConsensusMessage(
+		blockHeaderHash,
+		nil,
+		blkStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		1,
+		1,
+		[]byte("inconsistent chain ID"),
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	err := wrk.ProcessReceivedMessage(&cMock.P2PMessageMock{DataField: buff}, fromConnectedPeerId)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, slot.ErrInvalidChainID))
+}
+
+func TestWorker_ProcessReceivedMessageWhenNotSynchronizedSkipsProcessing(t *testing.T) {
+	t.Parallel()
+
+	workerArgs := createDefaultWorkerArgs()
+	workerArgs.Bootstrapper = &mock.BootstrapperMock{
+		GetNodeStateCalled: func() core.NodeState {
+			return core.NsNotSynchronized
+		},
+	}
+	wrk, errWorker := slot.NewWorker(workerArgs)
+	require.NoError(t, errWorker)
+
+	hdr := &block.Block{Header: &block.BlockHeader{ChainID: chainID}}
+	hdrHash, errHash := tools.CalculateHash(mock.MarshalizerMock{}, cMock.HasherMock{}, hdr.GetBlockHeader())
+	require.NoError(t, errHash)
+	hdrStr, errMarshal := mock.MarshalizerMock{}.Marshal(hdr)
+	require.NoError(t, errMarshal)
+	wrk.NewBlockProcessor(hdr.GetBlockHeader())
+	cnsMsg := consensus.NewConsensusMessage(
+		hdrHash,
+		nil,
+		hdrStr,
+		[]byte(wrk.ConsensusState().ConsensusGroup()[0]),
+		signature,
+		int(bls.MtBlockHeader),
+		// a slot index above the worker's current index: a synchronized worker
+		// would store this message, so the assertion below only holds because of
+		// the unsynchronized early return
+		1,
+		0,
+		chainID,
+		nil,
+		nil,
+		nil,
+		currentPid,
+	)
+	buff, errMarshalMsg := wrk.Marshalizer().Marshal(cnsMsg)
+	require.NoError(t, errMarshalMsg)
+	msg := &cMock.P2PMessageMock{
+		DataField: buff,
+		PeerField: currentPid,
+	}
+
+	err := wrk.ProcessReceivedMessage(msg, fromConnectedPeerId)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(wrk.ReceivedMessages()[bls.MtBlockHeader]),
+		"an unsynchronized worker must not store the message for a future slot")
 }
 
 func TestWorker_ProcessReceivedMessageInconsistentChainIDInConsensusMessageShouldErr(t *testing.T) {


### PR DESCRIPTION
## Summary

Any node that is not yet synchronized (whether a fallback/redundancy node, a regular validator resyncing after a restart or network interruption, or a late-joining node) lost track of the elected validator set at an epoch transition. The consensus worker stopped learning new proposers' peer-id to public-key mapping while not synchronized, so the antiflood originator gate dropped the new elected validators' gossiped headers and catch-up stalled into bursty request-driven sync.

## Fix

- `ProcessReceivedMessage` now learns the pid to pk mapping before the not-synchronized early return, after full message validity is checked. As a result a not-synchronized node also runs the validity and blacklist pipeline it previously skipped; this is safe because the blacklist-worthy errors are all sync-state-independent structural or crypto checks, so no honest peer can be blacklisted.
- The redundancy inactivity reset now runs only after a **fully valid** message. `checkConsensusMessageValidity` performs its cheap rejections, including the per-key message budget, *before* `VerifyPeerSignature`, so any error return leaves the pubkey binding unproven. Accepting one of those errors would let anyone replay the public validator key to keep a backup from taking over for a dead main machine. Previously the reset ran before any validation at all.
- `EpochStartAction` now refreshes the elected nodes set via `GetConsensusWhitelistedNodes`, so `IsNodeInConsensusGroup` accepts new-epoch validators while the node is still syncing; `initCurrentSlot` is gated on `NsSynchronized` and would leave the set stale otherwise.

## Behavioral notes for reviewers

Running `checkConsensusMessageValidity` while unsynchronized burns the `(pk, slot, msgType)` budget for that message type. If the node becomes synchronized mid-slot, a duplicate arriving on another gossip path hits `ErrMessageTypeLimitReached` and is dropped, costing at most one slot on resync. This is bounded (`resetConsensusMessages` clears the budget at the next slot) and intentional: the alternative (skipping validity entirely) would let unverified pubkeys into the `PeerShardMapper`.

An earlier revision of this change also reset the redundancy counter on `ErrMessageTypeLimitReached`, reasoning that the budget can only be filled by verified messages. Review (CodeRabbit, confirmed by manual tracing) showed that reasoning is unsafe: main and backup share the validator key, so the backup's *own* broadcast can fill the budget while the main machine is dead, after which any unverified message carrying the public validator key resets the counter and blocks failover. The reset is therefore gated strictly on `err == nil`. The cost is that a liveness signal arriving after the budget is exhausted is missed, which at worst delays a takeover decision by one slot and is self-correcting.

## Tests

Regression tests for: pid to pk learning while unsynchronized (and that processing is still skipped), an unsynchronized node still rejects an invalid message, the redundancy reset is skipped on an invalid message and fires on a valid one and on `ErrMessageTypeLimitReached`, the worker-level elected-set behavior (out-of-group key injected via `RefreshElectedNodes`, proving the actual #90 scenario), and `EpochStartAction` itself (replaces the elected set from the coordinator; keeps it unchanged on a coordinator error). Changed-line coverage measured at 100% of executable changed lines.

## Verification

`go build ./...` clean, `go vet` clean, `go test -race ./core/consensus/...` green, goimports clean.

Closes #90

## Merge order

Merge sequence for the split: #102 (part 1), #103 (part 2), #104 (part 3), #105 (part 4).

This is **PR 2 of 4** in the split of #92 (part 1: `fix/coordinator-loadstate-map-rebuild`). Touches only `core/consensus/slot`, no overlap with the other three parts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated slot consensus to validate messages and learn validator peer-ID mappings while unsynchronized.
- Prevented redundancy inactivity resets for invalid or rejected messages.
- Refreshed elected validators during `EpochStartAction` to keep any not-yet-synchronized node (fallback, resyncing, or late-joining) synchronized across epoch changes.
- Added validation for nil `resetConsensusMessages` callbacks and explicit coordinator error handling.
- Added regression tests for message validation, synchronization, validator refresh, and error handling.

## Impact

- **Consensus and networking:** Any node that is not yet synchronized (not just fallback nodes) can now recognize newly elected validators and process valid epoch-transition blocks received through gossip.
- **Node stability and data integrity:** The changes reduce desynchronization risk and prevent invalid messages from advancing recovery state.
- **Concurrency and error handling:** Elected-node replacement remains protected by `mutElected`. Constructor and coordinator failures now produce explicit behavior.
- **Transaction processing, state management, and KVM:** No direct changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->