### PR TITLE
fix: fail startup loudly when the nodes coordinator is not restored

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -307,6 +307,10 @@ var ErrCacheConfigInvalidEconomics = errors.New("cache-economics parameter is no
 // ErrNilNodesCoordinator signals a nil nodes coordinator has been provided
 var ErrNilNodesCoordinator = errors.New("nil nodes coordinator")
 
+// ErrNodesCoordinatorNotReadyAfterBootstrap signals that the nodes coordinator did not
+// restore a usable state after a non-genesis restart from storage
+var ErrNodesCoordinatorNotReadyAfterBootstrap = errors.New("nodes coordinator not ready after storage bootstrap")
+
 // ErrValidatorNotFound signals that the validator has not been found
 var ErrValidatorNotFound = errors.New("validator not found")
 

--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -26,6 +26,7 @@ type NodesCoordinatorMock struct {
 	ConsensusGroupSizeCalled                func() int
 	LoadValidatorsCalled                    func(validators []*state.ValidatorInfo) error
 	SetEpochValidatorsInfoCalled            func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
+	IsReadyCalled                           func() bool
 }
 
 // NewNodesCoordinatorMock -
@@ -226,6 +227,14 @@ func (ncm *NodesCoordinatorMock) GetOwnPublicKey() []byte {
 // LoadState -
 func (ncm *NodesCoordinatorMock) LoadState(_ []byte) error {
 	return nil
+}
+
+// IsReady -
+func (ncm *NodesCoordinatorMock) IsReady() bool {
+	if ncm.IsReadyCalled != nil {
+		return ncm.IsReadyCalled()
+	}
+	return true
 }
 
 // GetSavedStateKey -

--- a/core/bootstrap/disabled/disabledNodesCoordinator.go
+++ b/core/bootstrap/disabled/disabledNodesCoordinator.go
@@ -74,6 +74,11 @@ func (n *nodesCoordinator) LoadState(_ []byte) error {
 	return nil
 }
 
+// IsReady -
+func (n *nodesCoordinator) IsReady() bool {
+	return true
+}
+
 // SetEpochValidatorsInfo -
 func (n *nodesCoordinator) SetEpochValidatorsInfo(_ uint32, _ []*state.ValidatorInfo) error {
 	return nil

--- a/core/bootstrap/disabled/disabledNodesCoordinator_test.go
+++ b/core/bootstrap/disabled/disabledNodesCoordinator_test.go
@@ -1,0 +1,16 @@
+package disabled
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodesCoordinator_IsReady(t *testing.T) {
+	t.Parallel()
+
+	coordinator := NewNodesCoordinator()
+
+	// the disabled coordinator is always ready: it never restores state
+	require.True(t, coordinator.IsReady())
+}

--- a/node/node.go
+++ b/node/node.go
@@ -314,6 +314,14 @@ func (n *Node) StartConsensus() error {
 
 	n.bootstrapper.LoadStorage()
 
+	// the coordinator is marked ready at construction for genesis (startEpoch==0),
+	// or after a successful LoadState for non-genesis restarts; if it is still not
+	// ready after LoadStorage, the saved state could not be restored and the node
+	// can never compute consensus groups, so fail startup loudly
+	if !n.nodesCoordinator.IsReady() {
+		return common.ErrNodesCoordinatorNotReadyAfterBootstrap
+	}
+
 	log.Trace("creating proposal kapp")
 
 	acnt, err := n.kapps.LoadAccount(kapps.ProposalKAppAddress)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -7,27 +7,36 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
 	disabledSig "github.com/klever-io/klever-go/crypto/signing/disabled/singlesig"
+	"github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/indexer"
 	"github.com/klever-io/klever-go/network/api/models"
+	"github.com/klever-io/klever-go/sharding"
 
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/config"
+	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/core/fork"
 	"github.com/klever-io/klever-go/core/kapp"
 	kappcontroller "github.com/klever-io/klever-go/core/kapp/kappController"
 	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/core/process/block/bootstrapStorage"
+	"github.com/klever-io/klever-go/core/watchdog"
 	"github.com/klever-io/klever-go/crypto"
 	"github.com/klever-io/klever-go/crypto/hashing"
 	cryptoMock "github.com/klever-io/klever-go/crypto/mock"
+	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/retriever"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/kapps"
 	"github.com/klever-io/klever-go/node"
 	"github.com/klever-io/klever-go/storage"
+	"github.com/klever-io/klever-go/storage/timecache"
 	"github.com/klever-io/klever-go/tools/marshal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -807,4 +816,148 @@ func TestEstimateTransactionsFees(t *testing.T) {
 		assert.Equal(t, kAppFee, cost.KAppFee)
 		assert.Equal(t, expectedTotalBandwidthFee, cost.BandwidthFee)
 	})
+}
+
+// nonSubscriberForkController wraps a ForkController so the wrapper type does
+// NOT satisfy core.EpochSubscriberHandler; StartConsensus then fails on its
+// fork-controller type assertion right after the coordinator readiness check,
+// which lets the tests below stop deterministically at that point
+type nonSubscriberForkController struct {
+	core.ForkController
+}
+
+// createStartConsensusNode builds a node with just enough dependencies for
+// StartConsensus to reach the nodes-coordinator readiness check
+// createStartConsensusNodeWithFailingAccount builds the same node but with a
+// kapps adapter whose LoadAccount fails, to prove an earlier check is not
+// masked by that failure
+func createStartConsensusNodeWithFailingAccount(t *testing.T, coordinator sharding.NodesCoordinator) *node.Node {
+	return newStartConsensusNode(t, coordinator, errors.New("load account failed"))
+}
+
+func createStartConsensusNode(t *testing.T, coordinator sharding.NodesCoordinator) *node.Node {
+	return newStartConsensusNode(t, coordinator, nil)
+}
+
+func newStartConsensusNode(t *testing.T, coordinator sharding.NodesCoordinator, loadAccountErr error) *node.Node {
+	storerMock := mock.NewStorerMock("", 0)
+	genesisHeader := &block.Block{Header: &block.BlockHeader{Epoch: 0}}
+
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled: func() retriever.ShardedDataCacherNotifier {
+			return &mock.ShardedDataStub{}
+		},
+		HeadersCalled: func() retriever.HeadersPool {
+			return &mock.HeadersCacherStub{}
+		},
+	}
+
+	kappsAdapter := &mock.AccountsStub{
+		LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			if loadAccountErr != nil {
+				return nil, loadAccountErr
+			}
+			return &mock.KAppAccountHandlerStub{}, nil
+		},
+	}
+
+	n, err := node.NewNode(
+		node.WithDataPool(dataPool),
+		node.WithInternalMarshalizer(getMarshalizer()),
+		node.WithTxSignMarshalizer(getMarshalizer()),
+		node.WithDataStore(&mock.ChainStorerMock{
+			GetCalled: func(_ retriever.UnitType, key []byte) ([]byte, error) {
+				return storerMock.Get(key)
+			},
+			GetStorerCalled: func(_ retriever.UnitType) storage.Storer {
+				return storerMock
+			},
+		}),
+		node.WithUint64ByteSliceConverter(mock.NewNonceHashConverterMock()),
+		node.WithAddressPubkeyConverter(createMockPubkeyConverter()),
+		node.WithValidatorPubkeyConverter(createMockPubkeyConverter()),
+		node.WithAccountsAdapter(getAccAdapter(100)),
+		node.WithKAppsAdapter(kappsAdapter),
+		node.WithHasher(getHasher()),
+		node.WithTxSignHasher(getHasher()),
+		node.WithKeyGen(createKeyGenMock()),
+		node.WithTxFeeHandler(&mock.FeeHandlerStub{}),
+		node.WithSingleSigner(&cryptoMock.SignerMock{}),
+		node.WithTxSingleSigner(&disabledSig.DisabledSingleSig{}),
+		node.WithChainID(chainID),
+		node.WithBlockChain(&mock.BlockChainMock{
+			GetGenesisHeaderCalled: func() data.HeaderHandler {
+				return genesisHeader
+			},
+			GetGenesisHeaderHashCalled: func() []byte {
+				return []byte("genesis hash")
+			},
+		}),
+		node.WithMessenger(&mock.MessengerStub{}),
+		node.WithPrivKey(&cryptoMock.PrivateKeyStub{}),
+		node.WithPeerSignatureHandler(&mock.PeerSignatureHandler{}),
+		node.WithInterceptorsContainer(&mock.InterceptorsContainerStub{}),
+		node.WithForkDetector(&mock.ForkDetectorMock{}),
+		node.WithBlockProcessor(&consensusMock.BlockProcessorMock{}),
+		node.WithBootStorer(&mock.BoostrapStorerMock{
+			GetHighestSlotCalled: func() int64 { return 0 },
+			GetCalled: func(_ int64) (*bootstrapStorage.BootstrapData, error) {
+				return nil, errors.New("no boot data")
+			},
+		}),
+		node.WithEpochStartTrigger(&mock.EpochStartTriggerStub{}),
+		node.WithRequestHandler(&mock.RequestHandlerStub{}),
+		node.WithSlotManager(&consensusMock.SlotManagerMock{}),
+		node.WithSyncer(&consensusMock.SyncTimerMock{}),
+		node.WithGenesisTime(time.Now()),
+		node.WithIndexer(indexer.NewNilIndexer()),
+		node.WithWatchdogTimer(&watchdog.DisabledWatchdog{}),
+		node.WithBlockBlackListHandler(timecache.NewTimeCache(time.Second)),
+		node.WithNodesCoordinator(coordinator),
+		node.WithForkController(&nonSubscriberForkController{ForkController: &mock.ForkControllerStub{}}),
+	)
+	require.Nil(t, err)
+
+	return n
+}
+
+func TestStartConsensus_FailsWhenNodesCoordinatorNotReady(t *testing.T) {
+	t.Parallel()
+
+	coordinator := &mock.NodesCoordinatorMock{
+		IsReadyCalled: func() bool { return false },
+	}
+	n := createStartConsensusNode(t, coordinator)
+
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrNodesCoordinatorNotReadyAfterBootstrap, err)
+}
+
+func TestStartConsensus_ReadinessFailureIsNotMaskedByLaterErrors(t *testing.T) {
+	t.Parallel()
+
+	// the readiness check runs immediately after LoadStorage, so a downstream
+	// failure cannot mask the diagnostic that tells an operator the saved state
+	// was not restored
+	coordinator := &mock.NodesCoordinatorMock{
+		IsReadyCalled: func() bool { return false },
+	}
+	n := createStartConsensusNodeWithFailingAccount(t, coordinator)
+
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrNodesCoordinatorNotReadyAfterBootstrap, err)
+}
+
+func TestStartConsensus_PassesReadinessCheckWhenCoordinatorIsReady(t *testing.T) {
+	t.Parallel()
+
+	coordinator := &mock.NodesCoordinatorMock{
+		IsReadyCalled: func() bool { return true },
+	}
+	n := createStartConsensusNode(t, coordinator)
+
+	// the wrapped fork controller does not implement EpochSubscriberHandler, so
+	// reaching ErrWrongTypeAssertion proves the readiness check passed
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
 }

