### PR TITLE
fix: refresh peer type cache after storage bootstrap restores coordinator state

### DIFF
--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -10,22 +10,25 @@ import (
 
 // NodesCoordinatorMock defines the behaviour of a struct able to do validator group selection
 type NodesCoordinatorMock struct {
-	Validators                              []sharding.Validator
-	ConsensusSize                           uint32
-	GetSelectedPublicKeysCalled             func(selection []byte, epoch uint32) (publicKeys []string, err error)
-	GetValidatorsPublicKeysCalled           func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	GetValidatorsRewardsAddressesCalled     func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	SetNodesCalled                          func(nodes []sharding.Validator, epoch uint32) error
-	ComputeValidatorsGroupCalled            func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
-	GetValidatorWithPublicKeyCalled         func(publicKey []byte) (validator sharding.Validator, err error)
-	GetAllElectedValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllEligibleValidatorsKeysCalled      func() ([][]byte, error)
-	GetAllWaitingValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllLeavingValidatorsPublicKeysCalled func() ([][]byte, error)
-	CheckValidatorSlotCalled                func(epoch uint32, slotIndex int64, pubkey []byte) bool
-	ConsensusGroupSizeCalled                func() int
-	LoadValidatorsCalled                    func(validators []*state.ValidatorInfo) error
-	SetEpochValidatorsInfoCalled            func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
+	Validators                          []sharding.Validator
+	ConsensusSize                       uint32
+	GetSelectedPublicKeysCalled         func(selection []byte, epoch uint32) (publicKeys []string, err error)
+	GetValidatorsPublicKeysCalled       func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	GetValidatorsRewardsAddressesCalled func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	SetNodesCalled                      func(nodes []sharding.Validator, epoch uint32) error
+	ComputeValidatorsGroupCalled        func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
+	GetValidatorWithPublicKeyCalled     func(publicKey []byte) (validator sharding.Validator, err error)
+	GetAllElectedValidatorsKeysCalled   func() ([][]byte, error)
+	// GetAllElectedValidatorsKeysWithEpochCalled takes precedence over
+	// GetAllElectedValidatorsKeysCalled when both are set
+	GetAllElectedValidatorsKeysWithEpochCalled func(epoch uint32) ([][]byte, error)
+	GetAllEligibleValidatorsKeysCalled         func() ([][]byte, error)
+	GetAllWaitingValidatorsKeysCalled          func() ([][]byte, error)
+	GetAllLeavingValidatorsPublicKeysCalled    func() ([][]byte, error)
+	CheckValidatorSlotCalled                   func(epoch uint32, slotIndex int64, pubkey []byte) bool
+	ConsensusGroupSizeCalled                   func() int
+	LoadValidatorsCalled                       func(validators []*state.ValidatorInfo) error
+	SetEpochValidatorsInfoCalled               func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
 }
 
 // NewNodesCoordinatorMock -
@@ -59,7 +62,10 @@ func (ncm *NodesCoordinatorMock) GetNumTotalEligible() uint64 {
 }
 
 // GetAllElectedValidatorsKeys -
-func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(epoch uint32, _ bool) ([][]byte, error) {
+	if ncm.GetAllElectedValidatorsKeysWithEpochCalled != nil {
+		return ncm.GetAllElectedValidatorsKeysWithEpochCalled(epoch)
+	}
 	if ncm.GetAllElectedValidatorsKeysCalled != nil {
 		return ncm.GetAllElectedValidatorsKeysCalled()
 	}

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -22,6 +22,7 @@ type peerListAndShard struct {
 type PeerTypeProvider struct {
 	nodesCoordinator sharding.NodesCoordinator
 	cache            map[string]*peerListAndShard
+	cacheEpoch       uint32
 	mutCache         sync.RWMutex
 }
 
@@ -47,7 +48,18 @@ func NewPeerTypeProvider(arg ArgPeerTypeProvider) (*PeerTypeProvider, error) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	ptp.updateCache(arg.StartEpoch)
+	// seed the cache with construction-time data but leave cacheEpoch at zero:
+	// construction runs before the storage bootstrap restores the coordinator
+	// state, so this seed must never outrank the post-bootstrap RefreshCache,
+	// not even when a restore walk-back targets an older epoch than StartEpoch
+	seedCache, ok := ptp.createNewCache(arg.StartEpoch)
+	if ok {
+		ptp.mutCache.Lock()
+		ptp.cache = seedCache
+		ptp.mutCache.Unlock()
+	} else {
+		log.Warn("peerTypeProvider - no validator list available at construction", "epoch", arg.StartEpoch)
+	}
 
 	arg.EpochStartEventNotifier.RegisterHandler(ptp.epochStartEventHandler())
 
@@ -93,39 +105,74 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 				"epoch", hdr.GetEpoch())
 			ptp.updateCache(hdr.GetEpoch())
 		},
-		func(_ data.HeaderHandler) {},
+		func(_ data.HeaderHandler) {
+			// nothing to do on epoch start prepare; the cache refresh happens on the action event above
+		},
 		core.IndexerOrder,
 	)
 
 	return subscribeHandler
 }
 
