### PR TITLE
fix: report waiting-list validators in heartbeat peer-type metrics

### DIFF
--- a/core/metrics.go
+++ b/core/metrics.go
@@ -190,7 +190,12 @@ const MetricTxPoolLoad = "klv_tx_pool_load"
 const MetricIsSyncing = "klv_is_syncing"
 
 // MetricLiveValidatorNodes is the metric for monitoring live validators on the network
+// (elected, eligible or waiting)
 const MetricLiveValidatorNodes = "klv_live_validator_nodes"
+
+// MetricLiveConsensusValidatorNodes is the metric for monitoring live validators that can
+// participate in consensus (elected or eligible, excluding the waiting list)
+const MetricLiveConsensusValidatorNodes = "klv_live_consensus_validator_nodes"
 
 // MetricConnectedNodes is the metric for monitoring total connected nodes on the network
 const MetricConnectedNodes = "klv_connected_nodes"

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -93,7 +93,9 @@ func (ptp *PeerTypeProvider) epochStartEventHandler() sharding.EpochStartActionH
 				"epoch", hdr.GetEpoch())
 			ptp.UpdateCache(hdr.GetEpoch())
 		},
-		func(_ data.HeaderHandler) {},
+		func(_ data.HeaderHandler) {
+			// nothing to prepare before an epoch start; the cache is rebuilt in the action handler above
+		},
 		core.IndexerOrder,
 	)
 
@@ -119,6 +121,15 @@ func (ptp *PeerTypeProvider) createNewCache(
 	epoch uint32,
 ) (map[string]*peerListAndShard, bool) {
 	newCache := make(map[string]*peerListAndShard)
+
+	// waiting is seeded first so elected and eligible entries take precedence
+	// if a key ever appears in more than one list
+	nodesMapWaiting, err := ptp.nodesCoordinator.GetAllWaitingValidatorsKeys(epoch, false)
+	if err != nil {
+		log.Warn("peerTypeProvider - GetAllWaitingValidatorsKeys failed", "epoch", epoch, "error", err)
+		return nil, false
+	}
+	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
 
 	nodesMapElected, err := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
 	if err != nil {

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -355,6 +355,9 @@ func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 	ptp.UpdateCache(99)
 
 	require.Len(t, ptp.cache, 3)
+	require.Contains(t, ptp.cache, "waiting1")
+	require.Contains(t, ptp.cache, "elected1")
+	require.Contains(t, ptp.cache, "eligible1")
 	assert.Equal(t, core.WaitingList, ptp.cache["waiting1"].pType)
 	assert.Equal(t, core.ElectedList, ptp.cache["elected1"].pType)
 	assert.Equal(t, core.EligibleList, ptp.cache["eligible1"].pType)

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -326,6 +326,9 @@ func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 
 	arg := createDefaultArgPeerTypeProvider()
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("waiting1")}, nil
+		},
 		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
 			return [][]byte{[]byte("elected1")}, nil
 		},
@@ -341,17 +344,18 @@ func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 	}
 
 	ptp.UpdateCache(0)
-	require.Len(t, ptp.cache, 2)
+	require.Len(t, ptp.cache, 3)
 
 	ptp.nodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
 			return nil, fmt.Errorf("epoch config does not exist")
 		},
 	}
 
 	ptp.UpdateCache(99)
 
-	require.Len(t, ptp.cache, 2)
+	require.Len(t, ptp.cache, 3)
+	assert.Equal(t, core.WaitingList, ptp.cache["waiting1"].pType)
 	assert.Equal(t, core.ElectedList, ptp.cache["elected1"].pType)
 	assert.Equal(t, core.EligibleList, ptp.cache["eligible1"].pType)
 }
@@ -359,24 +363,97 @@ func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 func TestPeerTypeProvider_CreateNewCache_FailsOnAnyGetterError(t *testing.T) {
 	t.Parallel()
 
+	okGetter := func() ([][]byte, error) {
+		return [][]byte{[]byte("pk1")}, nil
+	}
+	failingGetter := func() ([][]byte, error) {
+		return nil, fmt.Errorf("list unavailable")
+	}
+
+	testCases := []struct {
+		name        string
+		coordinator *mock.NodesCoordinatorMock
+	}{
+		{
+			name: "waiting getter fails",
+			coordinator: &mock.NodesCoordinatorMock{
+				GetAllWaitingValidatorsKeysCalled:  failingGetter,
+				GetAllElectedValidatorsKeysCalled:  okGetter,
+				GetAllEligibleValidatorsKeysCalled: okGetter,
+			},
+		},
+		{
+			name: "elected getter fails",
+			coordinator: &mock.NodesCoordinatorMock{
+				GetAllWaitingValidatorsKeysCalled:  okGetter,
+				GetAllElectedValidatorsKeysCalled:  failingGetter,
+				GetAllEligibleValidatorsKeysCalled: okGetter,
+			},
+		},
+		{
+			name: "eligible getter fails",
+			coordinator: &mock.NodesCoordinatorMock{
+				GetAllWaitingValidatorsKeysCalled:  okGetter,
+				GetAllElectedValidatorsKeysCalled:  okGetter,
+				GetAllEligibleValidatorsKeysCalled: failingGetter,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ptp := PeerTypeProvider{
+				nodesCoordinator: tc.coordinator,
+				cache:            nil,
+				mutCache:         sync.RWMutex{},
+			}
+
+			cache, ok := ptp.createNewCache(0)
+
+			assert.False(t, ok)
+			assert.Nil(t, cache)
+		})
+	}
+}
+
+func TestPeerTypeProvider_ComputeForPubKey_PartitionScenarios(t *testing.T) {
+	t.Parallel()
+
 	arg := createDefaultArgPeerTypeProvider()
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("waiting1")}, nil
+		},
 		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
 			return [][]byte{[]byte("elected1")}, nil
 		},
 		GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
-			return nil, fmt.Errorf("eligible list unavailable")
+			return [][]byte{[]byte("eligible1")}, nil
 		},
 	}
 
