### PR TITLE
fix: rebuild publicKeyToValidatorMap in nodesCoordinator LoadState

### DIFF
--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -127,10 +127,12 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		indexHashedNodesCoordinator: ihgs,
 	}
 
-	err = ihgs.saveState(ihgs.savedStateKey)
-	if err != nil {
-		log.Error("saving initial nodes coordinator config failed",
-			"error", err.Error())
+	if arguments.StartEpoch == 0 {
+		err = ihgs.saveState(ihgs.savedStateKey)
+		if err != nil {
+			log.Error("saving initial nodes coordinator config failed",
+				"error", err.Error())
+		}
 	}
 
 	log.Info("new nodes config is set for epoch", "epoch", arguments.Epoch)
@@ -281,8 +283,12 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 	}
 
 	displayNodesConfigInfo(nodesConfig)
+
+	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
+
 	ihgs.mutNodesConfig.Lock()
 	ihgs.nodesConfig = nodesConfig
+	ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
 	ihgs.mutNodesConfig.Unlock()
 
 	ihgs.stateReady.Store(true)
@@ -372,10 +378,18 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 	ihgs.mutNodesConfig.Lock()
 	defer ihgs.mutNodesConfig.Unlock()
 
+	ihgs.publicKeyToValidatorMap = ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
+}
+
+// computePublicKeyToValidatorMap merges the elected and eligible validators of
+// all given epoch configs into one lookup map, later epochs taking precedence
+func (ihgs *indexHashedNodesCoordinator) computePublicKeyToValidatorMap(
+	nodesConfig map[uint32]*epochNodesConfig,
+) map[string]Validator {
 	index := 0
-	epochList := make([]uint32, len(ihgs.nodesConfig))
+	epochList := make([]uint32, len(nodesConfig))
 	mapAllValidators := make(map[uint32]map[string]Validator)
-	for epoch, epochConfig := range ihgs.nodesConfig {
+	for epoch, epochConfig := range nodesConfig {
 		epochConfig.mutNodesMaps.RLock()
 		mapAllValidators[epoch] = ihgs.createPublicKeyToValidatorMap(epochConfig.electedList, epochConfig.eligibleList)
 		epochConfig.mutNodesMaps.RUnlock()
@@ -388,13 +402,15 @@ func (ihgs *indexHashedNodesCoordinator) fillPublicKeyToValidatorMap() {
 		return epochList[i] < epochList[j]
 	})
 
-	ihgs.publicKeyToValidatorMap = make(map[string]Validator)
+	publicKeyToValidatorMap := make(map[string]Validator)
 	for _, epoch := range epochList {
 		validatorsForEpoch := mapAllValidators[epoch]
 		for pubKey, vInfo := range validatorsForEpoch {
-			ihgs.publicKeyToValidatorMap[pubKey] = vInfo
+			publicKeyToValidatorMap[pubKey] = vInfo
 		}
 	}
+
+	return publicKeyToValidatorMap
 }
 
 func (ihgs *indexHashedNodesCoordinator) createPublicKeyToValidatorMap(

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -284,11 +284,14 @@ func (ihgs *indexHashedNodesCoordinator) LoadState(key []byte) error {
 
 	displayNodesConfigInfo(nodesConfig)
 
-	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(nodesConfig)
-
 	ihgs.mutNodesConfig.Lock()
 	ihgs.nodesConfig = nodesConfig
-	ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
+	publicKeyToValidatorMap := ihgs.computePublicKeyToValidatorMap(ihgs.nodesConfig)
+	if len(publicKeyToValidatorMap) > 0 {
+		ihgs.publicKeyToValidatorMap = publicKeyToValidatorMap
+	} else {
+		log.Warn("LoadState: restored registry produced empty validator map, keeping existing lookup")
+	}
 	ihgs.mutNodesConfig.Unlock()
 
 	ihgs.stateReady.Store(true)

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -809,37 +809,34 @@ func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) 
 func TestNodesCoordinator_LoadStateMultiEpochPrecedence(t *testing.T) {
 	t.Parallel()
 
-	sharedPK := []byte("shared-pk-appears-in-both-epochs")
+	sharedPK := []byte("shared-pk-appears-in-all-epochs")
 	bootStorer := mock.NewStorerMock()
 
-	epoch4Elected := []Validator{
-		mock.NewValidatorMock(sharedPK, sharedPK, DefaultSelectionChances, 10),
-		mock.NewValidatorMock([]byte("pk4_1"), []byte("pk4_1"), DefaultSelectionChances, 1),
-		mock.NewValidatorMock([]byte("pk4_2"), []byte("pk4_2"), DefaultSelectionChances, 2),
-		mock.NewValidatorMock([]byte("pk4_3"), []byte("pk4_3"), DefaultSelectionChances, 3),
-	}
-	epoch5Elected := []Validator{
-		mock.NewValidatorMock(sharedPK, sharedPK, DefaultSelectionChances, 20),
-		mock.NewValidatorMock([]byte("pk5_1"), []byte("pk5_1"), DefaultSelectionChances, 1),
-		mock.NewValidatorMock([]byte("pk5_2"), []byte("pk5_2"), DefaultSelectionChances, 2),
-		mock.NewValidatorMock([]byte("pk5_3"), []byte("pk5_3"), DefaultSelectionChances, 3),
+	baseEpoch := uint32(4)
+	numEpochs := uint32(5)
+	highestEpoch := baseEpoch + numEpochs - 1
+
+	makeElected := func(epoch, index uint32) []Validator {
+		return []Validator{
+			mock.NewValidatorMock(sharedPK, sharedPK, DefaultSelectionChances, index),
+			mock.NewValidatorMock([]byte(fmt.Sprintf("pk%d_1", epoch)), []byte(fmt.Sprintf("pk%d_1", epoch)), DefaultSelectionChances, 1),
+			mock.NewValidatorMock([]byte(fmt.Sprintf("pk%d_2", epoch)), []byte(fmt.Sprintf("pk%d_2", epoch)), DefaultSelectionChances, 2),
+			mock.NewValidatorMock([]byte(fmt.Sprintf("pk%d_3", epoch)), []byte(fmt.Sprintf("pk%d_3", epoch)), DefaultSelectionChances, 3),
+		}
 	}
 
 	args := createArguments()
 	args.BootStorer = bootStorer
-	args.ElectedNodes = epoch4Elected
+	args.ElectedNodes = makeElected(baseEpoch, baseEpoch*10)
 	args.EligibleNodes = createDummyNodesList(0, "eligible")
-	args.Epoch = 4
+	args.Epoch = baseEpoch
+	args.StartEpoch = baseEpoch
 	coordinator, err := NewNodesCoordinator(args)
 	require.Nil(t, err)
 
-	selector5, err := coordinator.createSelector(&epochNodesConfig{electedList: epoch5Elected})
-	require.Nil(t, err)
-	coordinator.nodesConfig[5] = &epochNodesConfig{
-		electedList:  epoch5Elected,
-		eligibleList: []Validator{},
-		waitingList:  []Validator{},
-		selector:     selector5,
+	for ep := baseEpoch + 1; ep <= highestEpoch; ep++ {
+		err = coordinator.SetNodes(makeElected(ep, ep*10), []Validator{}, []Validator{}, ep)
+		require.Nil(t, err)
 	}
 
 	savedKey := []byte("multi-epoch-key")
@@ -858,8 +855,8 @@ func TestNodesCoordinator_LoadStateMultiEpochPrecedence(t *testing.T) {
 
 	v, err := coordinatorLoad.GetValidatorWithPublicKey(sharedPK)
 	require.Nil(t, err)
-	require.Equal(t, uint32(20), v.Index(),
-		"later epoch (5) should take precedence over earlier epoch (4)")
+	require.Equal(t, highestEpoch*10, v.Index(),
+		"later epoch should take precedence over earlier epochs")
 }
 
 func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *testing.T) {
@@ -901,6 +898,7 @@ func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *test
 	thirdArgs.Hasher = firstArgs.Hasher
 	thirdArgs.ElectedNodes = genesisElected
 	thirdArgs.EligibleNodes = genesisEligible
+	thirdArgs.Epoch = 5
 	thirdArgs.StartEpoch = 5
 	thirdCoordinator, err := NewNodesCoordinator(thirdArgs)
 	require.Nil(t, err)

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -806,6 +806,62 @@ func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) 
 	require.Equal(t, ErrValidatorNotFound, err)
 }
 
+func TestNodesCoordinator_LoadStateMultiEpochPrecedence(t *testing.T) {
+	t.Parallel()
+
+	sharedPK := []byte("shared-pk-appears-in-both-epochs")
+	bootStorer := mock.NewStorerMock()
+
+	epoch4Elected := []Validator{
+		mock.NewValidatorMock(sharedPK, sharedPK, DefaultSelectionChances, 10),
+		mock.NewValidatorMock([]byte("pk4_1"), []byte("pk4_1"), DefaultSelectionChances, 1),
+		mock.NewValidatorMock([]byte("pk4_2"), []byte("pk4_2"), DefaultSelectionChances, 2),
+		mock.NewValidatorMock([]byte("pk4_3"), []byte("pk4_3"), DefaultSelectionChances, 3),
+	}
+	epoch5Elected := []Validator{
+		mock.NewValidatorMock(sharedPK, sharedPK, DefaultSelectionChances, 20),
+		mock.NewValidatorMock([]byte("pk5_1"), []byte("pk5_1"), DefaultSelectionChances, 1),
+		mock.NewValidatorMock([]byte("pk5_2"), []byte("pk5_2"), DefaultSelectionChances, 2),
+		mock.NewValidatorMock([]byte("pk5_3"), []byte("pk5_3"), DefaultSelectionChances, 3),
+	}
+
+	args := createArguments()
+	args.BootStorer = bootStorer
+	args.ElectedNodes = epoch4Elected
+	args.EligibleNodes = createDummyNodesList(0, "eligible")
+	args.Epoch = 4
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	selector5, err := coordinator.createSelector(&epochNodesConfig{electedList: epoch5Elected})
+	require.Nil(t, err)
+	coordinator.nodesConfig[5] = &epochNodesConfig{
+		electedList:  epoch5Elected,
+		eligibleList: []Validator{},
+		waitingList:  []Validator{},
+		selector:     selector5,
+	}
+
+	savedKey := []byte("multi-epoch-key")
+	err = coordinator.saveState(savedKey)
+	require.Nil(t, err)
+
+	argsLoad := createArguments()
+	argsLoad.BootStorer = bootStorer
+	argsLoad.ElectedNodes = createDummyNodesList(4, "genesis")
+	argsLoad.EligibleNodes = createDummyNodesList(0, "eligible")
+	coordinatorLoad, err := NewNodesCoordinator(argsLoad)
+	require.Nil(t, err)
+
+	err = coordinatorLoad.LoadState(savedKey)
+	require.Nil(t, err)
+
+	v, err := coordinatorLoad.GetValidatorWithPublicKey(sharedPK)
+	require.Nil(t, err)
+	require.Equal(t, uint32(20), v.Index(),
+		"later epoch (5) should take precedence over earlier epoch (4)")
+}
+
 func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *testing.T) {
 	t.Parallel()
 

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -843,20 +843,21 @@ func TestNodesCoordinator_LoadStateMultiEpochPrecedence(t *testing.T) {
 	err = coordinator.saveState(savedKey)
 	require.Nil(t, err)
 
-	argsLoad := createArguments()
-	argsLoad.BootStorer = bootStorer
-	argsLoad.ElectedNodes = createDummyNodesList(4, "genesis")
-	argsLoad.EligibleNodes = createDummyNodesList(0, "eligible")
-	coordinatorLoad, err := NewNodesCoordinator(argsLoad)
-	require.Nil(t, err)
+	for attempt := 0; attempt < 20; attempt++ {
+		argsLoad := createArguments()
+		argsLoad.BootStorer = bootStorer
+		argsLoad.ElectedNodes = createDummyNodesList(4, "genesis")
+		argsLoad.EligibleNodes = createDummyNodesList(0, "eligible")
+		coordinatorLoad, err := NewNodesCoordinator(argsLoad)
+		require.Nil(t, err)
 
-	err = coordinatorLoad.LoadState(savedKey)
-	require.Nil(t, err)
+		err = coordinatorLoad.LoadState(savedKey)
+		require.Nil(t, err)
 
-	v, err := coordinatorLoad.GetValidatorWithPublicKey(sharedPK)
-	require.Nil(t, err)
-	require.Equal(t, highestEpoch*10, v.Index(),
-		"later epoch should take precedence over earlier epochs")
+		v, err := coordinatorLoad.GetValidatorWithPublicKey(sharedPK)
+		require.Nil(t, err)
+		require.Equal(t, highestEpoch*10, v.Index(), "attempt %d", attempt)
+	}
 }
 
 func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *testing.T) {

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -759,3 +759,137 @@ func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {
 	require.Nil(t, err)
 	require.False(t, check.IfNil(ihgs3))
 }
+
+func TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap(t *testing.T) {
+	t.Parallel()
+
+	currentElected := createDummyNodesList(4, "currentElected")
+	currentEligible := createDummyNodesList(1, "currentEligible")
+	bootStorer := mock.NewStorerMock()
+
+	argsBefore := createArguments()
+	argsBefore.BootStorer = bootStorer
+	argsBefore.ElectedNodes = currentElected
+	argsBefore.EligibleNodes = currentEligible
+	coordinatorBefore, err := NewNodesCoordinator(argsBefore)
+	require.Nil(t, err)
+
+	savedStateKey := []byte("rotated-saved-state-key")
+	err = coordinatorBefore.saveState(savedStateKey)
+	require.Nil(t, err)
+
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	argsAfter := createArguments()
+	argsAfter.BootStorer = bootStorer
+	argsAfter.ElectedNodes = genesisElected
+	argsAfter.EligibleNodes = genesisEligible
+	coordinatorAfter, err := NewNodesCoordinator(argsAfter)
+	require.Nil(t, err)
+
+	_, err = coordinatorAfter.GetValidatorWithPublicKey(currentElected[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
+
+	err = coordinatorAfter.LoadState(savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := coordinatorAfter.GetValidatorWithPublicKey(currentElected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, currentElected[0].PubKey(), validator.PubKey())
+
+	eligibleValidator, err := coordinatorAfter.GetValidatorWithPublicKey(currentEligible[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, currentEligible[0].PubKey(), eligibleValidator.PubKey())
+
+	_, err = coordinatorAfter.GetValidatorWithPublicKey(genesisElected[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
+func TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart(t *testing.T) {
+	t.Parallel()
+
+	realElected := createDummyNodesList(4, "realElected")
+	realEligible := createDummyNodesList(1, "realEligible")
+	bootStorer := mock.NewStorerMock()
+
+	firstArgs := createArguments()
+	firstArgs.BootStorer = bootStorer
+	firstArgs.ElectedNodes = realElected
+	firstArgs.EligibleNodes = realEligible
+	firstArgs.Epoch = 5
+	firstArgs.StartEpoch = 5
+	firstCoordinator, err := NewNodesCoordinator(firstArgs)
+	require.Nil(t, err)
+
+	err = firstCoordinator.saveState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	genesisElected := createDummyNodesList(4, "genesisElected")
+	genesisEligible := createDummyNodesList(1, "genesisEligible")
+
+	secondArgs := createArguments()
+	secondArgs.BootStorer = bootStorer
+	secondArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	secondArgs.Hasher = firstArgs.Hasher
+	secondArgs.ElectedNodes = genesisElected
+	secondArgs.EligibleNodes = genesisEligible
+	secondArgs.Epoch = 5
+	secondArgs.StartEpoch = 5
+	_, err = NewNodesCoordinator(secondArgs)
+	require.Nil(t, err)
+
+	thirdArgs := createArguments()
+	thirdArgs.BootStorer = bootStorer
+	thirdArgs.SelfPublicKey = firstArgs.SelfPublicKey
+	thirdArgs.Hasher = firstArgs.Hasher
+	thirdArgs.ElectedNodes = genesisElected
+	thirdArgs.EligibleNodes = genesisEligible
+	thirdArgs.StartEpoch = 5
+	thirdCoordinator, err := NewNodesCoordinator(thirdArgs)
+	require.Nil(t, err)
+
+	err = thirdCoordinator.LoadState(firstCoordinator.savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := thirdCoordinator.GetValidatorWithPublicKey(realElected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, realElected[0].PubKey(), validator.PubKey())
+
+	_, err = thirdCoordinator.GetValidatorWithPublicKey(genesisElected[0].PubKey())
+	require.Equal(t, ErrValidatorNotFound, err)
+}
+
+func TestNodesCoordinator_ConstructorSavesStateOnGenesisStart(t *testing.T) {
+	t.Parallel()
+
+	elected := createDummyNodesList(4, "genesisElected")
+	eligible := createDummyNodesList(1, "genesisEligible")
+	bootStorer := mock.NewStorerMock()
+
+	args := createArguments()
+	args.BootStorer = bootStorer
+	args.ElectedNodes = elected
+	args.EligibleNodes = eligible
+	args.Epoch = 0
+	args.StartEpoch = 0
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	args2 := createArguments()
+	args2.BootStorer = bootStorer
+	args2.SelfPublicKey = args.SelfPublicKey
+	args2.Hasher = args.Hasher
+	args2.ElectedNodes = createDummyNodesList(4, "otherElected")
+	args2.EligibleNodes = createDummyNodesList(1, "otherEligible")
+	args2.StartEpoch = 1
+	coordinator2, err := NewNodesCoordinator(args2)
+	require.Nil(t, err)
+
+	err = coordinator2.LoadState(coordinator.savedStateKey)
+	require.Nil(t, err)
+
+	validator, err := coordinator2.GetValidatorWithPublicKey(elected[0].PubKey())
+	require.Nil(t, err)
+	require.Equal(t, elected[0].PubKey(), validator.PubKey())
+}


### PR DESCRIPTION
## Problem

A validator node that is restarted with an existing database stops following the chain per slot. After the restart it commits blocks only in bursts of ~20 blocks every 20 slots (80 seconds with 4s slots), with fully silent windows in between, and every burst starts by re-committing the previous tip block. The behavior persists until the next epoch boundary, after which the node follows per slot again. This was observed in production on fallback/redundancy nodes (`--redundancy-level=1`) but affects any restart from local storage.

## Root cause

`indexHashedNodesCoordinator.publicKeyToValidatorMap` is only filled in two places: the constructor and `EpochStartPrepare`. `LoadState` (the restart-from-storage path, called by the storage bootstrapper) restores the per-epoch validator configs into `nodesConfig` but never rebuilds the map.

On a restart, the epoch-start bootstrap returns `Parameters{NodesConfig: nil}` (it is only populated on the network start-in-epoch path), so the constructor falls back to the genesis nodes file and seeds the map with genesis-era validators only. `LoadState` then restores the correct per-epoch configs (so header signature verification works), but the map stays genesis-only until the next `EpochStartPrepare`.

### Full cascade (traced through code)

1. `LoadState` (`nodesCoordinator.go:252`) sets `nodesConfig` but does not rebuild `publicKeyToValidatorMap`
2. `GetValidatorWithPublicKey` (`nodesCoordinator.go:418`) looks up the stale (genesis-only) map and returns `ErrValidatorNotFound` for all current validators
3. `PeerShardMapper.getPeerInfoWithNodesCoordinator` (`peerShardMapper.go:127`) classifies all current validators as `core.UnknownPeer`
4. `p2pAntiflood.IsOriginatorElectedForTopic` (`p2pAntiflood.go:106`) rejects them because `PeerType != ValidatorPeer`
5. `SingleDataInterceptor.ProcessReceivedMessage` (`singleDataInterceptor.go:137`) drops every gossip header that is not on the request whitelist
6. The fork detector's `ProbableHighestNonce` never advances (no gossip headers reach the pool)
7. The node considers itself synchronized (`hasLastBlock = ProbableHighestNonce <= currentNonce`)
8. Only the 20-slot `requestHeadersIfSyncIsStuck` cycle (`SlotModulusTriggerWhenSyncIsStuck = 20`) brings headers in via explicit requests (which bypass the validator gate through the request whitelist)
9. Each request batch brings `MaxHeadersToRequestInAdvance = 20` headers, producing the observed burst-of-20 pattern every 80 seconds

### Why it self-heals at epoch boundary

`EpochStartPrepare` (line 781) calls `fillPublicKeyToValidatorMap()`, which rebuilds the map with the correct validators. After that, gossip headers are accepted and the node follows per slot.

### Second bug: constructor saveState overwrites real data

The constructor unconditionally calls `saveState(hash(selfPubKey))` (line 130). On a restart within the install epoch (`StartEpoch > 0`), this overwrites the previously saved real validator state with genesis data. A subsequent `LoadState` then reads back genesis entries instead of the correct validators.

## Fix (two behavioral changes)

### 1. Rebuild publicKeyToValidatorMap in LoadState

`computePublicKeyToValidatorMap` (extracted helper) merges the elected and eligible validators of all restored epoch configs into one lookup map. `LoadState` computes this map from the freshly restored `nodesConfig` *before* acquiring the write lock, then publishes both `nodesConfig` and the rebuilt map atomically under one `mutNodesConfig.Lock`, so `GetValidatorWithPublicKey` can never observe a state where configs are updated but the map is stale.

### 2. Guard initial saveState behind StartEpoch == 0

The constructor's `saveState` call persists the genesis-seeded `nodesConfig` under `hash(selfPubKey)`. On a restart within the install epoch (`StartEpoch > 0`), this would overwrite the previously saved real validator state with genesis data, causing `LoadState` to read back genesis entries. The constructor now only saves on a fresh genesis start (`StartEpoch == 0`).

## Validation

- Regression tests:
  - `TestNodesCoordinator_LoadStateRefillsPublicKeyToValidatorMap`: seeds a coordinator the way a restart does, verifies both elected and eligible validators resolve after `LoadState`, and genesis-seeded entries are gone.
  - `TestNodesCoordinator_ConstructorDoesNotOverwriteSavedStateOnRestart`: verifies a restart within the install epoch (`Epoch == StartEpoch > 0`, matching production shape) does not overwrite saved state.
  - `TestNodesCoordinator_ConstructorSavesStateOnGenesisStart`: verifies the constructor does save state when `StartEpoch == 0`, protecting the genesis-start path against a future inversion.
- `go test ./sharding/... -race` green; `go vet` clean.

## Notes

- No wire or storage format changes; fixed and unfixed nodes interoperate, so no coordinated rollout is needed.
- A related pre-existing gap exists on the network start-in-epoch path (`SetNodes` for the previous epoch also does not refill the map). It is a much smaller window, self-healing at the next boundary, and intentionally left out of this fix; it can be tracked separately.

## Test plan

- [ ] Verify `go test ./sharding/... -race` passes
- [ ] Verify `go vet ./sharding/...` is clean
- [ ] Validate on a testnet fallback node: mid-epoch restart on the fixed build should resume per-slot following immediately after catch-up, with zero silent windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Rebuilds `publicKeyToValidatorMap` from restored validator configurations during `nodesCoordinator.LoadState`.
- Gives later epoch configurations precedence for duplicate public keys.
- Updates validator configurations and the lookup map under the same lock.
- Preserves the existing lookup map when restored data produces an empty map and logs a warning.
- Prevents current validators from being classified as unknown after restart.
- Prevents gossip headers from being dropped during validator-node synchronization.
- Prevents persisted validator state from being overwritten by genesis data when `StartEpoch > 0`.
- Saves initial state only when `StartEpoch == 0`.
- Improves node stability and validator-state integrity after restart.
- Limits the change to sharding state management and validator networking.
- Introduces no wire or storage format changes.
- Adds regression tests for map rebuilding, multi-epoch precedence, and constructor persistence.
- Reports passing race tests and `go vet` checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->