+// RefreshCache rebuilds the peer type cache from the nodes coordinator for the
+// given epoch; used after the storage bootstrap restores the coordinator state.
+// Epoch ordering is enforced between real updates (a stale refresh cannot
+// overwrite a newer epoch-start update), but the construction-time seed never
+// takes precedence: the first refresh always applies, also after a storage
+// restore that walks back to an epoch older than the construction epoch.
+func (ptp *PeerTypeProvider) RefreshCache(epoch uint32) {
+	ptp.updateCache(epoch)
+}
+
 func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
-	newCache := ptp.createNewCache(epoch)
+	newCache, ok := ptp.createNewCache(epoch)
+	if !ok {
+		log.Warn("peerTypeProvider - no validator list available, keeping previous cache", "epoch", epoch)
+		return
+	}
 
 	ptp.mutCache.Lock()
-	ptp.cache = newCache
+	if epoch >= ptp.cacheEpoch {
+		ptp.cache = newCache
+		ptp.cacheEpoch = epoch
+	}
 	ptp.mutCache.Unlock()
 }
 
+// createNewCache returns (cache, false) when the epoch config is entirely
+// missing (all three getters fail), preserving the previous cache; when the
+// config exists but lists are empty the new (empty) cache replaces the old one
 func (ptp *PeerTypeProvider) createNewCache(
 	epoch uint32,
-) map[string]*peerListAndShard {
+) (map[string]*peerListAndShard, bool) {
 	newCache := make(map[string]*peerListAndShard)
 
-	nodesMapElected, err := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch)
+	// the coordinator produces disjoint lists; if they ever overlap, the last
+	// list merged below wins
+	nodesMapElected, electedErr := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
+	if electedErr != nil {
+		log.Debug("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch, "error", electedErr)
 	}
 	computePeerType(newCache, nodesMapElected, core.ElectedList)
 
-	nodesMapEligible, err := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch)
+	nodesMapEligible, eligibleErr := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
+	if eligibleErr != nil {
+		log.Debug("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch, "error", eligibleErr)
 	}
 	computePeerType(newCache, nodesMapEligible, core.EligibleList)
 
-	return newCache
+	nodesMapWaiting, waitingErr := ptp.nodesCoordinator.GetAllWaitingValidatorsKeys(epoch, false)
+	if waitingErr != nil {
+		log.Debug("peerTypeProvider - GetAllWaitingValidatorsKeys failed", "epoch", epoch, "error", waitingErr)
+	}
+	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
+
+	// all three getters fail on the same missing nodesConfig[epoch] lookup, so
+	// they fail or succeed together; keep the previous cache only when the
+	// epoch config is entirely missing
+	allListsFailed := electedErr != nil && eligibleErr != nil && waitingErr != nil
+
+	return newCache, !allListsFailed
 }
 
 func computePeerType(

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/eventNotifier"
+	"github.com/klever-io/klever-go/sharding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -120,7 +122,9 @@ func TestNewPeerTypeProvider_createCache(t *testing.T) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
 
 	assert.NotNil(t, cache)
 
@@ -129,6 +133,224 @@ func TestNewPeerTypeProvider_createCache(t *testing.T) {
 
 	assert.NotNil(t, cache[pkEligible])
 	assert.Equal(t, core.EligibleList, cache[pkEligible].pType)
+}
+
+func TestNewPeerTypeProvider_createCacheIncludesWaitingList(t *testing.T) {
+	pkElected := "pk1"
+	pkEligible := "pk2"
+	pkWaiting := "pk3"
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkElected)}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkEligible)}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pkWaiting)}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
+
+	require.NotNil(t, cache[pkWaiting])
+	require.Equal(t, core.WaitingList, cache[pkWaiting].pType)
+}
+
+func TestPeerTypeProvider_RefreshCacheRebuildsFromCoordinator(t *testing.T) {
+	// mimic a restart: at construction time the coordinator only holds stale
+	// data (no validators); after LoadState restores the real configs a
+	// RefreshCache call must rebuild the cache from the coordinator, querying
+	// it with the exact epoch the caller passed
+	pk := []byte("pk1")
+	restored := false
+	restoredEpoch := uint32(5)
+	var lastQueriedEpoch uint32
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			lastQueriedEpoch = epoch
+			if restored {
+				return [][]byte{pk}, nil
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+
+	restored = true
+	ptp.RefreshCache(restoredEpoch)
+
+	require.Equal(t, restoredEpoch, lastQueriedEpoch)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheReplacesCacheWhenListsAreEmptyWithoutError(t *testing.T) {
+	pk := []byte("pk1")
+	demoted := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			if demoted {
+				return [][]byte{}, nil
+			}
+			return [][]byte{pk}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	// successful fetches returning empty lists are a genuine state (validator
+	// demoted) and must replace the cache, unlike the all-fetches-failed case
+	demoted = true
+	ptp.RefreshCache(6)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheAppliesForEpochOlderThanConstruction(t *testing.T) {
+	// mimic a restart where the storage bootstrap walks back to an older epoch:
+	// construction happens at StartEpoch 5 (pre-restore data), then the restored
+	// chain head is in epoch 4; RefreshCache(4) must rebuild the cache, the
+	// construction-time seed must not claim epoch precedence
+	pkRestored := []byte("pkRestored")
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.StartEpoch = 5
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			if epoch == 4 {
+				return [][]byte{pkRestored}, nil
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pkRestored)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+
+	ptp.RefreshCache(4)
+
+	peerType, _, err = ptp.ComputeForPubKey(pkRestored)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_UpdateCacheIgnoresStaleEpochAfterNewerUpdate(t *testing.T) {
+	// epoch ordering between real updates: once the cache was rebuilt for epoch
+	// 5, a late refresh for epoch 4 must not overwrite it
+	pkNew := []byte("pkNewEpoch")
+	pkOld := []byte("pkOldEpoch")
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			if epoch == 5 {
+				return [][]byte{pkNew}, nil
+			}
+			return [][]byte{pkOld}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	ptp.RefreshCache(5)
+
+	peerType, _, err := ptp.ComputeForPubKey(pkNew)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	ptp.RefreshCache(4)
+
+	peerType, _, err = ptp.ComputeForPubKey(pkNew)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	peerType, _, err = ptp.ComputeForPubKey(pkOld)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+}
+
+func TestPeerTypeProvider_RefreshCacheKeepsPreviousCacheWhenAllListsFail(t *testing.T) {
+	pk := []byte("pk1")
+	failing := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{pk}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{}, nil
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			if failing {
+				return nil, sharding.ErrEpochNodesConfigDoesNotExist
+			}
+			return [][]byte{}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+
+	// a refresh for an epoch the coordinator does not know must not wipe the
+	// previously valid cache
+	failing = true
+	ptp.RefreshCache(42)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
 }
 
 func TestNewPeerTypeProvider_CallsUpdateCacheOnEpochChange(t *testing.T) {
@@ -274,7 +496,9 @@ func TestPeerTypeProvider_CreateNewCacheScenarios(t *testing.T) {
 	}
 	ptp, _ := NewPeerTypeProvider(arg)
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
+
+	require.True(t, ok)
 	assert.Len(t, cache, 3)
 	assert.Equal(t, core.EligibleList, cache["elected1"].pType) // elected1 is also eligible as it have been updated in the eligible list
 	assert.Equal(t, core.ElectedList, cache["elected2"].pType)
@@ -316,4 +540,113 @@ func TestPeerTypeProvider_GetAllPeerTypeInfos(t *testing.T) {
 	ptp.cache = make(map[string]*peerListAndShard)
 	emptyPeerTypeInfos := ptp.GetAllPeerTypeInfos()
 	assert.Empty(t, emptyPeerTypeInfos, "Should return empty slice for empty cache")
+}
+
+func TestNewPeerTypeProvider_KeepsEmptyCacheWhenConstructionSeedFails(t *testing.T) {
+	// all three list fetches fail at construction (no config for the epoch
+	// yet); the provider must still construct with an empty cache, and a later
+	// refresh must fill it
+	pk := []byte("pk1")
+	restored := false
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(_ uint32) ([][]byte, error) {
+			if restored {
+				return [][]byte{pk}, nil
+			}
+			return nil, errors.New("no config for epoch")
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return nil, errors.New("no config for epoch")
+		},
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return nil, errors.New("no config for epoch")
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ObserverList, peerType)
+
+	restored = true
+	ptp.RefreshCache(1)
+
+	peerType, _, err = ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_EpochStartPrepareIsANoOp(t *testing.T) {
+	pk := []byte("pk1")
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{pk}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	handler := ptp.epochStartEventHandler()
+	handler.EpochStartPrepare(&block.Block{Header: &block.BlockHeader{Epoch: 1}})
+
+	// prepare must not touch the cache; the refresh happens on the action event
+	peerType, _, err := ptp.ComputeForPubKey(pk)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
+}
+
+func TestPeerTypeProvider_ConcurrentRefreshAndEpochStartAreRaceFree(t *testing.T) {
+	// two writers exist in production: the epoch-start notifier callback and
+	// RefreshCache from StartConsensus, both racing readers of ComputeForPubKey.
+	// whichever order they land in, the highest epoch must win the cache
+	pkNewEpoch := []byte("pkNewEpoch")
+
+	arg := createDefaultArgPeerTypeProvider()
+	epochStartNotifier := &mock.EpochStartNotifierStub{}
+	arg.EpochStartEventNotifier = epochStartNotifier
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			if epoch == 2 {
+				return [][]byte{pkNewEpoch}, nil
+			}
+			return [][]byte{[]byte("pkOldEpoch")}, nil
+		},
+	}
+
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		ptp.RefreshCache(1)
+	}()
+	go func() {
+		defer wg.Done()
+		epochStartNotifier.NotifyAll(&block.Block{Header: &block.BlockHeader{Epoch: 2}})
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_, _, errCompute := ptp.ComputeForPubKey(pkNewEpoch)
+			require.Nil(t, errCompute)
+		}
+	}()
+
+	wg.Wait()
+
+	// epoch 2 is the highest applied epoch, so its cache must be the surviving one
+	ptp.RefreshCache(2)
+	peerType, _, err := ptp.ComputeForPubKey(pkNewEpoch)
+	require.Nil(t, err)
+	require.Equal(t, core.ElectedList, peerType)
 }

--- a/node/export_test.go
+++ b/node/export_test.go
@@ -9,3 +9,9 @@ func (n *Node) GetNetworkDegradedThreshold() uint32 {
 func (n *Node) GetNetworkDegradedCooldownSlots() uint32 {
 	return n.networkDegradedCooldownSlots
 }
+
+// SetHeartbeatHandler sets the heartbeat handler, for tests that exercise
+// StartConsensus without building the full heartbeat stack
+func (n *Node) SetHeartbeatHandler(handler HeartbeatHandler) {
+	n.heartbeatHandler = handler
+}

--- a/node/heartbeat/componentHandler/heartbeatHandler.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler.go
@@ -266,6 +266,16 @@ func (hbh *HeartbeatHandler) Sender() *process.Sender {
 	return hbh.sender
 }
 
+// RefreshPeerTypeCache rebuilds the peer type provider's cache for the given
+// epoch; called after the storage bootstrap restores the nodes coordinator state
+func (hbh *HeartbeatHandler) RefreshPeerTypeCache(epoch uint32) {
+	if hbh == nil || hbh.peerTypeProvider == nil {
+		return
+	}
+
+	hbh.peerTypeProvider.RefreshCache(epoch)
+}
+
 // Close stops the heartbeat sender and monitor background goroutines and waits
 // for both to exit. Idempotent: each step (cancelFunc, channel receive on closed
 // channel, monitor.Close) is safe to repeat.

--- a/node/heartbeat/componentHandler/heartbeatHandler_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_test.go
@@ -2,6 +2,7 @@ package componentHandler
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -141,4 +142,39 @@ func TestNewHeartbeatHandler_ShouldWork(t *testing.T) {
 
 	// let the sending go routine finish
 	time.Sleep(time.Second)
+}
+
+func TestHeartbeatHandler_RefreshPeerTypeCacheDelegatesToProvider(t *testing.T) {
+	t.Parallel()
+
+	// the monitor and sender goroutines started by NewHeartbeatHandler also reach
+	// the coordinator, so this callback can fire from more than one goroutine
+	var refreshedEpoch atomic.Uint32
+	coordinator := &cMock.NodesCoordinatorMock{
+		GetAllElectedValidatorsKeysWithEpochCalled: func(epoch uint32) ([][]byte, error) {
+			refreshedEpoch.Store(epoch)
+			return nil, nil
+		},
+	}
+
+	args := createMockArgument()
+	args.NodesCoordinator = coordinator
+	hbh, err := NewHeartbeatHandler(args)
+	require.Nil(t, err)
+	t.Cleanup(func() { require.NoError(t, hbh.Close()) })
+
+	hbh.RefreshPeerTypeCache(1)
+
+	assert.Equal(t, uint32(1), refreshedEpoch.Load(), "RefreshPeerTypeCache must delegate the epoch to the provider")
+}
+
+func TestHeartbeatHandler_RefreshPeerTypeCacheNilReceiverAndNilProvider(t *testing.T) {
+	t.Parallel()
+
+	// both guard paths must be no-ops instead of panicking
+	var nilHandler *HeartbeatHandler
+	nilHandler.RefreshPeerTypeCache(1)
+
+	emptyHandler := &HeartbeatHandler{}
+	emptyHandler.RefreshPeerTypeCache(1)
 }

--- a/node/interface.go
+++ b/node/interface.go
@@ -76,6 +76,7 @@ type Accumulator interface {
 type HeartbeatHandler interface {
 	Monitor() *process.Monitor
 	Sender() *process.Sender
+	RefreshPeerTypeCache(epoch uint32)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/node/node.go
+++ b/node/node.go
@@ -332,6 +332,13 @@ func (n *Node) StartConsensus() error {
 		epoch = crtBlockHeader.GetEpoch()
 	}
 
+	// the heartbeat's peer type cache was built before LoadStorage restored the
+	// nodes coordinator state; refresh it so the node reports its real peer type
+	// without waiting for the next epoch start
+	if !check.IfNil(n.heartbeatHandler) {
+		n.heartbeatHandler.RefreshPeerTypeCache(epoch)
+	}
+
 	forkControllerSubscriber, ok := n.forkController.(core.EpochSubscriberHandler)
 	if !ok {
 		return common.ErrWrongTypeAssertion

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -7,21 +7,31 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
 	disabledSig "github.com/klever-io/klever-go/crypto/signing/disabled/singlesig"
+	"github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/indexer"
 	"github.com/klever-io/klever-go/network/api/models"
+	heartbeatProcess "github.com/klever-io/klever-go/node/heartbeat/process"
+	"github.com/klever-io/klever-go/sharding"
+	"github.com/klever-io/klever-go/storage/timecache"
 
 	"github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/config"
+	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/core/fork"
 	"github.com/klever-io/klever-go/core/kapp"
 	kappcontroller "github.com/klever-io/klever-go/core/kapp/kappController"
 	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/core/process/block/bootstrapStorage"
+	"github.com/klever-io/klever-go/core/watchdog"
 	"github.com/klever-io/klever-go/crypto"
 	"github.com/klever-io/klever-go/crypto/hashing"
 	cryptoMock "github.com/klever-io/klever-go/crypto/mock"
+	"github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/retriever"
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/data/transaction"
@@ -807,4 +817,160 @@ func TestEstimateTransactionsFees(t *testing.T) {
 		assert.Equal(t, kAppFee, cost.KAppFee)
 		assert.Equal(t, expectedTotalBandwidthFee, cost.BandwidthFee)
 	})
+}
+
+// nonSubscriberForkController wraps a ForkController so the wrapper type does
+// NOT satisfy core.EpochSubscriberHandler; StartConsensus then fails on its
+// fork-controller type assertion right after the coordinator readiness check,
+// which lets the tests below stop deterministically at that point
+type nonSubscriberForkController struct {
+	core.ForkController
+}
+
+// createStartConsensusNode builds a node with just enough dependencies for
+// StartConsensus to reach the nodes-coordinator readiness check
+// crtHeader is variadic so the existing two-argument call sites keep compiling;
+// pass a header to exercise the restart path where the epoch comes from the
+// current block instead of the genesis fallback
+func createStartConsensusNode(t *testing.T, coordinator sharding.NodesCoordinator, crtHeader ...data.HeaderHandler) *node.Node {
+	storerMock := mock.NewStorerMock("", 0)
+	genesisHeader := &block.Block{Header: &block.BlockHeader{Epoch: 0}}
+
+	dataPool := &mock.PoolsHolderStub{
+		TransactionsCalled: func() retriever.ShardedDataCacherNotifier {
+			return &mock.ShardedDataStub{}
+		},
+		HeadersCalled: func() retriever.HeadersPool {
+			return &mock.HeadersCacherStub{}
+		},
+	}
+
+	kappsAdapter := &mock.AccountsStub{
+		LoadAccountCalled: func(_ []byte) (state.AccountHandler, error) {
+			return &mock.KAppAccountHandlerStub{}, nil
+		},
+	}
+
+	n, err := node.NewNode(
+		node.WithDataPool(dataPool),
+		node.WithInternalMarshalizer(getMarshalizer()),
+		node.WithTxSignMarshalizer(getMarshalizer()),
+		node.WithDataStore(&mock.ChainStorerMock{
+			GetCalled: func(_ retriever.UnitType, key []byte) ([]byte, error) {
+				return storerMock.Get(key)
+			},
+			GetStorerCalled: func(_ retriever.UnitType) storage.Storer {
+				return storerMock
+			},
+		}),
+		node.WithUint64ByteSliceConverter(mock.NewNonceHashConverterMock()),
+		node.WithAddressPubkeyConverter(createMockPubkeyConverter()),
+		node.WithValidatorPubkeyConverter(createMockPubkeyConverter()),
+		node.WithAccountsAdapter(getAccAdapter(100)),
+		node.WithKAppsAdapter(kappsAdapter),
+		node.WithHasher(getHasher()),
+		node.WithTxSignHasher(getHasher()),
+		node.WithKeyGen(createKeyGenMock()),
+		node.WithTxFeeHandler(&mock.FeeHandlerStub{}),
+		node.WithSingleSigner(&cryptoMock.SignerMock{}),
+		node.WithTxSingleSigner(&disabledSig.DisabledSingleSig{}),
+		node.WithChainID(chainID),
+		node.WithBlockChain(&mock.BlockChainMock{
+			GetGenesisHeaderCalled: func() data.HeaderHandler {
+				return genesisHeader
+			},
+			GetGenesisHeaderHashCalled: func() []byte {
+				return []byte("genesis hash")
+			},
+			GetCurrentBlockHeaderCalled: func() data.HeaderHandler {
+				if len(crtHeader) == 0 {
+					return nil
+				}
+				return crtHeader[0]
+			},
+		}),
+		node.WithMessenger(&mock.MessengerStub{}),
+		node.WithPrivKey(&cryptoMock.PrivateKeyStub{}),
+		node.WithPeerSignatureHandler(&mock.PeerSignatureHandler{}),
+		node.WithInterceptorsContainer(&mock.InterceptorsContainerStub{}),
+		node.WithForkDetector(&mock.ForkDetectorMock{}),
+		node.WithBlockProcessor(&consensusMock.BlockProcessorMock{}),
+		node.WithBootStorer(&mock.BoostrapStorerMock{
+			GetHighestSlotCalled: func() int64 { return 0 },
+			GetCalled: func(_ int64) (*bootstrapStorage.BootstrapData, error) {
+				return nil, errors.New("no boot data")
+			},
+		}),
+		node.WithEpochStartTrigger(&mock.EpochStartTriggerStub{}),
+		node.WithRequestHandler(&mock.RequestHandlerStub{}),
+		node.WithSlotManager(&consensusMock.SlotManagerMock{}),
+		node.WithSyncer(&consensusMock.SyncTimerMock{}),
+		node.WithGenesisTime(time.Now()),
+		node.WithIndexer(indexer.NewNilIndexer()),
+		node.WithWatchdogTimer(&watchdog.DisabledWatchdog{}),
+		node.WithBlockBlackListHandler(timecache.NewTimeCache(time.Second)),
+		node.WithNodesCoordinator(coordinator),
+		node.WithForkController(&nonSubscriberForkController{ForkController: &mock.ForkControllerStub{}}),
+	)
+	require.Nil(t, err)
+
+	return n
+}
+
+// heartbeatHandlerStub implements node.HeartbeatHandler for StartConsensus tests
+type heartbeatHandlerStub struct {
+	refreshedEpoch *uint32
+}
+
+func (h *heartbeatHandlerStub) Monitor() *heartbeatProcess.Monitor { return nil }
+
+func (h *heartbeatHandlerStub) Sender() *heartbeatProcess.Sender { return nil }
+func (h *heartbeatHandlerStub) RefreshPeerTypeCache(epoch uint32) {
+	*h.refreshedEpoch = epoch
+}
+func (h *heartbeatHandlerStub) Close() error         { return nil }
+func (h *heartbeatHandlerStub) IsInterfaceNil() bool { return h == nil }
+
+func TestStartConsensus_RefreshesPeerTypeCacheWithCurrentEpoch(t *testing.T) {
+	t.Parallel()
+
+	n := createStartConsensusNode(t, &mock.NodesCoordinatorMock{})
+
+	// sentinel start value: the refresh must overwrite it with the genesis
+	// epoch (0), proving RefreshPeerTypeCache was actually called
+	refreshedEpoch := uint32(999)
+	n.SetHeartbeatHandler(&heartbeatHandlerStub{refreshedEpoch: &refreshedEpoch})
+
+	// the wrapped fork controller does not implement EpochSubscriberHandler, so
+	// StartConsensus stops right after the peer type cache refresh
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
+	require.Equal(t, uint32(0), refreshedEpoch)
+}
+
+func TestStartConsensus_RefreshesPeerTypeCacheWithCurrentBlockEpoch(t *testing.T) {
+	t.Parallel()
+
+	// the mid-epoch restart case of issue #88: the restored chain head carries
+	// the real epoch, which is what the peer type cache must be rebuilt for
+	crtHeader := &block.Block{Header: &block.BlockHeader{Epoch: 7}}
+	n := createStartConsensusNode(t, &mock.NodesCoordinatorMock{}, crtHeader)
+
+	refreshedEpoch := uint32(999)
+	n.SetHeartbeatHandler(&heartbeatHandlerStub{refreshedEpoch: &refreshedEpoch})
+
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
+	require.Equal(t, uint32(7), refreshedEpoch)
+}
+
+func TestStartConsensus_SkipsPeerTypeCacheRefreshWithoutHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	n := createStartConsensusNode(t, &mock.NodesCoordinatorMock{})
+
+	// no heartbeat handler set: the refresh is skipped and StartConsensus
+	// proceeds to the fork-controller assertion
+	err := n.StartConsensus()
+	require.Equal(t, common.ErrWrongTypeAssertion, err)
 }


### PR DESCRIPTION
## Summary

The heartbeat `PeerTypeProvider` cache is built at heartbeat construction, before the storage bootstrapper restores the nodes coordinator state, and is only refreshed on epoch start events. After a mid-epoch restart every current validator therefore resolved to `observer` (own `klv_node_type`/`klv_peer_type` metrics and heartbeat monitor labels) until the next epoch switch. Reporting only, no consensus effect.

## Fix

- Expose `RefreshCache(epoch)` on `PeerTypeProvider` and `RefreshPeerTypeCache(epoch)` on the heartbeat handler; `StartConsensus` calls it right after `LoadStorage`, when both the restored coordinator state and the current epoch are available.
- Include the waiting list in the cache builder; it was never added, so waiting validators always reported as observer.
- Keep the previous cache when every validator list fetch fails, so a refresh for an unknown epoch cannot wipe valid labels; fetch errors are logged with the error value.
- Order cache updates by epoch between real updates, so a stale `RefreshCache(N)` can never clobber a concurrent epoch-start update for N+1. The construction-time seed deliberately does not claim epoch precedence: the post-bootstrap refresh also applies when the storage restore walks back to an epoch older than the construction epoch (found in pre-push audit; the earlier #92 version silently dropped that refresh).
- The nodes coordinator mock gains an epoch-aware `GetAllElectedValidatorsKeysWithEpochCalled` hook so tests can assert the epoch delegation.

## Tests

Coverage for: refresh after bootstrap resolves the real peer types, waiting validators are classified, a refresh where all three list fetches fail keeps the previous cache while empty-but-valid lists still replace it, the post-restore refresh applies for an epoch older than construction (walk-back regression), epoch ordering between real updates, a failed construction seed still constructs with an empty cache, the heartbeat handler delegates the epoch and guards nil receiver/provider, and `StartConsensus` calls the refresh with the boot epoch (and skips it without a heartbeat handler). Changed-line coverage measured at 100% of executable changed lines.

## Verification

`go build ./...` clean, `go vet` clean, `go test -race` green on `core/process/peer` (pre-existing unrelated race in `validatorsProvider` tests exists on `develop` and fails there identically; the tests pass without `-race` and none of the raced code is touched here), `node/heartbeat/...`, `node`, `common`, goimports clean.

Closes #88

## Merge order

Merge sequence for the split: #102 (part 1), #103 (part 2), #104 (part 3), #105 (part 4).

This is **PR 4 of 4** in the split of #92 (parts 1 to 3: `fix/coordinator-loadstate-map-rebuild`, `fix/fallback-sync-epoch-transition`, `fix/coordinator-readiness-startup-check`). Needs a rebase after part 3 merges. `node/node.go` no longer conflicts: part 3 moved its readiness check up to `LoadStorage`, while this PR's refresh block stays after the epoch computation. Two files still need a manual resolution, both verified locally to build and pass:
- `common/mock/nodesCoordinatorMock.go`: union of both sides (this PR's epoch-aware hook plus part 3's `IsReadyCalled` field and `IsReady` method).
- `node/node_test.go`: keep part 3's `newStartConsensusNode` helper and widen it with this PR's variadic `crtHeader` parameter, so the signature becomes `newStartConsensusNode(t, coordinator, loadAccountErr error, crtHeader ...data.HeaderHandler)`; add this PR's `GetCurrentBlockHeaderCalled` to the blockchain mock, then append both PRs' test functions. All six `TestStartConsensus_*` tests then coexist.
