### PR TITLE
fix: refresh PeerTypeProvider cache after storage bootstrap and include waiting list

### DIFF
--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -10,22 +10,25 @@ import (
 
 // NodesCoordinatorMock defines the behaviour of a struct able to do validator group selection
 type NodesCoordinatorMock struct {
-	Validators                              []sharding.Validator
-	ConsensusSize                           uint32
-	GetSelectedPublicKeysCalled             func(selection []byte, epoch uint32) (publicKeys []string, err error)
-	GetValidatorsPublicKeysCalled           func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	GetValidatorsRewardsAddressesCalled     func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	SetNodesCalled                          func(nodes []sharding.Validator, epoch uint32) error
-	ComputeValidatorsGroupCalled            func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
-	GetValidatorWithPublicKeyCalled         func(publicKey []byte) (validator sharding.Validator, err error)
-	GetAllElectedValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllEligibleValidatorsKeysCalled      func() ([][]byte, error)
-	GetAllWaitingValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllLeavingValidatorsPublicKeysCalled func() ([][]byte, error)
-	CheckValidatorSlotCalled                func(epoch uint32, slotIndex int64, pubkey []byte) bool
-	ConsensusGroupSizeCalled                func() int
-	LoadValidatorsCalled                    func(validators []*state.ValidatorInfo) error
-	SetEpochValidatorsInfoCalled            func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
+	Validators                                  []sharding.Validator
+	ConsensusSize                               uint32
+	GetSelectedPublicKeysCalled                 func(selection []byte, epoch uint32) (publicKeys []string, err error)
+	GetValidatorsPublicKeysCalled               func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	GetValidatorsRewardsAddressesCalled         func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	SetNodesCalled                              func(nodes []sharding.Validator, epoch uint32) error
+	ComputeValidatorsGroupCalled                func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
+	GetValidatorWithPublicKeyCalled             func(publicKey []byte) (validator sharding.Validator, err error)
+	GetAllElectedValidatorsKeysCalled           func() ([][]byte, error)
+	GetAllElectedValidatorsKeysWithEpochCalled  func(uint32, bool) ([][]byte, error)
+	GetAllEligibleValidatorsKeysCalled          func() ([][]byte, error)
+	GetAllEligibleValidatorsKeysWithEpochCalled func(uint32, bool) ([][]byte, error)
+	GetAllWaitingValidatorsKeysCalled           func() ([][]byte, error)
+	GetAllWaitingValidatorsKeysWithEpochCalled  func(uint32, bool) ([][]byte, error)
+	GetAllLeavingValidatorsPublicKeysCalled     func() ([][]byte, error)
+	CheckValidatorSlotCalled                    func(epoch uint32, slotIndex int64, pubkey []byte) bool
+	ConsensusGroupSizeCalled                    func() int
+	LoadValidatorsCalled                        func(validators []*state.ValidatorInfo) error
+	SetEpochValidatorsInfoCalled                func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
 }
 
 // NewNodesCoordinatorMock -
@@ -59,7 +62,10 @@ func (ncm *NodesCoordinatorMock) GetNumTotalEligible() uint64 {
 }
 
 // GetAllElectedValidatorsKeys -
-func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(epoch uint32, includeLeaving bool) ([][]byte, error) {
+	if ncm.GetAllElectedValidatorsKeysWithEpochCalled != nil {
+		return ncm.GetAllElectedValidatorsKeysWithEpochCalled(epoch, includeLeaving)
+	}
 	if ncm.GetAllElectedValidatorsKeysCalled != nil {
 		return ncm.GetAllElectedValidatorsKeysCalled()
 	}
@@ -67,7 +73,10 @@ func (ncm *NodesCoordinatorMock) GetAllElectedValidatorsKeys(_ uint32, _ bool) (
 }
 
 // GetAllEligibleValidatorsKeys -
-func (ncm *NodesCoordinatorMock) GetAllEligibleValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+func (ncm *NodesCoordinatorMock) GetAllEligibleValidatorsKeys(epoch uint32, includeLeaving bool) ([][]byte, error) {
+	if ncm.GetAllEligibleValidatorsKeysWithEpochCalled != nil {
+		return ncm.GetAllEligibleValidatorsKeysWithEpochCalled(epoch, includeLeaving)
+	}
 	if ncm.GetAllEligibleValidatorsKeysCalled != nil {
 		return ncm.GetAllEligibleValidatorsKeysCalled()
 	}
@@ -75,7 +84,10 @@ func (ncm *NodesCoordinatorMock) GetAllEligibleValidatorsKeys(_ uint32, _ bool) 
 }
 
 // GetAllWaitingValidatorsKeys -
-func (ncm *NodesCoordinatorMock) GetAllWaitingValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+func (ncm *NodesCoordinatorMock) GetAllWaitingValidatorsKeys(epoch uint32, includeLeaving bool) ([][]byte, error) {
+	if ncm.GetAllWaitingValidatorsKeysWithEpochCalled != nil {
+		return ncm.GetAllWaitingValidatorsKeysWithEpochCalled(epoch, includeLeaving)
+	}
 	if ncm.GetAllWaitingValidatorsKeysCalled != nil {
 		return ncm.GetAllWaitingValidatorsKeysCalled()
 	}

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -101,8 +101,14 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 }
 
 // UpdateCache rebuilds the validator-type cache for the given epoch.
+// When the coordinator cannot provide validator lists (e.g. unknown epoch),
+// the previous cache is kept to avoid replacing valid data with an empty map.
 func (ptp *PeerTypeProvider) UpdateCache(epoch uint32) {
-	newCache := ptp.createNewCache(epoch)
+	newCache, ok := ptp.createNewCache(epoch)
+	if !ok {
+		log.Warn("peerTypeProvider - keeping previous cache, validator list unavailable", "epoch", epoch)
+		return
+	}
 
 	ptp.mutCache.Lock()
 	ptp.cache = newCache
@@ -111,28 +117,24 @@ func (ptp *PeerTypeProvider) UpdateCache(epoch uint32) {
 
 func (ptp *PeerTypeProvider) createNewCache(
 	epoch uint32,
-) map[string]*peerListAndShard {
+) (map[string]*peerListAndShard, bool) {
 	newCache := make(map[string]*peerListAndShard)
-
-	nodesMapWaiting, err := ptp.nodesCoordinator.GetAllWaitingValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("peerTypeProvider - GetAllWaitingValidatorsKeys failed", "epoch", epoch)
-	}
-	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
 
 	nodesMapElected, err := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
 	if err != nil {
-		log.Debug("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch)
+		log.Warn("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch, "error", err)
+		return nil, false
 	}
 	computePeerType(newCache, nodesMapElected, core.ElectedList)
 
 	nodesMapEligible, err := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
 	if err != nil {
-		log.Debug("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch)
+		log.Warn("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch, "error", err)
+		return nil, false
 	}
 	computePeerType(newCache, nodesMapEligible, core.EligibleList)
 
-	return newCache
+	return newCache, true
 }
 
 func computePeerType(

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -47,7 +47,7 @@ func NewPeerTypeProvider(arg ArgPeerTypeProvider) (*PeerTypeProvider, error) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	ptp.updateCache(arg.StartEpoch)
+	ptp.UpdateCache(arg.StartEpoch)
 
 	arg.EpochStartEventNotifier.RegisterHandler(ptp.epochStartEventHandler())
 
@@ -91,7 +91,7 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 				"nonce", hdr.GetNonce(),
 				"slot", hdr.GetSlot(),
 				"epoch", hdr.GetEpoch())
-			ptp.updateCache(hdr.GetEpoch())
+			ptp.UpdateCache(hdr.GetEpoch())
 		},
 		func(_ data.HeaderHandler) {},
 		core.IndexerOrder,
@@ -100,7 +100,8 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 	return subscribeHandler
 }
 
-func (ptp *PeerTypeProvider) updateCache(epoch uint32) {
+// UpdateCache rebuilds the validator-type cache for the given epoch.
+func (ptp *PeerTypeProvider) UpdateCache(epoch uint32) {
 	newCache := ptp.createNewCache(epoch)
 
 	ptp.mutCache.Lock()
@@ -112,6 +113,12 @@ func (ptp *PeerTypeProvider) createNewCache(
 	epoch uint32,
 ) map[string]*peerListAndShard {
 	newCache := make(map[string]*peerListAndShard)
+
+	nodesMapWaiting, err := ptp.nodesCoordinator.GetAllWaitingValidatorsKeys(epoch, false)
+	if err != nil {
+		log.Debug("peerTypeProvider - GetAllWaitingValidatorsKeys failed", "epoch", epoch)
+	}
+	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
 
 	nodesMapElected, err := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
 	if err != nil {

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -121,8 +121,9 @@ func TestNewPeerTypeProvider_createCache(t *testing.T) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
 
+	require.True(t, ok)
 	assert.NotNil(t, cache)
 
 	assert.NotNil(t, cache[pkElected])
@@ -275,8 +276,9 @@ func TestPeerTypeProvider_CreateNewCacheScenarios(t *testing.T) {
 	}
 	ptp, _ := NewPeerTypeProvider(arg)
 
-	cache := ptp.createNewCache(0)
-	assert.Len(t, cache, 3)
+	cache, ok := ptp.createNewCache(0)
+	require.True(t, ok)
+	require.Len(t, cache, 3)
 	assert.Equal(t, core.EligibleList, cache["elected1"].pType) // elected1 is also eligible as it have been updated in the eligible list
 	assert.Equal(t, core.ElectedList, cache["elected2"].pType)
 	assert.Equal(t, core.EligibleList, cache["eligible1"].pType)
@@ -319,14 +321,11 @@ func TestPeerTypeProvider_GetAllPeerTypeInfos(t *testing.T) {
 	assert.Empty(t, emptyPeerTypeInfos, "Should return empty slice for empty cache")
 }
 
-func TestPeerTypeProvider_CreateNewCache_IncludesWaitingList(t *testing.T) {
+func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 	t.Parallel()
 
 	arg := createDefaultArgPeerTypeProvider()
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte("waiting1")}, nil
-		},
 		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
 			return [][]byte{[]byte("elected1")}, nil
 		},
@@ -341,84 +340,32 @@ func TestPeerTypeProvider_CreateNewCache_IncludesWaitingList(t *testing.T) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	cache := ptp.createNewCache(0)
+	ptp.UpdateCache(0)
+	require.Len(t, ptp.cache, 2)
 
-	assert.Len(t, cache, 3)
-	assert.Equal(t, core.WaitingList, cache["waiting1"].pType)
-	assert.Equal(t, core.ElectedList, cache["elected1"].pType)
-	assert.Equal(t, core.EligibleList, cache["eligible1"].pType)
-}
-
-func TestPeerTypeProvider_CreateNewCache_WaitingOverwrittenByElected(t *testing.T) {
-	t.Parallel()
-
-	pk := "overlapping_pk"
-
-	arg := createDefaultArgPeerTypeProvider()
-	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte(pk)}, nil
-		},
+	ptp.nodesCoordinator = &mock.NodesCoordinatorMock{
 		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte(pk)}, nil
+			return nil, fmt.Errorf("epoch config does not exist")
 		},
 	}
 
-	ptp := PeerTypeProvider{
-		nodesCoordinator: arg.NodesCoordinator,
-		cache:            nil,
-		mutCache:         sync.RWMutex{},
-	}
+	ptp.UpdateCache(99)
 
-	cache := ptp.createNewCache(0)
-
-	assert.Len(t, cache, 1)
-	assert.Equal(t, core.ElectedList, cache[pk].pType)
+	require.Len(t, ptp.cache, 2)
+	assert.Equal(t, core.ElectedList, ptp.cache["elected1"].pType)
+	assert.Equal(t, core.EligibleList, ptp.cache["eligible1"].pType)
 }
 
-func TestPeerTypeProvider_CreateNewCache_AllThreeOverlap(t *testing.T) {
-	t.Parallel()
-
-	pk := "overlapping_pk"
-
-	arg := createDefaultArgPeerTypeProvider()
-	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte(pk)}, nil
-		},
-		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte(pk)}, nil
-		},
-		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte(pk)}, nil
-		},
-	}
-
-	ptp := PeerTypeProvider{
-		nodesCoordinator: arg.NodesCoordinator,
-		cache:            nil,
-		mutCache:         sync.RWMutex{},
-	}
-
-	cache := ptp.createNewCache(0)
-
-	assert.Len(t, cache, 1)
-	assert.Equal(t, core.EligibleList, cache[pk].pType)
-}
-
-func TestPeerTypeProvider_CreateNewCache_WaitingErrorDoesNotAffectOtherLists(t *testing.T) {
+func TestPeerTypeProvider_CreateNewCache_FailsOnAnyGetterError(t *testing.T) {
 	t.Parallel()
 
 	arg := createDefaultArgPeerTypeProvider()
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
-			return nil, fmt.Errorf("waiting list unavailable")
-		},
 		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
 			return [][]byte{[]byte("elected1")}, nil
 		},
 		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte("eligible1")}, nil
