### PR TITLE
test: fix data race in core/process/peer validatorsProvider tests

### DIFF
--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -278,7 +278,11 @@ func TestValidatorsProvider_ConcurrentAccess(t *testing.T) {
 	}
 	vp, err := NewValidatorsProvider(arg)
 	require.Nil(t, err)
-	t.Cleanup(func() { _ = vp.Close() })
+	t.Cleanup(func() {
+		if err := vp.Close(); err != nil {
+			t.Errorf("close validators provider: %v", err)
+		}
+	})
 
 	// hammer the public read path while the background refresher is alive;
 	// the 1ms refresh interval keeps forcing the stale->updateCache path

--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -111,7 +111,7 @@ func TestValidatorsProvider_GetLatestValidators(t *testing.T) {
 
 	t.Run("should return cached validators if cache is fresh", func(t *testing.T) {
 		arg := createDefaultValidatorsProviderArg()
-		vp, _ := NewValidatorsProvider(arg)
+		vp := newTestValidatorsProvider(arg)
 
 		// Manually set cache and last update time
 		vp.cache = map[string]*state.ValidatorApiResponse{
@@ -137,7 +137,7 @@ func TestValidatorsProvider_GetLatestValidators(t *testing.T) {
 				}, nil
 			},
 		}
-		vp, _ := NewValidatorsProvider(arg)
+		vp := newTestValidatorsProvider(arg)
 
 		// Set an old cache
 		vp.cache = map[string]*state.ValidatorApiResponse{
@@ -163,7 +163,7 @@ func TestValidatorsProvider_GetLatestPeers(t *testing.T) {
 				return nil
 			},
 		}
-		vp, _ := NewValidatorsProvider(arg)
+		vp := newTestValidatorsProvider(arg)
 
 		peers := vp.GetLatestPeers()
 		assert.Nil(t, peers)
@@ -182,7 +182,7 @@ func TestValidatorsProvider_GetLatestPeers(t *testing.T) {
 				}, nil
 			},
 		}
-		vp, _ := NewValidatorsProvider(arg)
+		vp := newTestValidatorsProvider(arg)
 
 		peers := vp.GetLatestPeers()
 		assert.Len(t, peers, 2)
@@ -199,7 +199,7 @@ func TestValidatorsProvider_UpdateCache(t *testing.T) {
 				return nil
 			},
 		}
-		vp, _ := NewValidatorsProvider(arg)
+		vp := newTestValidatorsProvider(arg)
 
 		vp.updateCache()
 		assert.Empty(t, vp.cache)
@@ -217,7 +217,7 @@ func TestValidatorsProvider_UpdateCache(t *testing.T) {
 				}, nil
 			},
 		}
-		vp, _ := NewValidatorsProvider(arg)
+		vp := newTestValidatorsProvider(arg)
 
 		vp.updateCache()
 		assert.Len(t, vp.cache, 1)
@@ -238,7 +238,7 @@ func TestValidatorsProvider_CreateNewCache(t *testing.T) {
 				return [][]byte{[]byte("eligible")}, nil
 			},
 		}