-	ptp := PeerTypeProvider{
-		nodesCoordinator: arg.NodesCoordinator,
-		cache:            nil,
-		mutCache:         sync.RWMutex{},
+	ptp, err := NewPeerTypeProvider(arg)
+	require.Nil(t, err)
+
+	// a key can only be in one of the three lists in production
+	// (computeNodesConfigFromList partitions on validatorInfo.List),
+	// so the scenarios cover the partition, not overlap states
+	testCases := []struct {
+		name         string
+		pubKey       string
+		expectedType core.PeerType
+	}{
+		{name: "key in waiting list resolves to waiting", pubKey: "waiting1", expectedType: core.WaitingList},
+		{name: "key in elected list resolves to elected", pubKey: "elected1", expectedType: core.ElectedList},
+		{name: "key in eligible list resolves to eligible", pubKey: "eligible1", expectedType: core.EligibleList},
+		{name: "key in no list resolves to observer", pubKey: "unknown1", expectedType: core.ObserverList},
 	}
 
-	cache, ok := ptp.createNewCache(0)
-
-	assert.False(t, ok)
-	assert.Nil(t, cache)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			peerType, _, err := ptp.ComputeForPubKey([]byte(tc.pubKey))
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedType, peerType)
+		})
+	}
 }

--- a/node/heartbeat/mock/peerTypeProviderStub.go
+++ b/node/heartbeat/mock/peerTypeProviderStub.go
@@ -7,7 +7,8 @@ import (
 
 // PeerTypeProviderStub -
 type PeerTypeProviderStub struct {
-	ComputeForPubKeyCalled func(pubKey []byte) (core.PeerType, uint32, error)
+	ComputeForPubKeyCalled    func(pubKey []byte) (core.PeerType, uint32, error)
+	GetAllPeerTypeInfosCalled func() []*state.PeerTypeInfo
 }
 
 // ComputeForPubKey -
@@ -21,6 +22,9 @@ func (p *PeerTypeProviderStub) ComputeForPubKey(pubKey []byte) (core.PeerType, u
 
 // GetAllPeerTypeInfos -
 func (p *PeerTypeProviderStub) GetAllPeerTypeInfos() []*state.PeerTypeInfo {
+	if p.GetAllPeerTypeInfosCalled != nil {
+		return p.GetAllPeerTypeInfosCalled()
+	}
 	return nil
 }
 

--- a/node/heartbeat/process/heartbeatMessageInfo.go
+++ b/node/heartbeat/process/heartbeatMessageInfo.go
@@ -206,19 +206,34 @@ func (hbmi *heartbeatMessageInfo) GetIsActive() bool {
 	return isActive
 }
 
-// isValidatorPeerType returns true for the peer types that count as validators
-// (waiting, elected, eligible). GetIsValidator and Monitor.shouldSkipValidator
-// must share this definition so the klv_live_validator_nodes metric and the
-// Cleanup shielding cannot diverge.
-func isValidatorPeerType(peerType string) bool {
+// isConsensusCapablePeerType is the single definition of which peer types can
+// participate in the consensus rotation: elected and eligible. It feeds the
+// klv_live_consensus_validator_nodes metric.
+func isConsensusCapablePeerType(peerType string) bool {
 	return peerType == string(core.ElectedList) ||
-		peerType == string(core.EligibleList) ||
+		peerType == string(core.EligibleList)
+}
+
+// isValidatorPeerType is the single definition of which peer types count as
+// validators: waiting plus the consensus-capable types. Every consumer that
+// classifies a peer as a validator (metrics counting, Cleanup shielding,
+// node-type reporting) must use this predicate instead of comparing peer
+// types itself, so the classifications cannot diverge.
+func isValidatorPeerType(peerType string) bool {
+	return isConsensusCapablePeerType(peerType) ||
 		peerType == string(core.WaitingList)
 }
 
 // GetIsValidator will return true is the peer is a validator
 func (hbmi *heartbeatMessageInfo) GetIsValidator() bool {
-	hbmi.updateMutex.Lock()
-	defer hbmi.updateMutex.Unlock()
+	hbmi.updateMutex.RLock()
+	defer hbmi.updateMutex.RUnlock()
 	return isValidatorPeerType(hbmi.peerType)
+}
+
+// GetIsConsensusCapable will return true if the peer can participate in consensus
+func (hbmi *heartbeatMessageInfo) GetIsConsensusCapable() bool {
+	hbmi.updateMutex.RLock()
+	defer hbmi.updateMutex.RUnlock()
+	return isConsensusCapablePeerType(hbmi.peerType)
 }

--- a/node/heartbeat/process/heartbeatMessageInfo.go
+++ b/node/heartbeat/process/heartbeatMessageInfo.go
@@ -206,9 +206,19 @@ func (hbmi *heartbeatMessageInfo) GetIsActive() bool {
 	return isActive
 }
 
+// isValidatorPeerType returns true for the peer types that count as validators
+// (waiting, elected, eligible). GetIsValidator and Monitor.shouldSkipValidator
+// must share this definition so the klv_live_validator_nodes metric and the
+// Cleanup shielding cannot diverge.
+func isValidatorPeerType(peerType string) bool {
+	return peerType == string(core.ElectedList) ||
+		peerType == string(core.EligibleList) ||
+		peerType == string(core.WaitingList)
+}
+
 // GetIsValidator will return true is the peer is a validator
 func (hbmi *heartbeatMessageInfo) GetIsValidator() bool {
 	hbmi.updateMutex.Lock()
 	defer hbmi.updateMutex.Unlock()
-	return hbmi.peerType == string(core.ElectedList) || hbmi.peerType == string(core.EligibleList)
+	return isValidatorPeerType(hbmi.peerType)
 }

--- a/node/heartbeat/process/heartbeatMessageInfo_test.go
+++ b/node/heartbeat/process/heartbeatMessageInfo_test.go
@@ -298,6 +298,36 @@ func TestHeartbeatMessageInfo_GetIsValidator_PeerTypeObserverShouldReturnFalse(t
 	assert.False(t, hbmi.GetIsValidator())
 }
 
+func TestHeartbeatMessageInfo_GetIsConsensusCapable_PeerTypeEligibleShouldReturnTrue(t *testing.T) {
+	t.Parallel()
+
+	mockTimer := mock.NewTimerMock()
+	genesisTime := time.Unix(1, 0)
+	hbmi, _ := process.NewHeartbeatMessageInfo(
+		100*time.Second,
+		string(core.EligibleList),
+		genesisTime,
+		mockTimer,
+	)
+
+	assert.True(t, hbmi.GetIsConsensusCapable())
+}
+
+func TestHeartbeatMessageInfo_GetIsConsensusCapable_PeerTypeWaitingShouldReturnFalse(t *testing.T) {
+	t.Parallel()
+
+	mockTimer := mock.NewTimerMock()
+	genesisTime := time.Unix(1, 0)
+	hbmi, _ := process.NewHeartbeatMessageInfo(
+		100*time.Second,
+		string(core.WaitingList),
+		genesisTime,
+		mockTimer,
+	)
+
+	assert.False(t, hbmi.GetIsConsensusCapable())
+}
+
 //------- UpdatePeerType
 
 func TestHeartbeatMessageInfo_Update(t *testing.T) {

--- a/node/heartbeat/process/heartbeatMessageInfo_test.go
+++ b/node/heartbeat/process/heartbeatMessageInfo_test.go
@@ -268,6 +268,36 @@ func TestHeartbeatMessageInfo_GetIsValidator_PeerTypeEligibleShouldReturnTrue(t 
 	assert.True(t, hbmi.GetIsValidator())
 }
 
+func TestHeartbeatMessageInfo_GetIsValidator_PeerTypeWaitingShouldReturnTrue(t *testing.T) {
+	t.Parallel()
+
+	mockTimer := mock.NewTimerMock()
+	genesisTime := time.Unix(1, 0)
+	hbmi, _ := process.NewHeartbeatMessageInfo(
+		100*time.Second,
+		string(core.WaitingList),
+		genesisTime,
+		mockTimer,
+	)
+
+	assert.True(t, hbmi.GetIsValidator())
+}
+
+func TestHeartbeatMessageInfo_GetIsValidator_PeerTypeObserverShouldReturnFalse(t *testing.T) {
+	t.Parallel()
+
+	mockTimer := mock.NewTimerMock()
+	genesisTime := time.Unix(1, 0)
+	hbmi, _ := process.NewHeartbeatMessageInfo(
+		100*time.Second,
+		string(core.ObserverList),
+		genesisTime,
+		mockTimer,
+	)
+
+	assert.False(t, hbmi.GetIsValidator())
+}
+
 //------- UpdatePeerType
 
 func TestHeartbeatMessageInfo_Update(t *testing.T) {

--- a/node/heartbeat/process/monitor.go
+++ b/node/heartbeat/process/monitor.go
@@ -482,11 +482,17 @@ func (m *Monitor) GetHeartbeats() []data.PubKeyHeartbeat {
 }
 
 func (m *Monitor) shouldSkipValidator(v *heartbeatMessageInfo) bool {
-	isInactiveObserver := !v.GetIsActive() &&
-		(v.peerType != string(core.ElectedList) &&
-			v.peerType != string(core.EligibleList))
-	if isInactiveObserver {
-		lastInactiveInterval := m.timer.Now().Sub(v.timestamp)
+	// snapshot the fields under updateMutex: HeartbeatReceived writes them while
+	// holding only that mutex, so raw reads here race with inbound heartbeats
+	v.updateMutex.RLock()
+	isActive := v.isActive
+	peerType := v.peerType
+	timestamp := v.timestamp
+	v.updateMutex.RUnlock()
+
+	isInactiveNonValidator := !isActive && !isValidatorPeerType(peerType)
+	if isInactiveNonValidator {
+		lastInactiveInterval := m.timer.Now().Sub(timestamp)
 		if lastInactiveInterval.Seconds() > float64(m.hideInactiveValidatorIntervalInSec) {
 			return true
 		}

--- a/node/heartbeat/process/monitor.go
+++ b/node/heartbeat/process/monitor.go
@@ -373,6 +373,7 @@ func (m *Monitor) computePeerType(pubkey []byte) string {
 func (m *Monitor) computeAllHeartbeatMessages() {
 	m.mutHeartbeatMessages.Lock()
 	counterActiveValidators := 0
+	counterActiveConsensusValidators := 0
 	counterConnectedNodes := 0
 	hbChangedStateToInactiveMap := make(map[string]*heartbeatMessageInfo)
 	for key, v := range m.heartbeatMessages {
@@ -386,6 +387,9 @@ func (m *Monitor) computeAllHeartbeatMessages() {
 			if v.GetIsValidator() {
 				counterActiveValidators++
 			}
+			if v.GetIsConsensusCapable() {
+				counterActiveConsensusValidators++
+			}
 		}
 		changedStateToInactive := previousActive && !isActive
 		if changedStateToInactive {
@@ -397,8 +401,9 @@ func (m *Monitor) computeAllHeartbeatMessages() {
 	go m.SaveMultipleHeartbeatMessageInfos(hbChangedStateToInactiveMap)
 
 	m.mutAppStatusHandler.Lock()
-	m.appStatusHandler.SetUInt64Value(core.MetricLiveValidatorNodes, uint64(counterActiveValidators)) // #nosec G115
-	m.appStatusHandler.SetUInt64Value(core.MetricConnectedNodes, uint64(counterConnectedNodes))       // #nosec G115
+	m.appStatusHandler.SetUInt64Value(core.MetricLiveValidatorNodes, uint64(counterActiveValidators))                   // #nosec G115
+	m.appStatusHandler.SetUInt64Value(core.MetricLiveConsensusValidatorNodes, uint64(counterActiveConsensusValidators)) // #nosec G115
+	m.appStatusHandler.SetUInt64Value(core.MetricConnectedNodes, uint64(counterConnectedNodes))                         // #nosec G115
 	m.mutAppStatusHandler.Unlock()
 }
 

--- a/node/heartbeat/process/monitor_test.go
+++ b/node/heartbeat/process/monitor_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/network/p2p"
 	"github.com/klever-io/klever-go/node/heartbeat"
 	"github.com/klever-io/klever-go/node/heartbeat/data"
@@ -16,6 +17,7 @@ import (
 	"github.com/klever-io/klever-go/node/heartbeat/storage"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var fromConnectedPeerId = core.PeerID("from connected peer Id")
@@ -409,6 +411,7 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 	pubKey2 := "pk2-eligible"
 	pubKey3 := "pk3-observer"
 	pubKey4 := "pk4-inactive"
+	pubKey5 := "pk5-waiting"
 
 	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
 
@@ -436,6 +439,8 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 					return core.ObserverList, 0, nil
 				case pubKey4:
 					return core.InactiveList, 0, nil
+				case pubKey5:
+					return core.WaitingList, 0, nil
 				}
 				return core.ObserverList, 0, nil
 			},
@@ -447,28 +452,32 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 		HideInactiveValidatorIntervalInSec: 600,
 	}
 	mon, _ := process.NewMonitor(arg)
+	defer func() {
+		_ = mon.Close()
+	}()
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey1)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey2)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey3)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey4)})
+	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey5)})
 
 	// Check that all are added
 	mon.RefreshHeartbeatMessageInfo()
 	hbStatus := mon.GetHeartbeats()
-	assert.Equal(t, 5, len(hbStatus))
+	assert.Equal(t, 6, len(hbStatus))
 
 	timer.IncrementSeconds(int(arg.HideInactiveValidatorIntervalInSec) - 20)
 	mon.RefreshHeartbeatMessageInfo()
 	hbStatus = mon.GetHeartbeats()
-	assert.Equal(t, 5, len(hbStatus))
+	assert.Equal(t, 6, len(hbStatus))
 
 	// increase to over HideInactiveValidatorIntervalInSec ~ 10 min
 	timer.IncrementSeconds(int(arg.HideInactiveValidatorIntervalInSec) + 10)
 	mon.RefreshHeartbeatMessageInfo()
 	hbStatus = mon.GetHeartbeats()
-	// check if pk1 and pk2 are still on
-	assert.Equal(t, 2, len(hbStatus))
+	// check if pk1, pk2 and pk5 are still on
+	assert.Equal(t, 3, len(hbStatus))
 }
 
 func TestMonitor_ProcessReceivedMessageImpersonatedMessageShouldErr(t *testing.T) {
@@ -556,6 +565,150 @@ func TestMonitor_AddAndGetDoubleSignerPeersShouldWork(t *testing.T) {
 
 	mon.AddDoubleSignerPeers(&data.Heartbeat{Pubkey: []byte("pk3"), Pid: []byte("pid3.4")})
 	assert.Equal(t, uint64(1), mon.GetNumInstancesOfPublicKey(string("pk3")))
+}
+
+func TestMonitor_WaitingNodeSurvivesRefreshAndCleanupRounds(t *testing.T) {
+	t.Parallel()
+
+	pkWaiting := "pk-waiting"
+
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	arg := createMockArgHeartbeatMonitor()
+	arg.GenesisTime = genesisTime
+	arg.Timer = timer
+	arg.PubKeysList = []string{}
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			if string(pubKey) == pkWaiting {
+				return core.WaitingList, 0, nil
+			}
+			return core.ObserverList, 0, nil
+		},
+		GetAllPeerTypeInfosCalled: func() []*state.PeerTypeInfo {
+			return []*state.PeerTypeInfo{
+				{PublicKey: pkWaiting, PeerType: string(core.WaitingList)},
+			}
+		},
+	}
+	mon, err := process.NewMonitor(arg)
+	require.Nil(t, err)
+	defer func() {
+		_ = mon.Close()
+	}()
+
+	// move far past the hide interval so an unshielded inactive entry would be
+	// deleted by Cleanup and recreated by the next refresh (the churn cycle)
+	timer.SetSeconds(int(arg.HideInactiveValidatorIntervalInSec) + 100)
+
+	mon.RefreshHeartbeatMessageInfo()
+	assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+
+	for i := 0; i < 3; i++ {
+		mon.Cleanup()
+		assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+		mon.RefreshHeartbeatMessageInfo()
+		assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+	}
+}
+
+func TestMonitor_ActiveWaitingNodeCountsAsLiveValidator(t *testing.T) {
+	t.Parallel()
+
+	pkWaiting := "pk-waiting"
+	pkObserver := "pk-observer"
+
+	arg := createMockArgHeartbeatMonitor()
+	arg.MaxDurationPeerUnresponsive = time.Second * 1000
+	arg.PubKeysList = []string{}
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			if string(pubKey) == pkWaiting {
+				return core.WaitingList, 0, nil
+			}
+			return core.ObserverList, 0, nil
+		},
+	}
+	mon, err := process.NewMonitor(arg)
+	require.Nil(t, err)
+	// stop the background refresher before installing the status handler so a
+	// stale initial refresh can never overwrite the asserted metric values;
+	// the test drives the refresh manually
+	_ = mon.Close()
+
+	liveValidators := uint64(0)
+	connectedNodes := uint64(0)
+	_ = mon.SetAppStatusHandler(&mock.AppStatusHandlerStub{
+		SetUInt64ValueHandler: func(key string, value uint64) {
+			switch key {
+			case core.MetricLiveValidatorNodes:
+				liveValidators = value
+			case core.MetricConnectedNodes:
+				connectedNodes = value
+			}
+		},
+	})
+
+	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkWaiting)})
+	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkObserver)})
+
+	mon.RefreshHeartbeatMessageInfo()
+
+	assert.Equal(t, uint64(1), liveValidators)
+	assert.Equal(t, uint64(2), connectedNodes)
+}
+
+func TestMonitor_UnstakedWaitingNodeIsDemotedAndCleaned(t *testing.T) {
+	t.Parallel()
+
+	pkWaiting := "pk-waiting"
+
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	stillWaiting := true
+
+	arg := createMockArgHeartbeatMonitor()
+	arg.GenesisTime = genesisTime
+	arg.Timer = timer
+	arg.PubKeysList = []string{}
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			if stillWaiting && string(pubKey) == pkWaiting {
+				return core.WaitingList, 0, nil
+			}
+			return core.ObserverList, 0, nil
+		},
+		GetAllPeerTypeInfosCalled: func() []*state.PeerTypeInfo {
+			if stillWaiting {
+				return []*state.PeerTypeInfo{
+					{PublicKey: pkWaiting, PeerType: string(core.WaitingList)},
+				}
+			}
+			return nil
+		},
+	}
+	mon, err := process.NewMonitor(arg)
+	require.Nil(t, err)
+	// stop the background refresher: the test drives refresh and cleanup
+	// manually, and flips the stub without synchronization
+	_ = mon.Close()
+
+	timer.SetSeconds(int(arg.HideInactiveValidatorIntervalInSec) + 100)
+
+	mon.RefreshHeartbeatMessageInfo()
+	mon.Cleanup()
+	assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+
+	// the key leaves the waiting list (e.g. unstaked before promotion): the
+	// cache rebuild drops it and ComputeForPubKey falls back to observer, so
+	// the entry must be demoted by the next refresh and removed by Cleanup
+	stillWaiting = false
+
+	mon.RefreshHeartbeatMessageInfo()
+	mon.Cleanup()
+	assert.Equal(t, 0, mon.GetNumHearbeatMessages())
 }
 
 func TestMonitor_CleanupShouldWork(t *testing.T) {

--- a/node/heartbeat/process/monitor_test.go
+++ b/node/heartbeat/process/monitor_test.go
@@ -452,9 +452,9 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 		HideInactiveValidatorIntervalInSec: 600,
 	}
 	mon, _ := process.NewMonitor(arg)