+			return nil, fmt.Errorf("eligible list unavailable")
 		},
 	}
 
@@ -428,36 +375,8 @@ func TestPeerTypeProvider_CreateNewCache_WaitingErrorDoesNotAffectOtherLists(t *
 		mutCache:         sync.RWMutex{},
 	}
 
-	cache := ptp.createNewCache(0)
+	cache, ok := ptp.createNewCache(0)
 
-	assert.Len(t, cache, 2)
-	assert.Equal(t, core.ElectedList, cache["elected1"].pType)
-	assert.Equal(t, core.EligibleList, cache["eligible1"].pType)
-}
-
-func TestPeerTypeProvider_CreateNewCache_WaitingOverwrittenByEligible(t *testing.T) {
-	t.Parallel()
-
-	pk := "overlapping_pk"
-
-	arg := createDefaultArgPeerTypeProvider()
-	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte(pk)}, nil
-		},
-		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
-			return [][]byte{[]byte(pk)}, nil
-		},
-	}
-
-	ptp := PeerTypeProvider{
-		nodesCoordinator: arg.NodesCoordinator,
-		cache:            nil,
-		mutCache:         sync.RWMutex{},
-	}
-
-	cache := ptp.createNewCache(0)
-
-	assert.Len(t, cache, 1)
-	assert.Equal(t, core.EligibleList, cache[pk].pType)
+	assert.False(t, ok)
+	assert.Nil(t, cache)
 }

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -84,7 +84,7 @@ func TestPeerTypeProvider_UpdateCache(t *testing.T) {
 		mutCache:         sync.RWMutex{},
 	}
 