-		vp, _ := NewValidatorsProvider(arg)
+		vp := newTestValidatorsProvider(arg)
 
 		cache := vp.createNewCache(0, []*state.ValidatorInfo{
 			{PublicKey: []byte("elected"), List: string(core.ElectedList)},
@@ -259,6 +259,66 @@ func TestValidatorsProvider_Close(t *testing.T) {
 
 	err := vp.Close()
 	assert.Nil(t, err)
+}
+
+func TestValidatorsProvider_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	arg := createDefaultValidatorsProviderArg()
+	arg.ValidatorStatistics = &mock.ValidatorStatisticsProcessorStub{
+		LastFinalizedRootHashCalled: func() []byte {
+			return []byte("rootHash")
+		},
+		GetValidatorInfoForRootHashCalled: func(rootHash []byte) ([]*state.ValidatorInfo, error) {
+			return []*state.ValidatorInfo{
+				{PublicKey: []byte("validator1"), List: string(core.EligibleList)},
+			}, nil
+		},
+	}
+	vp, err := NewValidatorsProvider(arg)
+	assert.Nil(t, err)
+
+	// hammer the public read path while the background refresher is alive;
+	// the 1ms refresh interval keeps forcing the stale->updateCache path
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = vp.GetLatestValidators()
+			}
+		}()
+	}
+
+	// force refreshes through the epoch channel, as epochStartEventHandler does
+	for epoch := uint32(0); epoch < 10; epoch++ {
+		vp.refreshCache <- epoch
+	}
+
+	wg.Wait()
+	assert.Nil(t, vp.Close())
+
+	validators := vp.GetLatestValidators()
+	assert.Contains(t, validators, hex.EncodeToString([]byte("validator1")))
+}
+
+// newTestValidatorsProvider builds a validatorsProvider without launching the
+// background refresh goroutine, keeping cache-focused unit tests deterministic
+// and race-free. The constructor's goroutine/lifecycle is covered separately by
+// the NewValidatorsProvider-based tests (Close, Cancel_startRefreshProcess).
+func newTestValidatorsProvider(arg ArgValidatorsProvider) *validatorsProvider {
+	return &validatorsProvider{
+		nodesCoordinator:             arg.NodesCoordinator,
+		validatorStatistics:          arg.ValidatorStatistics,
+		cache:                        make(map[string]*state.ValidatorApiResponse),
+		cacheRefreshIntervalDuration: arg.CacheRefreshInterval,
+		refreshCache:                 make(chan uint32),
+		cancelFunc:                   func() {},
+		pubkeyConverter:              arg.PubKeyConverter,
+		maxRating:                    arg.MaxRating,
+		currentEpoch:                 arg.StartEpoch,
+	}
 }
 
 func createDefaultValidatorsProviderArg() ArgValidatorsProvider {

--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewValidatorsProvider_WithNilValidatorStatisticsShouldErr(t *testing.T) {
@@ -276,7 +277,8 @@ func TestValidatorsProvider_ConcurrentAccess(t *testing.T) {
 		},
 	}
 	vp, err := NewValidatorsProvider(arg)
-	assert.Nil(t, err)
+	require.Nil(t, err)
+	t.Cleanup(func() { _ = vp.Close() })
 
 	// hammer the public read path while the background refresher is alive;
 	// the 1ms refresh interval keeps forcing the stale->updateCache path


### PR DESCRIPTION
## Problem

`go test ./core/process/peer/ -race` fails 100% of the time on `develop` (measured ×8: pass=0, fail=8). Without `-race` it passes, and CI never runs `-race`, which is why it went unnoticed.

Under `-race` the blamed test set changes every run and includes tests that cannot be concurrent (e.g. pure constructor-validation checks). That is an artifact of how the race detector attributes failures — the only real culprits are the `validatorsProvider` cache tests.

## Root cause

`NewValidatorsProvider` starts a background refresh goroutine in the constructor (`validatorsProvider.go:87`) which immediately writes `vp.cache` and `vp.lastCacheUpdate` under `vp.lock`. The white-box cache tests read and write those same fields **without the lock** and never `Close()` the provider. The racing write frame is identical in every report: `updateCache()` at `validatorsProvider.go:209`.

This is a test bug only — production locking is correct on every path.

## Fix

- Add `newTestValidatorsProvider`, which builds the struct without launching the goroutine (same idiom `TestValidatorsProvider_Cancel_startRefreshProcess` already uses), and point the seven cache-focused tests at it.
- Constructor validation (six `Nil*` tests), `Close`, and `Cancel_startRefreshProcess` stay on the real `NewValidatorsProvider` — goroutine/lifecycle coverage is unchanged.
- Add `TestValidatorsProvider_ConcurrentAccess`: 10 goroutines hammer `GetLatestValidators()` through the public API while the real background refresher is alive, plus forced refreshes through the epoch channel. This replaces the accidental (and undefined-behavior) concurrency exposure the old tests had with a deliberate, race-safe check of the production locking — verified to fail with `DATA RACE` if the lock in `updateCache` is removed.

No assertions weakened; no sleeps or retries added; no production code changed.

## Verification

| Check | Before | After |
|---|---|---|
| `go test ./core/process/peer/ -race -count=1` ×20 | fail=20 | pass=20 |
| `go test ./core/process/peer/... ./node/heartbeat/... ./node/ -race` ×10 | DATA RACE every run | peer ok=10, zero DATA RACE |
| `go test ./core/process/peer/ -count=10` (no race) | pass | pass |
| `go vet ./core/process/peer/` | clean | clean |

## Follow-up (not in this PR)

CI runs `go test` without `-race` (`.github/workflows/pr-qa-sec.yaml`, `Makefile`), so this class of bug is invisible to the pipeline. A `-race` job for at least `core/process/peer`, `sharding`, `core/consensus/...` and `node/...` would catch the next one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed data races in `validatorsProvider` cache tests by using `newTestValidatorsProvider` without the background refresh goroutine.
- Added concurrent-access coverage for validator reads and forced refreshes while the refresher is active.
- Added shutdown error reporting and ensured test providers close on all exit paths.
- No production code or assertions changed.

## Impact

- Affects validator-cache and networking-related test concurrency only.
- Prevents test data races and provider resource leaks.
- No change to consensus, transaction processing, state management, KVM behavior, node stability, or data integrity.
- Race-enabled tests, repeated standard tests, and `go vet` pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->