-	defer func() {
-		_ = mon.Close()
-	}()
+	t.Cleanup(func() {
+		require.NoError(t, mon.Close())
+	})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkValidator)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey1)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey2)})
@@ -594,9 +594,9 @@ func TestMonitor_WaitingNodeSurvivesRefreshAndCleanupRounds(t *testing.T) {
 	}
 	mon, err := process.NewMonitor(arg)
 	require.Nil(t, err)
-	defer func() {
-		_ = mon.Close()
-	}()
+	t.Cleanup(func() {
+		require.NoError(t, mon.Close())
+	})
 
 	// move far past the hide interval so an unshielded inactive entry would be
 	// deleted by Cleanup and recreated by the next refresh (the churn cycle)
@@ -635,11 +635,11 @@ func TestMonitor_ActiveWaitingNodeCountsAsLiveValidator(t *testing.T) {
 	// stop the background refresher before installing the status handler so a
 	// stale initial refresh can never overwrite the asserted metric values;
 	// the test drives the refresh manually
-	_ = mon.Close()
+	require.NoError(t, mon.Close())
 
 	liveValidators := uint64(0)
 	connectedNodes := uint64(0)
-	_ = mon.SetAppStatusHandler(&mock.AppStatusHandlerStub{
+	require.NoError(t, mon.SetAppStatusHandler(&mock.AppStatusHandlerStub{
 		SetUInt64ValueHandler: func(key string, value uint64) {
 			switch key {
 			case core.MetricLiveValidatorNodes:
@@ -648,7 +648,7 @@ func TestMonitor_ActiveWaitingNodeCountsAsLiveValidator(t *testing.T) {
 				connectedNodes = value
 			}
 		},
-	})
+	}))
 
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkWaiting)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkObserver)})
@@ -693,7 +693,7 @@ func TestMonitor_UnstakedWaitingNodeIsDemotedAndCleaned(t *testing.T) {
 	require.Nil(t, err)
 	// stop the background refresher: the test drives refresh and cleanup
 	// manually, and flips the stub without synchronization
-	_ = mon.Close()
+	require.NoError(t, mon.Close())
 
 	timer.SetSeconds(int(arg.HideInactiveValidatorIntervalInSec) + 100)
 

--- a/node/heartbeat/process/monitor_test.go
+++ b/node/heartbeat/process/monitor_test.go
@@ -594,9 +594,10 @@ func TestMonitor_WaitingNodeSurvivesRefreshAndCleanupRounds(t *testing.T) {
 	}
 	mon, err := process.NewMonitor(arg)
 	require.Nil(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, mon.Close())
-	})
+	// stop the background refresher before the Cleanup/assert rounds: if it
+	// kept running it could recreate an evicted entry between Cleanup and the
+	// assertion, masking a shielding regression
+	require.NoError(t, mon.Close())
 
 	// move far past the hide interval so an unshielded inactive entry would be
 	// deleted by Cleanup and recreated by the next refresh (the churn cycle)