-	ptp.updateCache(0)
+	ptp.UpdateCache(0)
 
 	assert.NotNil(t, ptp.cache)
 	assert.Equal(t, len(elected), len(ptp.cache))
@@ -316,4 +316,118 @@ func TestPeerTypeProvider_GetAllPeerTypeInfos(t *testing.T) {
 	ptp.cache = make(map[string]*peerListAndShard)
 	emptyPeerTypeInfos := ptp.GetAllPeerTypeInfos()
 	assert.Empty(t, emptyPeerTypeInfos, "Should return empty slice for empty cache")
+}
+
+func TestPeerTypeProvider_CreateNewCache_IncludesWaitingList(t *testing.T) {
+	t.Parallel()
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("waiting1")}, nil
+		},
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("elected1")}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("eligible1")}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache := ptp.createNewCache(0)
+
+	assert.Len(t, cache, 3)
+	assert.Equal(t, core.WaitingList, cache["waiting1"].pType)
+	assert.Equal(t, core.ElectedList, cache["elected1"].pType)
+	assert.Equal(t, core.EligibleList, cache["eligible1"].pType)
+}
+
+func TestPeerTypeProvider_CreateNewCache_WaitingOverwrittenByElected(t *testing.T) {
+	t.Parallel()
+
+	pk := "overlapping_pk"
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pk)}, nil
+		},
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pk)}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache := ptp.createNewCache(0)
+
+	assert.Len(t, cache, 1)
+	assert.Equal(t, core.ElectedList, cache[pk].pType)
+}
+
+func TestPeerTypeProvider_CreateNewCache_AllThreeOverlap(t *testing.T) {
+	t.Parallel()
+
+	pk := "overlapping_pk"
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pk)}, nil
+		},
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pk)}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pk)}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache := ptp.createNewCache(0)
+
+	assert.Len(t, cache, 1)
+	assert.Equal(t, core.EligibleList, cache[pk].pType)
+}
+
+func TestPeerTypeProvider_CreateNewCache_WaitingOverwrittenByEligible(t *testing.T) {
+	t.Parallel()
+
+	pk := "overlapping_pk"
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pk)}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte(pk)}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache := ptp.createNewCache(0)
+
+	assert.Len(t, cache, 1)
+	assert.Equal(t, core.EligibleList, cache[pk].pType)
 }

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -403,6 +404,35 @@ func TestPeerTypeProvider_CreateNewCache_AllThreeOverlap(t *testing.T) {
 
 	assert.Len(t, cache, 1)
 	assert.Equal(t, core.EligibleList, cache[pk].pType)
+}
+
+func TestPeerTypeProvider_CreateNewCache_WaitingErrorDoesNotAffectOtherLists(t *testing.T) {
+	t.Parallel()
+
+	arg := createDefaultArgPeerTypeProvider()
+	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return nil, fmt.Errorf("waiting list unavailable")
+		},
+		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("elected1")}, nil
+		},
+		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("eligible1")}, nil
+		},
+	}
+
+	ptp := PeerTypeProvider{
+		nodesCoordinator: arg.NodesCoordinator,
+		cache:            nil,
+		mutCache:         sync.RWMutex{},
+	}
+
+	cache := ptp.createNewCache(0)
+
+	assert.Len(t, cache, 2)
+	assert.Equal(t, core.ElectedList, cache["elected1"].pType)
+	assert.Equal(t, core.EligibleList, cache["eligible1"].pType)
 }
 
 func TestPeerTypeProvider_CreateNewCache_WaitingOverwrittenByEligible(t *testing.T) {

--- a/node/heartbeat/componentHandler/heartbeatHandler.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler.go
@@ -281,6 +281,14 @@ func (hbh *HeartbeatHandler) Close() error {
 	return nil
 }
 
+// RefreshPeerTypeCache forces the peer-type cache to rebuild for the given epoch.
+func (hbh *HeartbeatHandler) RefreshPeerTypeCache(epoch uint32) {
+	if hbh.peerTypeProvider == nil {
+		return
+	}
+	hbh.peerTypeProvider.UpdateCache(epoch)
+}
+
 // IsInterfaceNil returns true if there is no value under the interface
 func (hbh *HeartbeatHandler) IsInterfaceNil() bool {
 	return hbh == nil

--- a/node/heartbeat/componentHandler/heartbeatHandler_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_test.go
@@ -152,6 +152,9 @@ func TestHeartbeatHandler_RefreshPeerTypeCache(t *testing.T) {
 	arg := createMockArgument()
 	hbh, err := NewHeartbeatHandler(arg)
 	require.Nil(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, hbh.Close())
+	})
 
 	peerType, _, _ := hbh.peerTypeProvider.ComputeForPubKey(newPK)
 	assert.Equal(t, core.ObserverList, peerType)
@@ -165,10 +168,6 @@ func TestHeartbeatHandler_RefreshPeerTypeCache(t *testing.T) {
 
 	peerType, _, _ = hbh.peerTypeProvider.ComputeForPubKey(newPK)
 	assert.Equal(t, core.ElectedList, peerType)
-
-	time.Sleep(time.Second)
-	_ = hbh.Close()
-	time.Sleep(time.Second)
 }
 
 func TestHeartbeatHandler_RefreshPeerTypeCache_NilProvider(t *testing.T) {

--- a/node/heartbeat/componentHandler/heartbeatHandler_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_test.go
@@ -7,6 +7,7 @@ import (
 
 	cMock "github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/config"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/node/heartbeat"
 	"github.com/klever-io/klever-go/node/heartbeat/mock"
 	"github.com/klever-io/klever-go/tools/check"
@@ -141,4 +142,43 @@ func TestNewHeartbeatHandler_ShouldWork(t *testing.T) {
 
 	// let the sending go routine finish
 	time.Sleep(time.Second)
+}
+
+func TestHeartbeatHandler_RefreshPeerTypeCache(t *testing.T) {
+	t.Parallel()
+
+	newPK := []byte("new_validator")
+
+	arg := createMockArgument()
+	hbh, err := NewHeartbeatHandler(arg)
+	require.Nil(t, err)
+
+	peerType, _, _ := hbh.peerTypeProvider.ComputeForPubKey(newPK)
+	assert.Equal(t, core.ObserverList, peerType)
+
+	ncMock := arg.NodesCoordinator.(*cMock.NodesCoordinatorMock)
+	ncMock.GetAllElectedValidatorsKeysCalled = func() ([][]byte, error) {
+		return [][]byte{newPK}, nil
+	}
+
+	hbh.RefreshPeerTypeCache(1)
+
+	peerType, _, _ = hbh.peerTypeProvider.ComputeForPubKey(newPK)
+	assert.Equal(t, core.ElectedList, peerType)
+
+	time.Sleep(time.Second)
+	_ = hbh.Close()
+	time.Sleep(time.Second)
+}
+
+func TestHeartbeatHandler_RefreshPeerTypeCache_NilProvider(t *testing.T) {
+	t.Parallel()
+
+	hbh := &HeartbeatHandler{
+		peerTypeProvider: nil,
+	}
+
+	assert.NotPanics(t, func() {
+		hbh.RefreshPeerTypeCache(0)
+	})
 }

--- a/node/heartbeat/componentHandler/heartbeatHandler_test.go
+++ b/node/heartbeat/componentHandler/heartbeatHandler_test.go
@@ -148,6 +148,7 @@ func TestHeartbeatHandler_RefreshPeerTypeCache(t *testing.T) {
 	t.Parallel()
 
 	newPK := []byte("new_validator")
+	targetEpoch := uint32(7)
 
 	arg := createMockArgument()
 	hbh, err := NewHeartbeatHandler(arg)
@@ -159,13 +160,16 @@ func TestHeartbeatHandler_RefreshPeerTypeCache(t *testing.T) {
 	peerType, _, _ := hbh.peerTypeProvider.ComputeForPubKey(newPK)
 	assert.Equal(t, core.ObserverList, peerType)
 
+	var capturedEpoch uint32
 	ncMock := arg.NodesCoordinator.(*cMock.NodesCoordinatorMock)
-	ncMock.GetAllElectedValidatorsKeysCalled = func() ([][]byte, error) {
+	ncMock.GetAllElectedValidatorsKeysWithEpochCalled = func(epoch uint32, _ bool) ([][]byte, error) {
+		capturedEpoch = epoch
 		return [][]byte{newPK}, nil
 	}
 
-	hbh.RefreshPeerTypeCache(1)
+	hbh.RefreshPeerTypeCache(targetEpoch)
 
+	assert.Equal(t, targetEpoch, capturedEpoch)
 	peerType, _, _ = hbh.peerTypeProvider.ComputeForPubKey(newPK)
 	assert.Equal(t, core.ElectedList, peerType)
 }

--- a/node/interface.go
+++ b/node/interface.go
@@ -76,6 +76,7 @@ type Accumulator interface {
 type HeartbeatHandler interface {
 	Monitor() *process.Monitor
 	Sender() *process.Sender
+	RefreshPeerTypeCache(epoch uint32)
 	Close() error
 	IsInterfaceNil() bool
 }

--- a/node/node.go
+++ b/node/node.go
@@ -332,6 +332,10 @@ func (n *Node) StartConsensus() error {
 		epoch = crtBlockHeader.GetEpoch()
 	}
 
+	if !check.IfNil(n.heartbeatHandler) {
+		n.heartbeatHandler.RefreshPeerTypeCache(epoch)
+	}
+
 	forkControllerSubscriber, ok := n.forkController.(core.EpochSubscriberHandler)
 	if !ok {
 		return common.ErrWrongTypeAssertion

--- a/node/node.go
+++ b/node/node.go
@@ -332,7 +332,7 @@ func (n *Node) StartConsensus() error {
 		epoch = crtBlockHeader.GetEpoch()
 	}
 
-	if !check.IfNil(n.heartbeatHandler) {
+	if !check.IfNil(crtBlockHeader) && !check.IfNil(n.heartbeatHandler) {
 		n.heartbeatHandler.RefreshPeerTypeCache(epoch)
 	}
 


### PR DESCRIPTION
## Context

Closes #88.

When a node restarts mid-epoch (crash, maintenance, temporary outage), the heartbeat metrics `klv_node_type` and `klv_peer_type` report every post-genesis validator as `observer` from startup until the next epoch boundary. Consensus is unaffected; only the metrics/status reporting is wrong.

### Root cause: stale cache after mid-epoch restart

The startup sequence builds the `PeerTypeProvider` cache before the real validator data is available:

1. `createNodesCoordinator` seeds the coordinator with genesis/bootstrap config only.
2. `createNode` -> `StartHeartbeat` -> `NewPeerTypeProvider` -> `updateCache()` populates the cache from the not-yet-loaded coordinator. At this point `nodesConfig` only holds genesis-era keys.
3. Much later, `StartConsensus` -> `LoadStorage` -> `nodesCoordinator.LoadState()` restores the real per-epoch validator configs from disk.

Nothing refreshes the `PeerTypeProvider` cache after step 3. The cache stays populated with genesis keys. The only existing refresh path is the epoch-start event handler, which only fires on a *new* epoch boundary, not on a mid-epoch restart.

The effect is wrong in both directions: post-genesis validators (eligible/elected in the current epoch) are downgraded to "observer", while genesis-era keys that are no longer active get promoted to "elected" because they still appear in the genesis `nodesSetup.json`.

## What this PR does

### Cache refresh after storage bootstrap

- Export `updateCache` as `UpdateCache` on `PeerTypeProvider`, so the heartbeat subsystem can trigger a rebuild externally.
- Add `RefreshPeerTypeCache(epoch uint32)` to the `HeartbeatHandler` interface and its concrete implementation, delegating to `PeerTypeProvider.UpdateCache`.
- Call `RefreshPeerTypeCache(epoch)` from `Node.StartConsensus()` after `LoadStorage()` completes and the epoch has been determined from the chain. At this point the nodes coordinator has real validator data from `LoadState`, and the epoch is correctly derived from the restored block header.

### Two guards so the refresh can never make things worse

Both were raised in review and both are addressed:

- **Skip the refresh when no current block header exists.** When `LoadStorage` cannot restore a header (fresh sync, wiped storage, bootstrap failure), the epoch falls back to the genesis epoch. Refreshing with that epoch could replace a populated cache with wrong data. The call is guarded with `!check.IfNil(crtBlockHeader)`, so the refresh only runs when a restored header proves the coordinator has real data for that epoch.
- **Keep the previous cache when the coordinator cannot serve the epoch.** `createNewCache` now returns `(map, ok)` and fails on *any* getter error (the coordinator returns `ErrEpochNodesConfigDoesNotExist` for unknown epochs). `UpdateCache` keeps the previous cache and logs a Warn (with the error value) instead of installing an empty or partial map over valid data. This restores the keep-previous guard that PR #92 introduced for the same failure mode.

### Scope note: waiting-list support was split out

An earlier revision of this PR also seeded the cache with the waiting list. Review showed that change has consequences beyond this fix: `Monitor.shouldSkipValidator` and `heartbeatMessageInfo.GetIsValidator` only count elected/eligible, so waiting nodes would report contradictory metrics (`node_type=validator` on the node itself, absent from the network-wide validator view) and cause per-tick create/delete churn in the monitor under lock. That change needs the monitor side updated with it, so it was dropped here and will be a separate PR. This PR is a single behaviour change: the stale-cache fix.

## Why this approach (and not alternatives)

**Considered: fire `NotifyAll` on the epoch-start subscription handler after `LoadState`.** Rejected because it would trigger *all* epoch-start subscribers, not just the `PeerTypeProvider`. Notably, `nodesCoordinator.EpochStartAction` calls `saveState()` (writes to disk, prunes old configs) and `netStatistics` resets per-epoch byte counters to zero. A synthetic epoch event would cause real side effects in components that have nothing to do with this metrics bug.

**Considered: inject the epoch notifier into `storageBootstrapper` and fire `NotifyAll` from `applyBootInfos`.** Same blast radius problem, plus it requires changing `ArgsBaseStorageBootstrapper` (a widely-used struct) and threading a notifier through a low-level component that currently has no notion of epoch notifications.

**Chosen: direct, targeted refresh.** Only the `PeerTypeProvider` cache is rebuilt. No synthetic epoch events, no side effects on other components. The refresh call sits at the right lifecycle point in `StartConsensus` where both the restored validator data and the correct epoch are available.

Review also recorded two related pre-existing issues that this PR deliberately does not touch (both point at the same architectural follow-up: seed providers with the bootstrapped epoch instead of the pre-bootstrap one): the construction-time cache is still built from the pre-bootstrap epoch and serves reads until `StartConsensus`, and `validatorsProvider` has the same stale-epoch bug with no refresh. Worth its own issue; too big for this diff.

## Consensus safety

`PeerTypeProvider` is used exclusively by the heartbeat subsystem:
- `heartbeat/process/sender.go:191` (`ComputeForPubKey` for heartbeat message composition)
- `heartbeat/process/monitor.go:364` (`ComputeForPubKey` for peer type display/metrics)

It is not referenced anywhere in consensus group selection, block processing, or epoch transitions. This change has zero consensus impact.

## Thread safety

`UpdateCache` builds a complete new cache map outside the lock, then atomically swaps the map reference under `mutCache.Lock`. `ComputeForPubKey` reads under `mutCache.RLock`. This is the same `sync.RWMutex` pattern already in place. The constructor call runs before the sender goroutine starts, and the `StartConsensus` refresh runs before `StartSyncingBlocks`, so no epoch-start event can interleave with it. The heartbeat sender goroutine may read the stale cache for a few seconds during boot; this is a pre-existing condition that this change reduces from "remainder of epoch" to "seconds".

## Files changed

| File | Change |
|------|--------|
| `core/process/peer/peerTypeProvider.go` | Export `updateCache` -> `UpdateCache`; `createNewCache` returns `(map, ok)` and fails on any getter error; `UpdateCache` keeps the previous cache on failure; Warn logging with error values |
| `core/process/peer/peerTypeProvider_test.go` | Update `createNewCache`/`UpdateCache` callers; add keep-previous-on-failure and fail-fast-on-any-getter-error tests; `require.Len` before map dereferences |
| `common/mock/nodesCoordinatorMock.go` | Add epoch-aware hook variants (`...WithEpochCalled`) so tests can assert which epoch reaches the coordinator |
| `node/heartbeat/componentHandler/heartbeatHandler.go` | Add `RefreshPeerTypeCache` method |
| `node/heartbeat/componentHandler/heartbeatHandler_test.go` | Add 2 tests (refresh with epoch-forwarding assertion, nil-safety) |
| `node/interface.go` | Add `RefreshPeerTypeCache` to `HeartbeatHandler` interface |
| `node/node.go` | Call `RefreshPeerTypeCache` in `StartConsensus` after `LoadStorage`, guarded on a restored block header |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./core/process/peer/... ./node/...` passes
- [x] `go test ./core/process/peer/...` passes (existing + new tests)
- [x] `go test ./node/heartbeat/componentHandler/...` passes (existing + new tests)
- [x] `go test ./node/...` passes
- [x] Three-agent audit (security, code review, adversarial full-diff), plus a second independent full-diff review after the review-feedback revision
- [ ] CI checks green
- [ ] Validated live on mainnet node (see #88 comment for reproduction procedure)

## Known gap

The `StartConsensus` wiring itself (call site, ordering after `LoadStorage`, nil-header guard) has no node-level test: exercising `StartConsensus` requires mocking 30+ `Node` dependencies. The behaviour on either side of the wiring is pinned by unit tests (`UpdateCache` semantics, keep-previous guard, epoch forwarding through `RefreshPeerTypeCache`). Accepted and recorded as a conscious trade-off.