--- a/sharding/interface.go
+++ b/sharding/interface.go
@@ -30,6 +30,7 @@ type NodesCoordinator interface {
 	GetValidatorWithPublicKey(publicKey []byte) (validator Validator, err error)
 	ConsensusGroupSize() int
 	LoadState(key []byte) error
+	IsReady() bool
 	GetSavedStateKey() []byte
 	GetOwnPublicKey() []byte
 	GetConsensusWhitelistedNodes(epoch uint32) (map[string]struct{}, error)

--- a/sharding/networksharding/mock_test.go
+++ b/sharding/networksharding/mock_test.go
@@ -90,6 +90,11 @@ func (ncs *nodesCoordinatorStub) LoadState(_ []byte) error {
 	panic("implement me")
 }
 
+// IsReady -
+func (ncs *nodesCoordinatorStub) IsReady() bool {
+	return true
+}
+
 // GetSavedStateKey -
 func (ncs *nodesCoordinatorStub) GetSavedStateKey() []byte {
 	panic("implement me")

--- a/sharding/networksharding/nodesCoordinatorStub.go
+++ b/sharding/networksharding/nodesCoordinatorStub.go
@@ -140,6 +140,11 @@ func (ncm *NodesCoordinatorStub) LoadState(key []byte) error {
 	return nil
 }
 
+// IsReady -
+func (ncm *NodesCoordinatorStub) IsReady() bool {
+	return true
+}
+
 // SetEpochValidatorsInfo
 func (ncm *NodesCoordinatorStub) SetEpochValidatorsInfo(epoch uint32, validatorsInfo []*state.ValidatorInfo) error {
 	if ncm.SetEpochValidatorsInfoCalled != nil {

--- a/sharding/networksharding/nodesCoordinatorStub_test.go
+++ b/sharding/networksharding/nodesCoordinatorStub_test.go
@@ -1,0 +1,16 @@
+package networksharding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodesCoordinatorStub_IsReady(t *testing.T) {
+	t.Parallel()
+
+	stub := &NodesCoordinatorStub{}
+
+	// the stub is always ready: it never restores state
+	require.True(t, stub.IsReady())
+}

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -290,6 +290,14 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	return nil
 }
 
+// IsReady returns true once the initial saved state has been restored. It is set
+// at construction for genesis (startEpoch==0) or after a successful LoadState for
+// non-genesis restarts. EpochStartPrepare does NOT flip this flag, so IsReady
+// answers "was the persisted state loaded", not "is the coordinator usable".
+func (ihgs *indexHashedNodesCoordinator) IsReady() bool {
+	return ihgs.stateReady.Load()
+}
+
 func displayNodesConfigInfo(config map[uint32]*epochNodesConfig) {
 	for epoch, cfg := range config {
 		log.Debug("restored config for",

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -759,3 +759,71 @@ func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {
 	require.Nil(t, err)
 	require.False(t, check.IfNil(ihgs3))
 }
+
+func TestNodesCoordinator_IsReadyOnGenesisStart(t *testing.T) {
+	t.Parallel()
+
+	args := createArguments()
+	args.Epoch = 0
+	args.StartEpoch = 0
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	require.True(t, coordinator.IsReady())
+}
+
+func TestNodesCoordinator_IsReadyFalseOnRestartBeforeLoadState(t *testing.T) {
+	t.Parallel()
+
+	args := createArguments()
+	args.StartEpoch = 1
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	require.False(t, coordinator.IsReady())
+}
+
+func TestNodesCoordinator_IsReadyTrueAfterSuccessfulLoadState(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "currentElected")
+	eligible := createDummyNodesList(1, "currentEligible")
+	bootStorer := mock.NewStorerMock()
+
+	argsBeforeRestart := createArguments()
+	argsBeforeRestart.BootStorer = bootStorer
+	argsBeforeRestart.ElectedNodes = elected
+	argsBeforeRestart.EligibleNodes = eligible
+	coordinatorBeforeRestart, err := NewNodesCoordinator(argsBeforeRestart)
+	require.Nil(t, err)
+
+	savedStateKey := []byte("rotated-saved-state-key")
+	err = coordinatorBeforeRestart.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	argsAfterRestart := createArguments()
+	argsAfterRestart.BootStorer = bootStorer
+	argsAfterRestart.StartEpoch = 1
+	coordinatorAfterRestart, err := NewNodesCoordinator(argsAfterRestart)
+	require.Nil(t, err)
+	require.False(t, coordinatorAfterRestart.IsReady())
+
+	err = coordinatorAfterRestart.LoadState(savedStateKey)
+	require.Nil(t, err)
+	require.True(t, coordinatorAfterRestart.IsReady())
+}
+
+func TestNodesCoordinator_IsReadyStaysFalseAfterFailedLoadState(t *testing.T) {
+	t.Parallel()
+
+	args := createArguments()
+	args.StartEpoch = 1
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+	require.False(t, coordinator.IsReady())
+
+	// no registry saved under this key: LoadState fails and must not flip readiness
+	err = coordinator.LoadState([]byte("missing-key"))
+	require.NotNil(t, err)
+	require.False(t, coordinator.IsReady())
+}


### PR DESCRIPTION
## Summary

A restart from storage into a non-genesis epoch that failed to restore the nodes coordinator left it permanently not-ready: `ComputeConsensusGroup` kept returning `ErrNodesCoordinatorNotReady`, so the node retried and rolled back forever without recovering or shutting down.

## Fix

- Expose `IsReady()` on the `NodesCoordinator` interface, backed by the existing `stateReady` flag (set at construction for genesis starts with `StartEpoch == 0`, or by a successful `LoadState` for non-genesis restarts).
- `StartConsensus` now verifies coordinator readiness **immediately after** `LoadStorage` and fails startup with the new `ErrNodesCoordinatorNotReadyAfterBootstrap` instead of running a node that can never compute consensus groups. The check sits at the earliest point where the answer is known, so a later failure (for example a failing `LoadAccount`) cannot mask the diagnostic that tells an operator the saved state was not restored.
- All `NodesCoordinator` implementers (mock, stubs, disabled coordinator) implement `IsReady()`.

## Tests

`IsReady` is covered across a genesis start (true), a restart before `LoadState` (false), a successful `LoadState` (flips to true), and a failed `LoadState` (stays false). The `StartConsensus` enforcement point itself is covered by three node-level tests (fails with `ErrNodesCoordinatorNotReadyAfterBootstrap` when not ready, still fails with that same error when `LoadAccount` also fails, and passes through when ready), and the trivial `IsReady` implementations of the disabled coordinator and the networksharding stub are covered. Changed-line coverage measured at 100% of executable changed lines.

## Verification

`go build ./...` clean, `go vet ./...` clean (all implementers compile), `go test -race` green on `sharding`, `node`, `common`, `core/bootstrap`, goimports clean.

Closes #91

## Merge order

Merge sequence for the split: #102 (part 1), #103 (part 2), #104 (part 3), #105 (part 4).

This is **PR 3 of 4** in the split of #92 (parts 1 and 2: `fix/coordinator-loadstate-map-rebuild`, `fix/fallback-sync-epoch-transition`). Needs a rebase after part 1 merges: both append tests to `sharding/nodesCoordinator_test.go`; the intended resolution is the union (part 1's tests first, then this PR's `IsReady` tests).

Moving the readiness check up to `LoadStorage` also removed the `node/node.go` conflict with part 4, since the two no longer insert at the same anchor.