@@ -617,6 +618,7 @@ func TestMonitor_ActiveWaitingNodeCountsAsLiveValidator(t *testing.T) {
 	t.Parallel()
 
 	pkWaiting := "pk-waiting"
+	pkEligible := "pk-eligible"
 	pkObserver := "pk-observer"
 
 	arg := createMockArgHeartbeatMonitor()
@@ -624,8 +626,11 @@ func TestMonitor_ActiveWaitingNodeCountsAsLiveValidator(t *testing.T) {
 	arg.PubKeysList = []string{}
 	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
 		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
-			if string(pubKey) == pkWaiting {
+			switch string(pubKey) {
+			case pkWaiting:
 				return core.WaitingList, 0, nil
+			case pkEligible:
+				return core.EligibleList, 0, nil
 			}
 			return core.ObserverList, 0, nil
 		},
@@ -638,12 +643,15 @@ func TestMonitor_ActiveWaitingNodeCountsAsLiveValidator(t *testing.T) {
 	require.NoError(t, mon.Close())
 
 	liveValidators := uint64(0)
+	liveConsensusValidators := uint64(0)
 	connectedNodes := uint64(0)
 	require.NoError(t, mon.SetAppStatusHandler(&mock.AppStatusHandlerStub{
 		SetUInt64ValueHandler: func(key string, value uint64) {
 			switch key {
 			case core.MetricLiveValidatorNodes:
 				liveValidators = value
+			case core.MetricLiveConsensusValidatorNodes:
+				liveConsensusValidators = value
 			case core.MetricConnectedNodes:
 				connectedNodes = value
 			}
@@ -651,12 +659,16 @@ func TestMonitor_ActiveWaitingNodeCountsAsLiveValidator(t *testing.T) {
 	}))
 
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkWaiting)})
+	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkEligible)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkObserver)})
 
 	mon.RefreshHeartbeatMessageInfo()
 
-	assert.Equal(t, uint64(1), liveValidators)
-	assert.Equal(t, uint64(2), connectedNodes)
+	// waiting and eligible count as live validators, only eligible as
+	// consensus-capable, all three as connected
+	assert.Equal(t, uint64(2), liveValidators)
+	assert.Equal(t, uint64(1), liveConsensusValidators)
+	assert.Equal(t, uint64(3), connectedNodes)
 }
 
 func TestMonitor_UnstakedWaitingNodeIsDemotedAndCleaned(t *testing.T) {

--- a/node/heartbeat/process/sender.go
+++ b/node/heartbeat/process/sender.go
@@ -176,10 +176,8 @@ func (s *Sender) getCurrentPrivateAndPublicKeys() (crypto.PrivateKey, crypto.Pub
 func (s *Sender) updateMetrics(hb *heartbeatData.Heartbeat) {
 	result := s.computePeerList(hb.Pubkey)
 
-	nodeType := ""
-	if result == string(core.ObserverList) {
-		nodeType = string(core.NodeTypeObserver)
-	} else {
+	nodeType := string(core.NodeTypeObserver)
+	if isValidatorPeerType(result) {
 		nodeType = string(core.NodeTypeValidator)
 	}
 

--- a/node/heartbeat/process/sender_test.go
+++ b/node/heartbeat/process/sender_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	cMock "github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/crypto"
 	"github.com/klever-io/klever-go/node/heartbeat"
 	"github.com/klever-io/klever-go/node/heartbeat/data"
@@ -291,6 +292,66 @@ func TestSender_SendHeartbeatShouldWork(t *testing.T) {
 	assert.True(t, signCalled)
 	assert.True(t, genPubKeyCalled)
 	assert.True(t, marshalCalled)
+}
+
+func TestSender_SendHeartbeatUpdatesNodeTypeMetrics(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		peerType         core.PeerType
+		expectedNodeType string
+		expectedPeerType string
+	}{
+		{
+			name:             "waiting node reports validator node type",
+			peerType:         core.WaitingList,
+			expectedNodeType: string(core.NodeTypeValidator),
+			expectedPeerType: string(core.WaitingList),
+		},
+		{
+			name:             "observer node reports observer node type",
+			peerType:         core.ObserverList,
+			expectedNodeType: string(core.NodeTypeObserver),
+			expectedPeerType: string(core.ObserverList),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			arg := createMockArgHeartbeatSender()
+			arg.PrivKey = &mock.PrivateKeyStub{
+				GeneratePublicHandler: func() crypto.PublicKey {
+					return &mock.PublicKeyMock{
+						ToByteArrayHandler: func() (i []byte, e error) {
+							return []byte("pub key"), nil
+						},
+					}
+				},
+			}
+			arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+				ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+					return tc.peerType, 0, nil
+				},
+			}
+
+			// SendHeartbeat runs synchronously, so plain map access is safe
+			metrics := make(map[string]string)
+			arg.StatusHandler = &mock.AppStatusHandlerStub{
+				SetStringValueHandler: func(key string, value string) {
+					metrics[key] = value
+				},
+			}
+
+			sender, _ := process.NewSender(arg)
+
+			err := sender.SendHeartbeat()
+
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expectedNodeType, metrics[core.MetricNodeType])
+			assert.Equal(t, tc.expectedPeerType, metrics[core.MetricPeerType])
+		})
+	}
 }
 
 func TestSender_SendHeartbeatNotABackupNodeShouldWork(t *testing.T) {

--- a/node/heartbeat/process/sender_test.go
+++ b/node/heartbeat/process/sender_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/klever-io/klever-go/node/heartbeat/mock"
 	"github.com/klever-io/klever-go/node/heartbeat/process"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //------- NewSender
@@ -343,9 +344,10 @@ func TestSender_SendHeartbeatUpdatesNodeTypeMetrics(t *testing.T) {
 				},
 			}
 
-			sender, _ := process.NewSender(arg)
+			sender, err := process.NewSender(arg)
+			require.NoError(t, err)
 
-			err := sender.SendHeartbeat()
+			err = sender.SendHeartbeat()
 
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expectedNodeType, metrics[core.MetricNodeType])

--- a/node/heartbeat/process/sender_test.go
+++ b/node/heartbeat/process/sender_test.go
@@ -316,6 +316,14 @@ func TestSender_SendHeartbeatUpdatesNodeTypeMetrics(t *testing.T) {
 			expectedNodeType: string(core.NodeTypeObserver),
 			expectedPeerType: string(core.ObserverList),
 		},
+		{
+			// pins the allowlist default: a peer type outside the validator
+			// set (unreachable via the provider today) maps to observer
+			name:             "inactive node reports observer node type",
+			peerType:         core.InactiveList,
+			expectedNodeType: string(core.NodeTypeObserver),
+			expectedPeerType: string(core.InactiveList),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/statusHandler/view/termuic/termuiRenders/widgetsRender.go
+++ b/statusHandler/view/termuic/termuiRenders/widgetsRender.go
@@ -295,8 +295,14 @@ func (wr *WidgetsRender) prepareBlockInfo() {
 		rows[6] = []string{"Consensus slot state: N/A (syncing)"}
 	case 0:
 		instanceType := wr.presenter.GetNodeType()
+		peerType := wr.presenter.GetPeerType()
 		if instanceType == string(core.NodeTypeObserver) {
 			rows[6] = []string{fmt.Sprintf("Consensus slot state: N/A (%s)", string(core.NodeTypeObserver))}
+		} else if peerType == string(core.WaitingList) {
+			// a waiting validator is outside the consensus rotation, so no
+			// subround ever writes the slot-state metric; render N/A instead
+			// of the empty string it would otherwise show
+			rows[6] = []string{fmt.Sprintf("Consensus slot state: N/A (%s)", string(core.WaitingList))}
 		} else {
 			consensusSlotState := wr.presenter.GetConsensusSlotState()
 			rows[6] = []string{fmt.Sprintf("Consensus slot state: %s", consensusSlotState)}


### PR DESCRIPTION
## Summary

Implements #114: waiting-list validators no longer report as `observer` in the heartbeat peer-type metrics. This is the change that was deliberately split out of PR #110 because seeding the cache alone, without the monitor-side updates, produces contradictory metrics and per-tick churn (see the #110 review thread). This PR moves all pieces together.

Behavior for a waiting-list validator, before and after:

| Surface | Before | After |
|---|---|---|
| `klv_node_type` (own node) | `observer` | `validator` |
| `klv_peer_type` (own node) | `observer` | `waiting` |
| `klv_live_validator_nodes` (monitor) | not counted | counted while actively heartbeating |
| `/node/heartbeatstatus` | hidden after `HideInactiveValidatorIntervalInSec` | listed with `PeerType=waiting`, shielded from Cleanup |

## Design decision: waiting counts toward `klv_live_validator_nodes`

Issue #114 required an explicit decision. Waiting nodes count toward the existing metric (no separate metric), because the sender publishes `klv_node_type=validator` for waiting keys and the issue requires sender and monitor to agree, and the `MetricPeerType` doc comment (core/metrics.go) has always named "waiting list" as an expected value.

**Operator note:** the metric's meaning changes. It now includes registered validators that do not participate in consensus yet, so dashboards or alerts comparing it against consensus-group size shift meaning. During a rolling upgrade, old and new nodes report different values for the same network state (the classification is computed locally per node; the heartbeat wire format is unchanged, so mixed-version networks are safe).

**Release note (for the next tagged release):** `klv_live_validator_nodes` now includes actively heartbeating waiting-list validators, and a waiting validator's own node reports `klv_node_type=validator` / `klv_peer_type=waiting` (previously `observer`). Alert thresholds comparing `klv_live_validator_nodes` to the consensus or elected+eligible set size must be adjusted, or moved to the new gauge below. Startup already initialised `klv_node_type=validator` unconditionally (`metrics.InitMetrics`), so before this change a waiting node's reported type flipped from `validator` to `observer` on its first heartbeat; that inconsistency disappears.

**New metric (added after review):** `klv_live_consensus_validator_nodes` counts only actively heartbeating elected and eligible validators, restoring the old "counts nodes that can actually sign" invariant next to the widened gauge. Alerts that guarded consensus liveness should target this series.

## Review round (fbsobreira, changes requested at 6121d30)

All four in-scope items are fixed and both requested decisions are made explicit:

1. **termui slot state** ([widgetsRender.go](../blob/HEAD/statusHandler/view/termuic/termuiRenders/widgetsRender.go)): a waiting node rendered a blank `Consensus slot state` (node type is validator, but no subround ever writes the slot-state metric for a non-elected node). The renderer now shows `N/A (waiting)` for waiting peers, analogous to `N/A (observer)`.
2. **Churn test masking** (monitor_test.go): the shielding test closed the monitor via `t.Cleanup`, so the background refresher could recreate an evicted entry between `Cleanup()` and the assertion. It now closes eagerly like its siblings; verified by mutation (dropping `WaitingList` from the predicate makes the test fail, where before the refresher masked it).
3. **Map-deref panic risk** (peerTypeProvider_test.go): `require.Contains` guards added before the `.pType` dereferences, so a wrong-key regression fails with an assertion instead of aborting the package binary.
4. **Predicate doc comment** (heartbeatMessageInfo.go): the caller enumeration (which was already incomplete) is replaced by the rule: every consumer classifying a peer as validator must use the predicate.
5. **Decision, map growth** (accepted, no cap): measured on mainnet the waiting list is currently 1 node (elected 21, eligible 103, inactive 52, jailed 23), far under the "at hundreds, worth a cap" threshold from the review. Revisit if registration economics change; a cap needs a design round anyway because evict-and-rematerialize would reintroduce the churn cycle for never-broadcast entries.
6. **Decision, metric semantics** (separate gauge added): `klv_live_consensus_validator_nodes` (elected+eligible only) re-establishes the old invariant; `klv_live_validator_nodes` keeps the widened meaning. Both published from the same refresh pass; pinned by the extended metric test (waiting+eligible+observer active gives live=2, consensus=1, connected=3).

## Changes

1. **Cache seeding** ([core/process/peer/peerTypeProvider.go:118-146](../blob/HEAD/core/process/peer/peerTypeProvider.go)): `createNewCache` now queries `GetAllWaitingValidatorsKeys` first, then elected, then eligible; later writes win, so the precedence waiting < elected < eligible holds by insertion order. The getter follows the PR #110 fail-fast contract: any error aborts the build and `UpdateCache` keeps the previous cache. All three coordinator getters fail on the identical single condition (`ErrEpochNodesConfigDoesNotExist` on the same epoch lookup), so this adds no new failure mode where the previous code would have succeeded.
2. **Shared predicate** ([node/heartbeat/process/heartbeatMessageInfo.go:209-217](../blob/HEAD/node/heartbeat/process/heartbeatMessageInfo.go)): `isValidatorPeerType` (waiting, elected, eligible) is the single definition used by `GetIsValidator`, `Monitor.shouldSkipValidator`, and `Sender.updateMetrics`, so the three consumers cannot diverge again; the divergence between these call sites is exactly what issue #114 documents.
3. **Metric counting** (`GetIsValidator`, [heartbeatMessageInfo.go:219-224](../blob/HEAD/node/heartbeat/process/heartbeatMessageInfo.go)): active waiting nodes count in `klv_live_validator_nodes`.
4. **Cleanup shielding** (`shouldSkipValidator`, [node/heartbeat/process/monitor.go:484-502](../blob/HEAD/node/heartbeat/process/monitor.go)): waiting entries are never deleted by `Cleanup`, which ends the delete/recreate churn cycle over the waiting set (entry materialized every refresh tick, deleted on every Cleanup). The shielding is self-correcting: when a key leaves the waiting list, the next cache rebuild drops it, `getValsForUpdate` demotes the inactive entry to observer, and Cleanup removes it after the hide interval (pinned by a test).
5. **Race fix on the rewritten line** ([monitor.go:484-502](../blob/HEAD/node/heartbeat/process/monitor.go)): `shouldSkipValidator` read `v.peerType` and `v.timestamp` without `v.updateMutex` while `HeartbeatReceived` writes them under only that mutex (concurrent path: p2p heartbeat processing vs `/node/heartbeatstatus` triggering `Cleanup`). Pre-existing race, reproduced with an actual race-detector report during the pre-push audit; since this PR rewrites that exact expression, the fields are now snapshotted under one `RLock`. Reads are direct field reads, not `GetIsActive`/`GetIsValidator`, because those take the exclusive lock and `RWMutex` is not reentrant.
6. **Sender hardening** ([node/heartbeat/process/sender.go:176-186](../blob/HEAD/node/heartbeat/process/sender.go)): `updateMetrics` derives `klv_node_type` from `isValidatorPeerType` instead of the inverted "anything not observer is a validator" heuristic. Behavior today is identical (the provider's value domain is exactly waiting/elected/eligible plus observer fallback, and the sender test passes unchanged against develop); this closes the last consumer that could silently diverge if another list is ever seeded into the cache.
7. **SonarQube S1186** ([peerTypeProvider.go:96-98](../blob/HEAD/core/process/peer/peerTypeProvider.go)): nested comment added to the empty epoch-start prepare handler. Strictly outside the #114 scope, included deliberately: it is the only open SonarQube issue on a touched file (open since 2021) and the pre-push gate requires clearing those.
8. **Test hook** (node/heartbeat/mock/peerTypeProviderStub.go): `GetAllPeerTypeInfosCalled` hook added; nil-handler default unchanged, so no other test changes meaning.

## Tests

Every behavior test fails against the unpatched production code (verified by reverting the production files and re-running; independently replicated by a reviewer applying only the test diffs to a develop worktree):

- `TestPeerTypeProvider_ComputeForPubKey_PartitionScenarios`: partition table per the issue's test-design note (waiting/elected/eligible/absent), matching the `computeNodesConfigFromList` partition; no overlap-precedence tests, as specified.
- `TestPeerTypeProvider_CreateNewCache_FailsOnAnyGetterError`: table over all three getters; a failing waiting getter aborts the whole build.
- `TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure`: a populated cache including a waiting entry survives a failing refresh.
- `TestHeartbeatMessageInfo_GetIsValidator_PeerTypeWaitingShouldReturnTrue` / `_PeerTypeObserverShouldReturnFalse`.
- `TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded` (extended): waiting survives the hide interval alongside elected/eligible (6 entries, 3 survive).
- `TestMonitor_WaitingNodeSurvivesRefreshAndCleanupRounds`: churn regression test; the entry survives repeated refresh plus Cleanup rounds far past the hide interval.
- `TestMonitor_ActiveWaitingNodeCountsAsLiveValidator`: active waiting node counts (1) while observer only counts as connected (2); made deterministic by stopping the background refresher before installing the status handler.
- `TestMonitor_UnstakedWaitingNodeIsDemotedAndCleaned`: the shielding exit path; a key that leaves the waiting list is demoted to observer and removed by Cleanup (guards against permanent ghost entries).
- `TestSender_SendHeartbeatUpdatesNodeTypeMetrics`: waiting reports `validator`/`waiting`, observer reports `observer`/`observer`; pins the sender-monitor agreement (passes on develop by design, guarding the cross-side contract).

## Verification

- `go build ./...`, `gofmt`/`goimports` clean, `golangci-lint` clean on the changed trees (one pre-existing errorlint finding in the untouched `node/heartbeat/storage/heartbeatStorer.go`).
- `go test -race -count=1` green on `core/process/peer` and all `node/heartbeat` packages.
- SonarQube analysis of every changed source file: zero new issues; line coverage verified on every changed production line including both branches of the new error path (mocks are coverage-excluded by project config).
- Full `-short` suite (CI mirror): 247 packages ok; the only failure observed is the pre-existing flaky `TestMonitor_ObserverGapValidator*` family (issue #106), which fails at comparable rates on a clean develop worktree (3/8 runs) and whose mechanism this PR does not touch; root-cause analysis posted on #106.
- Pre-push audit: security, code-review, Go-idiom, and an independent full-diff reviewer; all findings fixed in this PR or tracked (see #106), none Critical.

## Follow-ups (tracked, not in this PR)

- #106: pre-existing flaky monitor uptime tests; may cause an unrelated red CI check on this PR.
- #113: seed providers with the bootstrapped epoch (touches the same file; no conflict, this PR only changes what the cache contains, not when it becomes correct).
- #116: jailed/leaving validators still report `observer` (the leaving list is not queried anywhere); same problem class, deliberately out of scope here.
- #117: consolidate the per-entry locking in `computeAllHeartbeatMessages` into one snapshot (review follow-up; pre-existing pattern, enlarged relevance now that the map includes waiting).
- #118: deduplicate the getter/log/computePeerType blocks in `createNewCache` and the validatorsProvider sibling (review nudge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Correct heartbeat peer-type classification for waiting-list validators.
- Include active waiting validators in `klv_live_validator_nodes`.
- Add `klv_live_consensus_validator_nodes` for elected and eligible validators only.
- Preserve waiting validators during heartbeat cleanup and refresh cycles.
- Demote and remove validators after they leave the waiting list and exceed the inactivity interval.
- Protect monitor state reads with locking to prevent data races.
- Make cache refresh fail fast and preserve the existing cache when any validator-list lookup fails.
- Update terminal UI output to show `N/A (waiting list)` for waiting validators.
- Add shared validator and consensus-capable predicates, test hooks, and coverage for cache errors, peer classifications, metrics, cleanup, and sender behavior.

The changes affect networking, monitoring, metrics, and terminal status reporting. They do not change consensus execution, transaction processing, state management, or KVM behavior. The cache error handling and monitor locking reduce risks from partial state updates and concurrent access. Waiting-list cache growth remains unbounded by design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->