### PR TITLE
fix: report jailed validators in peer-type cache and heartbeat metrics

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -373,7 +373,15 @@ func createNodesCoordinator(
 				return nil, err
 			}
 
-			err = nodesCoordinator.SetNodes(electedValidators, eligibleValidators, waitingValidators, currentEpoch-1)
+			// registries saved before the leaving list was persisted have no
+			// LeavingValidators field; the list is then simply empty
+			leaving := prevEpochsConfig.LeavingValidators
+			leavingValidators, err := sharding.SerializableValidatorsToValidators(leaving)
+			if err != nil {
+				return nil, err
+			}
+
+			err = nodesCoordinator.SetNodes(electedValidators, eligibleValidators, waitingValidators, leavingValidators, currentEpoch-1)
 			if err != nil {
 				return nil, err
 			}

--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -24,7 +24,8 @@ type NodesCoordinatorMock struct {
 	GetAllEligibleValidatorsKeysWithEpochCalled func(uint32, bool) ([][]byte, error)
 	GetAllWaitingValidatorsKeysCalled           func() ([][]byte, error)
 	GetAllWaitingValidatorsKeysWithEpochCalled  func(uint32, bool) ([][]byte, error)
-	GetAllLeavingValidatorsPublicKeysCalled     func() ([][]byte, error)
+	GetAllLeavingValidatorsKeysCalled           func() ([][]byte, error)
+	GetAllLeavingValidatorsKeysWithEpochCalled  func(uint32, bool) ([][]byte, error)
 	CheckValidatorSlotCalled                    func(epoch uint32, slotIndex int64, pubkey []byte) bool
 	ConsensusGroupSizeCalled                    func() int
 	LoadValidatorsCalled                        func(validators []*state.ValidatorInfo) error
@@ -90,6 +91,17 @@ func (ncm *NodesCoordinatorMock) GetAllWaitingValidatorsKeys(epoch uint32, inclu
 	}
 	if ncm.GetAllWaitingValidatorsKeysCalled != nil {
 		return ncm.GetAllWaitingValidatorsKeysCalled()
+	}
+	return nil, nil
+}
+
+// GetAllLeavingValidatorsKeys -
+func (ncm *NodesCoordinatorMock) GetAllLeavingValidatorsKeys(epoch uint32, includeLeaving bool) ([][]byte, error) {
+	if ncm.GetAllLeavingValidatorsKeysWithEpochCalled != nil {
+		return ncm.GetAllLeavingValidatorsKeysWithEpochCalled(epoch, includeLeaving)
+	}
+	if ncm.GetAllLeavingValidatorsKeysCalled != nil {
+		return ncm.GetAllLeavingValidatorsKeysCalled()
 	}
 	return nil, nil
 }
@@ -223,11 +235,6 @@ func (ncm *NodesCoordinatorMock) GetValidatorWithPublicKey(publicKey []byte) (sh
 	}
 
 	return nil, sharding.ErrValidatorNotFound
-}
-
-// GetAllLeavingValidatorsPublicKeys -
-func (ncm *NodesCoordinatorMock) GetAllLeavingValidatorsPublicKeys(_ uint32) ([][]byte, error) {
-	return nil, nil
 }
 
 // GetOwnPublicKey -

--- a/common/mock/nodesCoordinatorMock.go
+++ b/common/mock/nodesCoordinatorMock.go
@@ -96,9 +96,9 @@ func (ncm *NodesCoordinatorMock) GetAllWaitingValidatorsKeys(epoch uint32, inclu
 }
 
 // GetAllLeavingValidatorsKeys -
-func (ncm *NodesCoordinatorMock) GetAllLeavingValidatorsKeys(epoch uint32, includeLeaving bool) ([][]byte, error) {
+func (ncm *NodesCoordinatorMock) GetAllLeavingValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error) {
 	if ncm.GetAllLeavingValidatorsKeysWithEpochCalled != nil {
-		return ncm.GetAllLeavingValidatorsKeysWithEpochCalled(epoch, includeLeaving)
+		return ncm.GetAllLeavingValidatorsKeysWithEpochCalled(epoch, ownerKey)
 	}
 	if ncm.GetAllLeavingValidatorsKeysCalled != nil {
 		return ncm.GetAllLeavingValidatorsKeysCalled()

--- a/core/bootstrap/disabled/disabledNodesCoordinator.go
+++ b/core/bootstrap/disabled/disabledNodesCoordinator.go
@@ -44,6 +44,11 @@ func (n *nodesCoordinator) GetAllWaitingValidatorsKeys(_ uint32, _ bool) ([][]by
 	return nil, nil
 }
 
+// GetAllLeavingValidatorsKeys -
+func (n *nodesCoordinator) GetAllLeavingValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+	return nil, nil
+}
+
 // CheckValidatorSlot -
 func (n *nodesCoordinator) CheckValidatorSlot(epoch uint32, slotIndex int64, pubkey []byte) bool {
 	return false

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -159,7 +159,8 @@ const MetricCountConsensus = "klv_count_consensus"
 // MetricNodeType is the metric for monitoring the type of the node
 const MetricNodeType = "klv_node_type"
 
-// MetricPeerType is the metric which tells the peer's type (in eligible list, in waiting list, or observer)
+// MetricPeerType is the metric which tells the peer's type (in elected, eligible,
+// waiting or jailed list, or observer)
 const MetricPeerType = "klv_peer_type"
 
 // MetricNumValidators is the metric for the number of validators
@@ -190,7 +191,7 @@ const MetricTxPoolLoad = "klv_tx_pool_load"
 const MetricIsSyncing = "klv_is_syncing"
 
 // MetricLiveValidatorNodes is the metric for monitoring live validators on the network
-// (elected, eligible or waiting)
+// (elected, eligible or waiting, excluding jailed)
 const MetricLiveValidatorNodes = "klv_live_validator_nodes"
 
 // MetricLiveConsensusValidatorNodes is the metric for monitoring live validators that can

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -122,13 +122,18 @@ func (ptp *PeerTypeProvider) createNewCache(
 ) (map[string]*peerListAndShard, bool) {
 	newCache := make(map[string]*peerListAndShard)
 
-	// waiting is seeded first so elected and eligible entries take precedence
-	// if a key ever appears in more than one list
+	// the leaving list is seeded as jailed: the coordinator fills it exclusively
+	// from validators whose list is jailed (computeNodesConfigFromList), and
+	// operators should see that actionable state. Seeding order is defensive:
+	// later lists win, so working types take precedence if a key ever appears
+	// in more than one list (in production the lists are a partition, the
+	// numToStay promotion removes promoted keys from the leaving list).
 	listSources := []struct {
 		name     string
 		peerType core.PeerType
 		getKeys  func(epoch uint32, ownerKey bool) ([][]byte, error)
 	}{
+		{"GetAllLeavingValidatorsKeys", core.JailedList, ptp.nodesCoordinator.GetAllLeavingValidatorsKeys},
 		{"GetAllWaitingValidatorsKeys", core.WaitingList, ptp.nodesCoordinator.GetAllWaitingValidatorsKeys},
 		{"GetAllElectedValidatorsKeys", core.ElectedList, ptp.nodesCoordinator.GetAllElectedValidatorsKeys},
 		{"GetAllEligibleValidatorsKeys", core.EligibleList, ptp.nodesCoordinator.GetAllEligibleValidatorsKeys},

--- a/core/process/peer/peerTypeProvider.go
+++ b/core/process/peer/peerTypeProvider.go
@@ -124,26 +124,24 @@ func (ptp *PeerTypeProvider) createNewCache(
 
 	// waiting is seeded first so elected and eligible entries take precedence
 	// if a key ever appears in more than one list
-	nodesMapWaiting, err := ptp.nodesCoordinator.GetAllWaitingValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Warn("peerTypeProvider - GetAllWaitingValidatorsKeys failed", "epoch", epoch, "error", err)
-		return nil, false
+	listSources := []struct {
+		name     string
+		peerType core.PeerType
+		getKeys  func(epoch uint32, ownerKey bool) ([][]byte, error)
+	}{
+		{"GetAllWaitingValidatorsKeys", core.WaitingList, ptp.nodesCoordinator.GetAllWaitingValidatorsKeys},
+		{"GetAllElectedValidatorsKeys", core.ElectedList, ptp.nodesCoordinator.GetAllElectedValidatorsKeys},
+		{"GetAllEligibleValidatorsKeys", core.EligibleList, ptp.nodesCoordinator.GetAllEligibleValidatorsKeys},
 	}
-	computePeerType(newCache, nodesMapWaiting, core.WaitingList)
 
-	nodesMapElected, err := ptp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Warn("peerTypeProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch, "error", err)
-		return nil, false
+	for _, src := range listSources {
+		keys, err := src.getKeys(epoch, false)
+		if err != nil {
+			log.Warn("peerTypeProvider - "+src.name+" failed", "epoch", epoch, "error", err)
+			return nil, false
+		}
+		computePeerType(newCache, keys, src.peerType)
 	}
-	computePeerType(newCache, nodesMapElected, core.ElectedList)
-
-	nodesMapEligible, err := ptp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Warn("peerTypeProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch, "error", err)
-		return nil, false
-	}
-	computePeerType(newCache, nodesMapEligible, core.EligibleList)
 
 	return newCache, true
 }

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -267,6 +267,9 @@ func TestPeerTypeProvider_CreateNewCacheScenarios(t *testing.T) {
 	arg := createDefaultArgPeerTypeProvider()
 
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllLeavingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("jailed1"), []byte("elected1")}, nil
+		},
 		GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
 			return [][]byte{[]byte("elected1"), []byte("elected2")}, nil
 		},
@@ -278,10 +281,12 @@ func TestPeerTypeProvider_CreateNewCacheScenarios(t *testing.T) {
 
 	cache, ok := ptp.createNewCache(0)
 	require.True(t, ok)
-	require.Len(t, cache, 3)
+	require.Len(t, cache, 4)
 	assert.Equal(t, core.EligibleList, cache["elected1"].pType) // elected1 is also eligible as it have been updated in the eligible list
 	assert.Equal(t, core.ElectedList, cache["elected2"].pType)
 	assert.Equal(t, core.EligibleList, cache["eligible1"].pType)
+	// leaving is seeded first, so a working list wins over jailed for the same key
+	assert.Equal(t, core.JailedList, cache["jailed1"].pType)
 }
 
 func TestPeerTypeProvider_GetAllPeerTypeInfos(t *testing.T) {
@@ -326,6 +331,9 @@ func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 
 	arg := createDefaultArgPeerTypeProvider()
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllLeavingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("jailed1")}, nil
+		},
 		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
 			return [][]byte{[]byte("waiting1")}, nil
 		},
@@ -344,7 +352,7 @@ func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 	}
 
 	ptp.UpdateCache(0)
-	require.Len(t, ptp.cache, 3)
+	require.Len(t, ptp.cache, 4)
 
 	ptp.nodesCoordinator = &mock.NodesCoordinatorMock{
 		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
@@ -354,10 +362,12 @@ func TestPeerTypeProvider_UpdateCache_KeepsPreviousOnFailure(t *testing.T) {
 
 	ptp.UpdateCache(99)
 
-	require.Len(t, ptp.cache, 3)
+	require.Len(t, ptp.cache, 4)
+	require.Contains(t, ptp.cache, "jailed1")
 	require.Contains(t, ptp.cache, "waiting1")
 	require.Contains(t, ptp.cache, "elected1")
 	require.Contains(t, ptp.cache, "eligible1")
+	assert.Equal(t, core.JailedList, ptp.cache["jailed1"].pType)
 	assert.Equal(t, core.WaitingList, ptp.cache["waiting1"].pType)
 	assert.Equal(t, core.ElectedList, ptp.cache["elected1"].pType)
 	assert.Equal(t, core.EligibleList, ptp.cache["eligible1"].pType)
@@ -378,8 +388,18 @@ func TestPeerTypeProvider_CreateNewCache_FailsOnAnyGetterError(t *testing.T) {
 		coordinator *mock.NodesCoordinatorMock
 	}{
 		{
+			name: "leaving getter fails",
+			coordinator: &mock.NodesCoordinatorMock{
+				GetAllLeavingValidatorsKeysCalled:  failingGetter,
+				GetAllWaitingValidatorsKeysCalled:  okGetter,
+				GetAllElectedValidatorsKeysCalled:  okGetter,
+				GetAllEligibleValidatorsKeysCalled: okGetter,
+			},
+		},
+		{
 			name: "waiting getter fails",
 			coordinator: &mock.NodesCoordinatorMock{
+				GetAllLeavingValidatorsKeysCalled:  okGetter,
 				GetAllWaitingValidatorsKeysCalled:  failingGetter,
 				GetAllElectedValidatorsKeysCalled:  okGetter,
 				GetAllEligibleValidatorsKeysCalled: okGetter,
@@ -388,6 +408,7 @@ func TestPeerTypeProvider_CreateNewCache_FailsOnAnyGetterError(t *testing.T) {
 		{
 			name: "elected getter fails",
 			coordinator: &mock.NodesCoordinatorMock{
+				GetAllLeavingValidatorsKeysCalled:  okGetter,
 				GetAllWaitingValidatorsKeysCalled:  okGetter,
 				GetAllElectedValidatorsKeysCalled:  failingGetter,
 				GetAllEligibleValidatorsKeysCalled: okGetter,
@@ -396,6 +417,7 @@ func TestPeerTypeProvider_CreateNewCache_FailsOnAnyGetterError(t *testing.T) {
 		{
 			name: "eligible getter fails",
 			coordinator: &mock.NodesCoordinatorMock{
+				GetAllLeavingValidatorsKeysCalled:  okGetter,
 				GetAllWaitingValidatorsKeysCalled:  okGetter,
 				GetAllElectedValidatorsKeysCalled:  okGetter,
 				GetAllEligibleValidatorsKeysCalled: failingGetter,
@@ -424,6 +446,9 @@ func TestPeerTypeProvider_ComputeForPubKey_PartitionScenarios(t *testing.T) {
 
 	arg := createDefaultArgPeerTypeProvider()
 	arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+		GetAllLeavingValidatorsKeysCalled: func() ([][]byte, error) {
+			return [][]byte{[]byte("jailed1")}, nil
+		},
 		GetAllWaitingValidatorsKeysCalled: func() ([][]byte, error) {
 			return [][]byte{[]byte("waiting1")}, nil
 		},
@@ -438,14 +463,16 @@ func TestPeerTypeProvider_ComputeForPubKey_PartitionScenarios(t *testing.T) {
 	ptp, err := NewPeerTypeProvider(arg)
 	require.Nil(t, err)
 
-	// a key can only be in one of the three lists in production
-	// (computeNodesConfigFromList partitions on validatorInfo.List),
+	// a key can only be in one of the four lists in production
+	// (computeNodesConfigFromList partitions on validatorInfo.List and the
+	// numToStay promotion removes promoted keys from the leaving list),
 	// so the scenarios cover the partition, not overlap states
 	testCases := []struct {
 		name         string
 		pubKey       string
 		expectedType core.PeerType
 	}{
+		{name: "key in leaving list resolves to jailed", pubKey: "jailed1", expectedType: core.JailedList},
 		{name: "key in waiting list resolves to waiting", pubKey: "waiting1", expectedType: core.WaitingList},
 		{name: "key in elected list resolves to elected", pubKey: "elected1", expectedType: core.ElectedList},
 		{name: "key in eligible list resolves to eligible", pubKey: "eligible1", expectedType: core.EligibleList},

--- a/core/process/peer/peerTypeProvider_test.go
+++ b/core/process/peer/peerTypeProvider_test.go
@@ -282,10 +282,12 @@ func TestPeerTypeProvider_CreateNewCacheScenarios(t *testing.T) {
 	cache, ok := ptp.createNewCache(0)
 	require.True(t, ok)
 	require.Len(t, cache, 4)
-	assert.Equal(t, core.EligibleList, cache["elected1"].pType) // elected1 is also eligible as it have been updated in the eligible list
+	// elected1 is in the leaving, elected and eligible lists: leaving is seeded
+	// first, so the working lists win and the last one seeded (eligible) sticks
+	assert.Equal(t, core.EligibleList, cache["elected1"].pType)
 	assert.Equal(t, core.ElectedList, cache["elected2"].pType)
 	assert.Equal(t, core.EligibleList, cache["eligible1"].pType)
-	// leaving is seeded first, so a working list wins over jailed for the same key
+	// jailed1 appears only in the leaving list, so it stays jailed
 	assert.Equal(t, core.JailedList, cache["jailed1"].pType)
 }
 

--- a/core/process/peer/validatorsProvider.go
+++ b/core/process/peer/validatorsProvider.go
@@ -233,7 +233,7 @@ func (vp *validatorsProvider) createNewCache(
 	for _, src := range listSources {
 		keys, err := src.getKeys(epoch, false)
 		if err != nil {
-			log.Debug("validatorsProvider - "+src.name+" failed", "epoch", epoch)
+			log.Debug("validatorsProvider - "+src.name+" failed", "epoch", epoch, "error", err)
 		}
 		vp.aggregateLists(newCache, keys, src.peerType)
 	}

--- a/core/process/peer/validatorsProvider.go
+++ b/core/process/peer/validatorsProvider.go
@@ -166,7 +166,9 @@ func (vp *validatorsProvider) epochStartEventHandler() sharding.EpochStartAction
 				vp.refreshCache <- hdr.GetEpoch()
 			}()
 		},
-		func(_ data.HeaderHandler) {},
+		func(_ data.HeaderHandler) {
+			// nothing to prepare before an epoch start; the cache is refreshed in the action handler above
+		},
 		core.IndexerOrder,
 	)
 
@@ -217,17 +219,24 @@ func (vp *validatorsProvider) createNewCache(
 ) map[string]*state.ValidatorApiResponse {
 	newCache := vp.createValidatorAPIResponseMapFromValidatorInfoMap(allNodes)
 
-	nodesElected, err := vp.nodesCoordinator.GetAllElectedValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("validatorsProvider - GetAllElectedValidatorsKeys failed", "epoch", epoch)
+	// unlike the peerTypeProvider sibling, a failing getter is not fatal here:
+	// the trie-based cache is still served, only the list overlay is skipped
+	listSources := []struct {
+		name     string
+		peerType core.PeerType
+		getKeys  func(epoch uint32, ownerKey bool) ([][]byte, error)
+	}{
+		{"GetAllElectedValidatorsKeys", core.ElectedList, vp.nodesCoordinator.GetAllElectedValidatorsKeys},
+		{"GetAllEligibleValidatorsKeys", core.EligibleList, vp.nodesCoordinator.GetAllEligibleValidatorsKeys},
 	}
-	vp.aggregateLists(newCache, nodesElected, core.ElectedList)
 
-	nodesEligible, err := vp.nodesCoordinator.GetAllEligibleValidatorsKeys(epoch, false)
-	if err != nil {
-		log.Debug("validatorsProvider - GetAllEligibleValidatorsKeys failed", "epoch", epoch)
+	for _, src := range listSources {
+		keys, err := src.getKeys(epoch, false)
+		if err != nil {
+			log.Debug("validatorsProvider - "+src.name+" failed", "epoch", epoch)
+		}
+		vp.aggregateLists(newCache, keys, src.peerType)
 	}
-	vp.aggregateLists(newCache, nodesEligible, core.EligibleList)
 
 	return newCache
 }

--- a/core/process/peer/validatorsProvider_test.go
+++ b/core/process/peer/validatorsProvider_test.go
@@ -3,6 +3,7 @@ package peer
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -249,6 +250,31 @@ func TestValidatorsProvider_CreateNewCache(t *testing.T) {
 		assert.Len(t, cache, 2)
 		assert.Equal(t, string(core.ElectedList), cache[hex.EncodeToString([]byte("elected"))].ValidatorStatus)
 		assert.Equal(t, string(core.EligibleList), cache[hex.EncodeToString([]byte("eligible"))].ValidatorStatus)
+	})
+
+	t.Run("failing getter keeps trie-based cache and remaining overlays", func(t *testing.T) {
+		// unlike the peerTypeProvider sibling, a getter error must not discard
+		// the cache: the trie-based entries are still served and the other
+		// list overlays still run
+		arg := createDefaultValidatorsProviderArg()
+		arg.NodesCoordinator = &mock.NodesCoordinatorMock{
+			GetAllElectedValidatorsKeysCalled: func() ([][]byte, error) {
+				return nil, fmt.Errorf("list unavailable")
+			},
+			GetAllEligibleValidatorsKeysCalled: func() ([][]byte, error) {
+				return [][]byte{[]byte("promoted")}, nil
+			},
+		}
+		vp := newTestValidatorsProvider(arg)
+
+		cache := vp.createNewCache(0, []*state.ValidatorInfo{
+			{PublicKey: []byte("elected"), List: string(core.ElectedList)},
+			{PublicKey: []byte("promoted"), List: string(core.WaitingList)},
+		})
+
+		assert.Len(t, cache, 2)
+		assert.Equal(t, string(core.ElectedList), cache[hex.EncodeToString([]byte("elected"))].ValidatorStatus)
+		assert.Equal(t, string(core.EligibleList), cache[hex.EncodeToString([]byte("promoted"))].ValidatorStatus)
 	})
 }
 

--- a/node/heartbeat/process/export_test.go
+++ b/node/heartbeat/process/export_test.go
@@ -92,6 +92,11 @@ func VerifyLengths(hbmi *data.Heartbeat) error {
 	return verifyLengths(hbmi)
 }
 
+// IsRegisteredValidatorPeerType -
+func IsRegisteredValidatorPeerType(peerType string) bool {
+	return isRegisteredValidatorPeerType(peerType)
+}
+
 // GetMaxSizeInBytes -
 func GetMaxSizeInBytes() int {
 	return maxSizeInBytes

--- a/node/heartbeat/process/heartbeatMessageInfo.go
+++ b/node/heartbeat/process/heartbeatMessageInfo.go
@@ -206,22 +206,37 @@ func (hbmi *heartbeatMessageInfo) GetIsActive() bool {
 	return isActive
 }
 
-// isConsensusCapablePeerType is the single definition of which peer types can
-// participate in the consensus rotation: elected and eligible. It feeds the
-// klv_live_consensus_validator_nodes metric.
+// The peer-type predicates below form three nested tiers. Every consumer that
+// classifies a peer must pick its tier from here instead of comparing peer
+// types itself, so the classifications cannot diverge:
+//   - consensus-capable (elected, eligible): klv_live_consensus_validator_nodes
+//   - working validators (+ waiting): klv_live_validator_nodes
+//   - registered validators (+ jailed): Cleanup shielding, klv_node_type self-reporting
+
+// isConsensusCapablePeerType reports whether the peer type can participate in
+// the consensus rotation: elected and eligible.
 func isConsensusCapablePeerType(peerType string) bool {
 	return peerType == string(core.ElectedList) ||
 		peerType == string(core.EligibleList)
 }
 
-// isValidatorPeerType is the single definition of which peer types count as
-// validators: waiting plus the consensus-capable types. Every consumer that
-// classifies a peer as a validator (metrics counting, Cleanup shielding,
-// node-type reporting) must use this predicate instead of comparing peer
-// types itself, so the classifications cannot diverge.
+// isValidatorPeerType reports whether the peer type belongs to the working
+// validator set: waiting plus the consensus-capable types. Punished (jailed)
+// validators are deliberately not part of this tier, so they do not count
+// toward klv_live_validator_nodes.
 func isValidatorPeerType(peerType string) bool {
 	return isConsensusCapablePeerType(peerType) ||
 		peerType == string(core.WaitingList)
+}
+
+// isRegisteredValidatorPeerType reports whether the peer type belongs to a
+// registered validator at all, including punished (jailed) ones. A jailed
+// validator must stay visible in the heartbeat status and keep self-reporting
+// as a validator node. core.LeavingList is deliberately absent: the peer-type
+// cache reports leaving-list members as jailed and never emits "leaving".
+func isRegisteredValidatorPeerType(peerType string) bool {
+	return isValidatorPeerType(peerType) ||
+		peerType == string(core.JailedList)
 }
 
 // GetIsValidator will return true is the peer is a validator

--- a/node/heartbeat/process/heartbeatMessageInfo_test.go
+++ b/node/heartbeat/process/heartbeatMessageInfo_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/klever-io/klever-go/node/heartbeat/mock"
 	"github.com/klever-io/klever-go/node/heartbeat/process"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const dummyPeerType = "dummy peer type"
@@ -333,12 +334,13 @@ func TestHeartbeatMessageInfo_GetIsValidator_PeerTypeJailedShouldReturnFalse(t *
 
 	mockTimer := mock.NewTimerMock()
 	genesisTime := time.Unix(1, 0)
-	hbmi, _ := process.NewHeartbeatMessageInfo(
+	hbmi, err := process.NewHeartbeatMessageInfo(
 		100*time.Second,
 		string(core.JailedList),
 		genesisTime,
 		mockTimer,
 	)
+	require.NoError(t, err)
 
 	// jailed is a registered validator but not part of the working set, so it
 	// counts toward neither klv_live_validator_nodes nor the consensus gauge

--- a/node/heartbeat/process/heartbeatMessageInfo_test.go
+++ b/node/heartbeat/process/heartbeatMessageInfo_test.go
@@ -328,6 +328,49 @@ func TestHeartbeatMessageInfo_GetIsConsensusCapable_PeerTypeWaitingShouldReturnF
 	assert.False(t, hbmi.GetIsConsensusCapable())
 }
 
+func TestHeartbeatMessageInfo_GetIsValidator_PeerTypeJailedShouldReturnFalse(t *testing.T) {
+	t.Parallel()
+
+	mockTimer := mock.NewTimerMock()
+	genesisTime := time.Unix(1, 0)
+	hbmi, _ := process.NewHeartbeatMessageInfo(
+		100*time.Second,
+		string(core.JailedList),
+		genesisTime,
+		mockTimer,
+	)
+
+	// jailed is a registered validator but not part of the working set, so it
+	// counts toward neither klv_live_validator_nodes nor the consensus gauge
+	assert.False(t, hbmi.GetIsValidator())
+	assert.False(t, hbmi.GetIsConsensusCapable())
+}
+
+func TestIsRegisteredValidatorPeerType(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		peerType string
+		expected bool
+	}{
+		{peerType: string(core.ElectedList), expected: true},
+		{peerType: string(core.EligibleList), expected: true},
+		{peerType: string(core.WaitingList), expected: true},
+		{peerType: string(core.JailedList), expected: true},
+		{peerType: string(core.ObserverList), expected: false},
+		{peerType: string(core.InactiveList), expected: false},
+		// the peer-type cache reports leaving-list members as jailed and never
+		// emits "leaving", so the raw string is deliberately not registered
+		{peerType: string(core.LeavingList), expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.peerType, func(t *testing.T) {
+			assert.Equal(t, tc.expected, process.IsRegisteredValidatorPeerType(tc.peerType))
+		})
+	}
+}
+
 //------- UpdatePeerType
 
 func TestHeartbeatMessageInfo_Update(t *testing.T) {

--- a/node/heartbeat/process/monitor.go
+++ b/node/heartbeat/process/monitor.go
@@ -510,7 +510,8 @@ func (m *Monitor) shouldSkipValidator(v *heartbeatMessageInfo) bool {
 	timestamp := v.timestamp
 	v.updateMutex.RUnlock()
 
-	isInactiveNonValidator := !isActive && !isValidatorPeerType(peerType)
+	// registered tier: jailed validators keep their heartbeat entry visible
+	isInactiveNonValidator := !isActive && !isRegisteredValidatorPeerType(peerType)
 	if isInactiveNonValidator {
 		lastInactiveInterval := m.timer.Now().Sub(timestamp)
 		if lastInactiveInterval.Seconds() > float64(m.hideInactiveValidatorIntervalInSec) {

--- a/node/heartbeat/process/monitor_test.go
+++ b/node/heartbeat/process/monitor_test.go
@@ -443,6 +443,7 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 	pubKey3 := "pk3-observer"
 	pubKey4 := "pk4-inactive"
 	pubKey5 := "pk5-waiting"
+	pubKey6 := "pk6-jailed"
 
 	storer, _ := storage.NewHeartbeatDbStorer(mock.NewStorerMock(), &mock.MarshalizerMock{})
 
@@ -472,6 +473,8 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 					return core.InactiveList, 0, nil
 				case pubKey5:
 					return core.WaitingList, 0, nil
+				case pubKey6:
+					return core.JailedList, 0, nil
 				}
 				return core.ObserverList, 0, nil
 			},
@@ -494,23 +497,25 @@ func TestMonitor_RemoveInactiveValidatorsIfIntervalExceeded(t *testing.T) {
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey3)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey4)})
 	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey5)})
+	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pubKey6)})
 
 	// Check that all are added
 	mon.RefreshHeartbeatMessageInfo()
 	hbStatus := mon.GetHeartbeats()
-	assert.Equal(t, 6, len(hbStatus))
+	assert.Equal(t, 7, len(hbStatus))
 
 	timer.IncrementSeconds(int(arg.HideInactiveValidatorIntervalInSec) - 20)
 	mon.RefreshHeartbeatMessageInfo()
 	hbStatus = mon.GetHeartbeats()
-	assert.Equal(t, 6, len(hbStatus))
+	assert.Equal(t, 7, len(hbStatus))
 
 	// increase to over HideInactiveValidatorIntervalInSec ~ 10 min
 	timer.IncrementSeconds(int(arg.HideInactiveValidatorIntervalInSec) + 10)
 	mon.RefreshHeartbeatMessageInfo()
 	hbStatus = mon.GetHeartbeats()
-	// check if pk1, pk2 and pk5 are still on
-	assert.Equal(t, 3, len(hbStatus))
+	// check if pk1, pk2, pk5 and pk6 are still on: elected, eligible, waiting
+	// and jailed are all shielded from the hide interval
+	assert.Equal(t, 4, len(hbStatus))
 }
 
 func TestMonitor_ProcessReceivedMessageImpersonatedMessageShouldErr(t *testing.T) {
@@ -760,6 +765,161 @@ func TestMonitor_UnstakedWaitingNodeIsDemotedAndCleaned(t *testing.T) {
 	// cache rebuild drops it and ComputeForPubKey falls back to observer, so
 	// the entry must be demoted by the next refresh and removed by Cleanup
 	stillWaiting = false
+
+	mon.RefreshHeartbeatMessageInfo()
+	mon.Cleanup()
+	assert.Equal(t, 0, mon.GetNumHearbeatMessages())
+}
+
+func TestMonitor_JailedNodeSurvivesRefreshAndCleanupRounds(t *testing.T) {
+	t.Parallel()
+
+	pkJailed := "pk-jailed"
+
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	arg := createMockArgHeartbeatMonitor()
+	arg.GenesisTime = genesisTime
+	arg.Timer = timer
+	arg.PubKeysList = []string{}
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			if string(pubKey) == pkJailed {
+				return core.JailedList, 0, nil
+			}
+			return core.ObserverList, 0, nil
+		},
+		GetAllPeerTypeInfosCalled: func() []*state.PeerTypeInfo {
+			return []*state.PeerTypeInfo{
+				{PublicKey: pkJailed, PeerType: string(core.JailedList)},
+			}
+		},
+	}
+	mon, err := process.NewMonitor(arg)
+	require.Nil(t, err)
+	// stop the background refresher before the Cleanup/assert rounds: if it
+	// kept running it could recreate an evicted entry between Cleanup and the
+	// assertion, masking a shielding regression
+	require.NoError(t, mon.Close())
+
+	// the jailed validator never sent a heartbeat: the entry is created from
+	// the peer-type cache seeding alone, and must stay visible past the hide
+	// interval so operators can see the jailed node
+	timer.SetSeconds(int(arg.HideInactiveValidatorIntervalInSec) + 100)
+
+	mon.RefreshHeartbeatMessageInfo()
+	assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+
+	for i := 0; i < 3; i++ {
+		mon.Cleanup()
+		assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+		mon.RefreshHeartbeatMessageInfo()
+		assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+	}
+}
+
+func TestMonitor_ActiveJailedNodeCountsOnlyAsConnected(t *testing.T) {
+	t.Parallel()
+
+	pkJailed := "pk-jailed"
+	pkEligible := "pk-eligible"
+
+	arg := createMockArgHeartbeatMonitor()
+	arg.MaxDurationPeerUnresponsive = time.Second * 1000
+	arg.PubKeysList = []string{}
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			switch string(pubKey) {
+			case pkJailed:
+				return core.JailedList, 0, nil
+			case pkEligible:
+				return core.EligibleList, 0, nil
+			}
+			return core.ObserverList, 0, nil
+		},
+	}
+	mon, err := process.NewMonitor(arg)
+	require.Nil(t, err)
+	// stop the background refresher before installing the status handler so a
+	// stale initial refresh can never overwrite the asserted metric values;
+	// the test drives the refresh manually
+	require.NoError(t, mon.Close())
+
+	liveValidators := uint64(0)
+	liveConsensusValidators := uint64(0)
+	connectedNodes := uint64(0)
+	require.NoError(t, mon.SetAppStatusHandler(&mock.AppStatusHandlerStub{
+		SetUInt64ValueHandler: func(key string, value uint64) {
+			switch key {
+			case core.MetricLiveValidatorNodes:
+				liveValidators = value
+			case core.MetricLiveConsensusValidatorNodes:
+				liveConsensusValidators = value
+			case core.MetricConnectedNodes:
+				connectedNodes = value
+			}
+		},
+	}))
+
+	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkJailed)})
+	mon.SendHeartbeatMessage(&data.Heartbeat{Pubkey: []byte(pkEligible)})
+
+	mon.RefreshHeartbeatMessageInfo()
+
+	// a live jailed node is connected but does not count toward the validator
+	// gauges: it is registered, not part of the working set
+	assert.Equal(t, uint64(1), liveValidators)
+	assert.Equal(t, uint64(1), liveConsensusValidators)
+	assert.Equal(t, uint64(2), connectedNodes)
+}
+
+func TestMonitor_UnjailedNodeIsDemotedAndCleaned(t *testing.T) {
+	t.Parallel()
+
+	pkJailed := "pk-jailed"
+
+	timer := mock.NewTimerMock()
+	genesisTime := timer.Now()
+
+	stillJailed := true
+
+	arg := createMockArgHeartbeatMonitor()
+	arg.GenesisTime = genesisTime
+	arg.Timer = timer
+	arg.PubKeysList = []string{}
+	arg.PeerTypeProvider = &mock.PeerTypeProviderStub{
+		ComputeForPubKeyCalled: func(pubKey []byte) (core.PeerType, uint32, error) {
+			if stillJailed && string(pubKey) == pkJailed {
+				return core.JailedList, 0, nil
+			}
+			return core.ObserverList, 0, nil
+		},
+		GetAllPeerTypeInfosCalled: func() []*state.PeerTypeInfo {
+			if stillJailed {
+				return []*state.PeerTypeInfo{
+					{PublicKey: pkJailed, PeerType: string(core.JailedList)},
+				}
+			}
+			return nil
+		},
+	}
+	mon, err := process.NewMonitor(arg)
+	require.Nil(t, err)
+	// stop the background refresher: the test drives refresh and cleanup
+	// manually, and flips the stub without synchronization
+	require.NoError(t, mon.Close())
+
+	timer.SetSeconds(int(arg.HideInactiveValidatorIntervalInSec) + 100)
+
+	mon.RefreshHeartbeatMessageInfo()
+	mon.Cleanup()
+	assert.Equal(t, 1, mon.GetNumHearbeatMessages())
+
+	// the key leaves the coordinator lists entirely (e.g. dropped after the
+	// jail period): ComputeForPubKey falls back to observer, so the entry
+	// loses its shielding and is removed by the next Cleanup
+	stillJailed = false
 
 	mon.RefreshHeartbeatMessageInfo()
 	mon.Cleanup()

--- a/node/heartbeat/process/sender.go
+++ b/node/heartbeat/process/sender.go
@@ -176,8 +176,10 @@ func (s *Sender) getCurrentPrivateAndPublicKeys() (crypto.PrivateKey, crypto.Pub
 func (s *Sender) updateMetrics(hb *heartbeatData.Heartbeat) {
 	result := s.computePeerList(hb.Pubkey)
 
+	// registered tier: a jailed validator still self-reports as a validator
+	// node; the punished state is visible through klv_peer_type
 	nodeType := string(core.NodeTypeObserver)
-	if isValidatorPeerType(result) {
+	if isRegisteredValidatorPeerType(result) {
 		nodeType = string(core.NodeTypeValidator)
 	}
 

--- a/node/heartbeat/process/sender_test.go
+++ b/node/heartbeat/process/sender_test.go
@@ -324,6 +324,23 @@ func TestSender_SendHeartbeatUpdatesNodeTypeMetrics(t *testing.T) {
 			expectedNodeType: string(core.NodeTypeObserver),
 			expectedPeerType: string(core.InactiveList),
 		},
+		{
+			// registered tier: a jailed validator still self-reports as a
+			// validator node, the punished state shows in klv_peer_type
+			name:             "jailed node reports validator node type",
+			peerType:         core.JailedList,
+			expectedNodeType: string(core.NodeTypeValidator),
+			expectedPeerType: string(core.JailedList),
+		},
+		{
+			// the peer-type cache reports leaving-list members as jailed and
+			// never emits "leaving"; the raw string stays on the allowlist
+			// default deliberately
+			name:             "leaving peer type falls back to observer node type",
+			peerType:         core.LeavingList,
+			expectedNodeType: string(core.NodeTypeObserver),
+			expectedPeerType: string(core.LeavingList),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/sharding/indexHashedNodesCoordinatorRegistry.go
+++ b/sharding/indexHashedNodesCoordinatorRegistry.go
@@ -14,6 +14,7 @@ type EpochValidators struct {
 	ElectedValidators  []*SerializableValidator `json:"electedValidators"`
 	EligibleValidators []*SerializableValidator `json:"eligibleValidators"`
 	WaitingValidators  []*SerializableValidator `json:"waitingValidators"`
+	LeavingValidators  []*SerializableValidator `json:"leavingValidators"`
 }
 
 // NodesCoordinatorRegistry holds the data that can be used to initialize a nodes coordinator
@@ -44,6 +45,7 @@ func epochNodesConfigToEpochValidators(config *epochNodesConfig) *EpochValidator
 		ElectedValidators:  ValidatorArrayToSerializableValidatorArray(config.electedList),
 		EligibleValidators: ValidatorArrayToSerializableValidatorArray(config.eligibleList),
 		WaitingValidators:  ValidatorArrayToSerializableValidatorArray(config.waitingList),
+		LeavingValidators:  ValidatorArrayToSerializableValidatorArray(config.leavingList),
 	}
 
 	return result

--- a/sharding/interface.go
+++ b/sharding/interface.go
@@ -36,6 +36,7 @@ type NodesCoordinator interface {
 	GetAllElectedValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error)
 	GetAllEligibleValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error)
 	GetAllWaitingValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error)
+	GetAllLeavingValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error)
 	SetEpochValidatorsInfo(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
 	CheckValidatorSlot(epoch uint32, slotIndex int64, pubkey []byte) bool
 	GetConsensusValidatorsPublicKeys(randomness []byte, slot uint64, epoch uint32) ([]string, error)

--- a/sharding/networksharding/mock_test.go
+++ b/sharding/networksharding/mock_test.go
@@ -17,7 +17,7 @@ func (ncm *nodesCoordinatorStub) GetChance(uint32) uint32 {
 }
 
 // GetAllLeavingValidatorsKeys -
-func (ncs *nodesCoordinatorStub) GetAllLeavingValidatorsKeys(_ uint32) ([][]byte, error) {
+func (ncs *nodesCoordinatorStub) GetAllLeavingValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
 	return nil, nil
 }
 

--- a/sharding/networksharding/nodesCoordinatorStub.go
+++ b/sharding/networksharding/nodesCoordinatorStub.go
@@ -8,26 +8,26 @@ import (
 // NodesCoordinatorStub can not be moved inside mock package as it generates cyclic imports.
 // TODO refactor mock package & sharding package & remove this file. Put tests in sharding_test package
 type NodesCoordinatorStub struct {
-	Validators                              []sharding.Validator
-	ConsensusSize                           uint32
-	GetSelectedPublicKeysCalled             func(selection []byte, epoch uint32) (publicKeys []string, err error)
-	GetValidatorsPublicKeysCalled           func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	GetValidatorsRewardsAddressesCalled     func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
-	SetNodesCalled                          func(nodes []sharding.Validator, epoch uint32) error
-	ComputeValidatorsGroupCalled            func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
-	GetValidatorWithPublicKeyCalled         func(publicKey []byte) (validator sharding.Validator, err error)
-	GetAllElectedValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllEligibleValidatorsKeysCalled      func() ([][]byte, error)
-	GetAllWaitingValidatorsKeysCalled       func() ([][]byte, error)
-	GetAllLeavingValidatorsPublicKeysCalled func() ([][]byte, error)
-	CheckValidatorSlotCalled                func(epoch uint32, slotIndex int64, pubkey []byte) bool
-	ConsensusGroupSizeCalled                func() int
-	LoadValidatorsCalled                    func(validators []*state.ValidatorInfo) error
-	SetEpochValidatorsInfoCalled            func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
-	GetConsensusWhitelistedNodesCalled      func(epoch uint32) (map[string]struct{}, error)
-	GetOwnPublicKeyCalled                   func() []byte
-	GetSavedStateKeyCalled                  func() []byte
-	LoadStateCalled                         func(key []byte) error
+	Validators                          []sharding.Validator
+	ConsensusSize                       uint32
+	GetSelectedPublicKeysCalled         func(selection []byte, epoch uint32) (publicKeys []string, err error)
+	GetValidatorsPublicKeysCalled       func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	GetValidatorsRewardsAddressesCalled func(randomness []byte, slot uint64, epoch uint32) ([]string, error)
+	SetNodesCalled                      func(nodes []sharding.Validator, epoch uint32) error
+	ComputeValidatorsGroupCalled        func(randomness []byte, slot uint64, epoch uint32) (validatorsGroup []sharding.Validator, err error)
+	GetValidatorWithPublicKeyCalled     func(publicKey []byte) (validator sharding.Validator, err error)
+	GetAllElectedValidatorsKeysCalled   func() ([][]byte, error)
+	GetAllEligibleValidatorsKeysCalled  func() ([][]byte, error)
+	GetAllWaitingValidatorsKeysCalled   func() ([][]byte, error)
+	GetAllLeavingValidatorsKeysCalled   func() ([][]byte, error)
+	CheckValidatorSlotCalled            func(epoch uint32, slotIndex int64, pubkey []byte) bool
+	ConsensusGroupSizeCalled            func() int
+	LoadValidatorsCalled                func(validators []*state.ValidatorInfo) error
+	SetEpochValidatorsInfoCalled        func(epoch uint32, validatorsInfo []*state.ValidatorInfo) error
+	GetConsensusWhitelistedNodesCalled  func(epoch uint32) (map[string]struct{}, error)
+	GetOwnPublicKeyCalled               func() []byte
+	GetSavedStateKeyCalled              func() []byte
+	LoadStateCalled                     func(key []byte) error
 }
 
 // GetChance -
@@ -55,6 +55,14 @@ func (ncm *NodesCoordinatorStub) GetAllEligibleValidatorsKeys(_ uint32, _ bool) 
 func (ncm *NodesCoordinatorStub) GetAllWaitingValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
 	if ncm.GetAllWaitingValidatorsKeysCalled != nil {
 		return ncm.GetAllWaitingValidatorsKeysCalled()
+	}
+	return nil, nil
+}
+
+// GetAllLeavingValidatorsKeys -
+func (ncm *NodesCoordinatorStub) GetAllLeavingValidatorsKeys(_ uint32, _ bool) ([][]byte, error) {
+	if ncm.GetAllLeavingValidatorsKeysCalled != nil {
+		return ncm.GetAllLeavingValidatorsKeysCalled()
 	}
 	return nil, nil
 }

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -360,6 +360,13 @@ func epochValidatorsToEpochNodesConfig(config *EpochValidators) (*epochNodesConf
 		return nil, err
 	}
 
+	// registries saved before the leaving list was persisted have no
+	// LeavingValidators field; the list stays empty until the next epoch start
+	result.leavingList, err = serializableValidatorArrayToValidatorArray(config.LeavingValidators)
+	if err != nil {
+		return nil, err
+	}
+
 	return result, nil
 }
 
@@ -695,6 +702,35 @@ func (ihgs *indexHashedNodesCoordinator) GetAllWaitingValidatorsKeys(epoch uint3
 	return validatorsPubKeys, nil
 }
 
+// GetAllLeavingValidatorsKeys will return all leaving validators public keys.
+// The leaving list is populated by computeNodesConfigFromList from validators
+// whose list is jailed, minus the ones promoted back to eligible to fill the
+// consensus size.
+func (ihgs *indexHashedNodesCoordinator) GetAllLeavingValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error) {
+	validatorsPubKeys := make([][]byte, 0)
+
+	ihgs.mutNodesConfig.RLock()
+	nodesConfig, ok := ihgs.nodesConfig[epoch]
+	ihgs.mutNodesConfig.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
+	}
+
+	nodesConfig.mutNodesMaps.RLock()
+	defer nodesConfig.mutNodesMaps.RUnlock()
+
+	for i := 0; i < len(nodesConfig.leavingList); i++ {
+		if ownerKey {
+			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.leavingList[i].OwnerAddress())
+		} else {
+			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.leavingList[i].PubKey())
+		}
+	}
+
+	return validatorsPubKeys, nil
+}
+
 // CheckValidatorSlot - TODO: refactor
 func (ihgs *indexHashedNodesCoordinator) CheckValidatorSlot(epoch uint32, slotIndex int64, pubkey []byte) bool {
 	ihgs.mutNodesConfig.RLock()
@@ -792,7 +828,7 @@ func (ihgs *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 		return
 	}
 
-	err = ihgs.SetNodes(resUpdateNodes.Elected, resUpdateNodes.Eligible, newNodesConfig.waitingList, newEpoch)
+	err = ihgs.SetNodes(resUpdateNodes.Elected, resUpdateNodes.Eligible, newNodesConfig.waitingList, newNodesConfig.leavingList, newEpoch)
 	if err != nil {
 		log.Error("set nodes per shard failed", "error", err.Error())
 	}
@@ -830,6 +866,7 @@ func (ihgs *indexHashedNodesCoordinator) SetNodes(
 	elected []Validator,
 	eligible []Validator,
 	waiting []Validator,
+	leaving []Validator,
 	epoch uint32,
 ) error {
 	ihgs.mutNodesConfig.Lock()
@@ -853,6 +890,7 @@ func (ihgs *indexHashedNodesCoordinator) SetNodes(
 	nodesConfig.electedList = elected
 	nodesConfig.eligibleList = eligible
 	nodesConfig.waitingList = waiting
+	nodesConfig.leavingList = leaving
 	nodesConfig.selector, err = ihgs.createSelector(nodesConfig)
 	if err != nil {
 		return err

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -626,80 +626,23 @@ func displayValidatorsForRandomness(validators []Validator, randomness []byte, s
 
 // GetAllElectedValidatorsKeys will return all validators elected public keys
 func (ihgs *indexHashedNodesCoordinator) GetAllElectedValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error) {
-	validatorsPubKeys := make([][]byte, 0)
-
-	ihgs.mutNodesConfig.RLock()
-	nodesConfig, ok := ihgs.nodesConfig[epoch]
-	ihgs.mutNodesConfig.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
-	}
-
-	nodesConfig.mutNodesMaps.RLock()
-	defer nodesConfig.mutNodesMaps.RUnlock()
-
-	for i := 0; i < len(nodesConfig.electedList); i++ {
-		if ownerKey {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.electedList[i].OwnerAddress())
-		} else {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.electedList[i].PubKey())
-		}
-	}
-
-	return validatorsPubKeys, nil
+	return ihgs.getAllValidatorsKeys(epoch, ownerKey, func(nodesConfig *epochNodesConfig) []Validator {
+		return nodesConfig.electedList
+	})
 }
 
-// GetAllEligibleValidatorsPubGetAllEligibleValidatorsKeyslicKeys will return all validators public keys for all shards
+// GetAllEligibleValidatorsKeys will return all eligible validators public keys
 func (ihgs *indexHashedNodesCoordinator) GetAllEligibleValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error) {
-	validatorsPubKeys := make([][]byte, 0)
-
-	ihgs.mutNodesConfig.RLock()
-	nodesConfig, ok := ihgs.nodesConfig[epoch]
-	ihgs.mutNodesConfig.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
-	}
-
-	nodesConfig.mutNodesMaps.RLock()
-	defer nodesConfig.mutNodesMaps.RUnlock()
-
-	for i := 0; i < len(nodesConfig.eligibleList); i++ {
-		if ownerKey {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.eligibleList[i].OwnerAddress())
-		} else {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.eligibleList[i].PubKey())
-		}
-	}
-
-	return validatorsPubKeys, nil
+	return ihgs.getAllValidatorsKeys(epoch, ownerKey, func(nodesConfig *epochNodesConfig) []Validator {
+		return nodesConfig.eligibleList
+	})
 }
 
-// GetAllWaitingValidatorsKeys will return all validators public keys for all shards
+// GetAllWaitingValidatorsKeys will return all waiting validators public keys
 func (ihgs *indexHashedNodesCoordinator) GetAllWaitingValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error) {
-	validatorsPubKeys := make([][]byte, 0)
-
-	ihgs.mutNodesConfig.RLock()
-	nodesConfig, ok := ihgs.nodesConfig[epoch]
-	ihgs.mutNodesConfig.RUnlock()
-
-	if !ok {
-		return nil, fmt.Errorf("%w epoch=%v", ErrEpochNodesConfigDoesNotExist, epoch)
-	}
-
-	nodesConfig.mutNodesMaps.RLock()
-	defer nodesConfig.mutNodesMaps.RUnlock()
-
-	for i := 0; i < len(nodesConfig.waitingList); i++ {
-		if ownerKey {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.waitingList[i].OwnerAddress())
-		} else {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.waitingList[i].PubKey())
-		}
-	}
-
-	return validatorsPubKeys, nil
+	return ihgs.getAllValidatorsKeys(epoch, ownerKey, func(nodesConfig *epochNodesConfig) []Validator {
+		return nodesConfig.waitingList
+	})
 }
 
 // GetAllLeavingValidatorsKeys will return all leaving validators public keys.
@@ -707,8 +650,20 @@ func (ihgs *indexHashedNodesCoordinator) GetAllWaitingValidatorsKeys(epoch uint3
 // whose list is jailed, minus the ones promoted back to eligible to fill the
 // consensus size.
 func (ihgs *indexHashedNodesCoordinator) GetAllLeavingValidatorsKeys(epoch uint32, ownerKey bool) ([][]byte, error) {
-	validatorsPubKeys := make([][]byte, 0)
+	return ihgs.getAllValidatorsKeys(epoch, ownerKey, func(nodesConfig *epochNodesConfig) []Validator {
+		return nodesConfig.leavingList
+	})
+}
 
+// getAllValidatorsKeys returns the public keys (or owner addresses) of one of
+// the epoch's validator lists, selected by pickList. It is the single
+// implementation behind the GetAllXValidatorsKeys getters, so the epoch lookup
+// and the locking discipline live in one place.
+func (ihgs *indexHashedNodesCoordinator) getAllValidatorsKeys(
+	epoch uint32,
+	ownerKey bool,
+	pickList func(nodesConfig *epochNodesConfig) []Validator,
+) ([][]byte, error) {
 	ihgs.mutNodesConfig.RLock()
 	nodesConfig, ok := ihgs.nodesConfig[epoch]
 	ihgs.mutNodesConfig.RUnlock()
@@ -720,11 +675,13 @@ func (ihgs *indexHashedNodesCoordinator) GetAllLeavingValidatorsKeys(epoch uint3
 	nodesConfig.mutNodesMaps.RLock()
 	defer nodesConfig.mutNodesMaps.RUnlock()
 
-	for i := 0; i < len(nodesConfig.leavingList); i++ {
+	list := pickList(nodesConfig)
+	validatorsPubKeys := make([][]byte, 0, len(list))
+	for _, validator := range list {
 		if ownerKey {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.leavingList[i].OwnerAddress())
+			validatorsPubKeys = append(validatorsPubKeys, validator.OwnerAddress())
 		} else {
-			validatorsPubKeys = append(validatorsPubKeys, nodesConfig.leavingList[i].PubKey())
+			validatorsPubKeys = append(validatorsPubKeys, validator.PubKey())
 		}
 	}
 

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -1,6 +1,8 @@
 package sharding
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -8,6 +10,7 @@ import (
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/crypto/hashing/sha256"
 	"github.com/klever-io/klever-go/data/block"
+	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/sharding/mock"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
@@ -745,6 +748,77 @@ func TestNodesCoordinator_computeNodesConfigFromList_Validators(t *testing.T) {
 	assert.Equal(t, 0, len(newNodesConfig.leavingList))
 }
 
+func TestNodesCoordinator_computeNodesConfigFromList_JailedGoToLeavingList(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments() // ConsensusGroupSize = 4
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	validatorInfos := []*block.EValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("pk1"), PublicKey: []byte("pk1"), List: string(core.ElectedList), Index: 2},
+		{OwnerAddress: []byte("pk2"), PublicKey: []byte("pk2"), List: string(core.EligibleList), Index: 3},
+		{OwnerAddress: []byte("pk3"), PublicKey: []byte("pk3"), List: string(core.EligibleList), Index: 4},
+		{OwnerAddress: []byte("jailed0"), PublicKey: []byte("jailed0"), List: string(core.JailedList), Index: 5},
+		{OwnerAddress: []byte("jailed1"), PublicKey: []byte("jailed1"), List: string(core.JailedList), Index: 6},
+	}
+
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos)
+	require.Nil(t, err)
+
+	// consensus size (4) is covered by elected+eligible, so nothing is promoted
+	require.Equal(t, 2, len(newNodesConfig.leavingList))
+	assert.True(t, containsValidatorWithPubKey(newNodesConfig.leavingList, []byte("jailed0")))
+	assert.True(t, containsValidatorWithPubKey(newNodesConfig.leavingList, []byte("jailed1")))
+	assert.Equal(t, 2, len(newNodesConfig.eligibleList))
+	assert.False(t, containsValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailed0")))
+}
+
+func TestNodesCoordinator_computeNodesConfigFromList_JailedPromotedWhenConsensusShort(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments() // ConsensusGroupSize = 4
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	validatorInfos := []*block.EValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("pk1"), PublicKey: []byte("pk1"), List: string(core.ElectedList), Index: 2},
+		{OwnerAddress: []byte("pk2"), PublicKey: []byte("pk2"), List: string(core.EligibleList), Index: 3},
+		{OwnerAddress: []byte("jailed0"), PublicKey: []byte("jailed0"), List: string(core.JailedList), Index: 4},
+		{OwnerAddress: []byte("jailed1"), PublicKey: []byte("jailed1"), List: string(core.JailedList), Index: 5},
+	}
+
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos)
+	require.Nil(t, err)
+
+	// numToStay = 4 - 3 = 1: one jailed validator is promoted to eligible and
+	// removed from the leaving list, the remainder stays leaving
+	require.Equal(t, 2, len(newNodesConfig.eligibleList))
+	assert.True(t, containsValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailed0")))
+	require.Equal(t, 1, len(newNodesConfig.leavingList))
+	assert.True(t, containsValidatorWithPubKey(newNodesConfig.leavingList, []byte("jailed1")))
+}
+
+func containsValidatorWithPubKey(list []Validator, pubKey []byte) bool {
+	for _, v := range list {
+		if bytes.Equal(v.PubKey(), pubKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsByteSlice(haystack [][]byte, needle []byte) bool {
+	for _, h := range haystack {
+		if bytes.Equal(h, needle) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {
 	t.Parallel()
 
@@ -835,7 +909,7 @@ func TestNodesCoordinator_LoadStateMultiEpochPrecedence(t *testing.T) {
 	require.Nil(t, err)
 
 	for ep := baseEpoch + 1; ep <= highestEpoch; ep++ {
-		err = coordinator.SetNodes(makeElected(ep, ep*10), []Validator{}, []Validator{}, ep)
+		err = coordinator.SetNodes(makeElected(ep, ep*10), []Validator{}, []Validator{}, []Validator{}, ep)
 		require.Nil(t, err)
 	}
 
@@ -947,4 +1021,160 @@ func TestNodesCoordinator_ConstructorSavesStateOnGenesisStart(t *testing.T) {
 	validator, err := coordinator2.GetValidatorWithPublicKey(elected[0].PubKey())
 	require.Nil(t, err)
 	require.Equal(t, elected[0].PubKey(), validator.PubKey())
+}
+
+func TestNodesCoordinator_SetNodesStoresLeavingListAndGetterReturnsIt(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments()
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	leaving := createDummyNodesList(2, "leaving")
+	epoch := uint32(7)
+	err = ihgs.SetNodes(createDummyNodesList(4, "elected"), createDummyNodesList(1, "eligible"), []Validator{}, leaving, epoch)
+	require.Nil(t, err)
+
+	keys, err := ihgs.GetAllLeavingValidatorsKeys(epoch, false)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(keys))
+	for _, v := range leaving {
+		assert.True(t, containsByteSlice(keys, v.PubKey()))
+	}
+
+	ownerKeys, err := ihgs.GetAllLeavingValidatorsKeys(epoch, true)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(ownerKeys))
+	for _, v := range leaving {
+		assert.True(t, containsByteSlice(ownerKeys, v.OwnerAddress()))
+	}
+
+	_, err = ihgs.GetAllLeavingValidatorsKeys(999, false)
+	require.True(t, errors.Is(err, ErrEpochNodesConfigDoesNotExist))
+}
+
+func TestNodesCoordinator_SaveLoadStateRoundTripsLeavingList(t *testing.T) {
+	t.Parallel()
+
+	bootStorer := mock.NewStorerMock()
+	args := createArguments()
+	args.BootStorer = bootStorer
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	leaving := createDummyNodesList(2, "leavingRT")
+	err = coordinator.SetNodes(createDummyNodesList(4, "electedRT"), createDummyNodesList(1, "eligibleRT"), []Validator{}, leaving, 0)
+	require.Nil(t, err)
+
+	savedKey := []byte("leaving-roundtrip-key")
+	require.Nil(t, coordinator.saveState(savedKey))
+
+	argsLoad := createArguments()
+	argsLoad.BootStorer = bootStorer
+	coordinatorLoad, err := NewNodesCoordinator(argsLoad)
+	require.Nil(t, err)
+
+	require.Nil(t, coordinatorLoad.LoadState(savedKey))
+
+	keys, err := coordinatorLoad.GetAllLeavingValidatorsKeys(0, false)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(keys))
+	for _, v := range leaving {
+		assert.True(t, containsByteSlice(keys, v.PubKey()))
+	}
+}
+
+func TestNodesCoordinator_LoadStateWithoutLeavingFieldIsNilSafe(t *testing.T) {
+	t.Parallel()
+
+	// registry JSON written by binaries that predate leaving-list persistence
+	// has no leavingValidators field at all
+	type legacyEpochValidators struct {
+		ElectedValidators  []*SerializableValidator `json:"electedValidators"`
+		EligibleValidators []*SerializableValidator `json:"eligibleValidators"`
+		WaitingValidators  []*SerializableValidator `json:"waitingValidators"`
+	}
+	type legacyRegistry struct {
+		EpochsConfig map[string]*legacyEpochValidators `json:"epochConfigs"`
+		CurrentEpoch uint32                            `json:"currentEpoch"`
+	}
+
+	elected := createDummyNodesList(4, "legacyElected")
+	legacy := &legacyRegistry{
+		CurrentEpoch: 3,
+		EpochsConfig: map[string]*legacyEpochValidators{
+			"3": {
+				ElectedValidators:  ValidatorArrayToSerializableValidatorArray(elected),
+				EligibleValidators: ValidatorArrayToSerializableValidatorArray(createDummyNodesList(1, "legacyEligible")),
+				WaitingValidators:  ValidatorArrayToSerializableValidatorArray([]Validator{}),
+			},
+		},
+	}
+	raw, err := json.Marshal(legacy)
+	require.Nil(t, err)
+
+	bootStorer := mock.NewStorerMock()
+	savedKey := []byte("legacy-registry-key")
+	ncInternalKey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), savedKey...)
+	require.Nil(t, bootStorer.Put(ncInternalKey, raw))
+
+	args := createArguments()
+	args.BootStorer = bootStorer
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	require.Nil(t, coordinator.LoadState(savedKey))
+
+	keys, err := coordinator.GetAllLeavingValidatorsKeys(3, false)
+	require.Nil(t, err)
+	require.Empty(t, keys)
+
+	electedKeys, err := coordinator.GetAllElectedValidatorsKeys(3, false)
+	require.Nil(t, err)
+	require.Equal(t, 4, len(electedKeys))
+}
+
+func TestNodesCoordinator_EpochStartPrepareStoresLeavingList(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments() // ConsensusGroupSize = 4
+	// the shuffler requires elected+eligible >= Nodes; match it to the
+	// validator set below (4 elected + 2 eligible)
+	nodeShuffler, err := NewHashValidatorsShuffler(&NodesShufflerArgs{
+		Nodes:                6,
+		MaxNodesEnableConfig: nil,
+	})
+	require.Nil(t, err)
+	arguments.Shuffler = nodeShuffler
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	epoch := uint32(1)
+	validatorsInfo := []*state.ValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("pk1"), PublicKey: []byte("pk1"), List: string(core.ElectedList), Index: 2},
+		{OwnerAddress: []byte("pk2"), PublicKey: []byte("pk2"), List: string(core.ElectedList), Index: 3},
+		{OwnerAddress: []byte("pk3"), PublicKey: []byte("pk3"), List: string(core.ElectedList), Index: 4},
+		{OwnerAddress: []byte("pk4"), PublicKey: []byte("pk4"), List: string(core.EligibleList), Index: 5},
+		{OwnerAddress: []byte("pk5"), PublicKey: []byte("pk5"), List: string(core.EligibleList), Index: 6},
+		{OwnerAddress: []byte("jailed0"), PublicKey: []byte("jailed0"), List: string(core.JailedList), Index: 7},
+	}
+	require.Nil(t, ihgs.SetEpochValidatorsInfo(epoch, validatorsInfo))
+
+	epochStartBlock := &block.Block{
+		Header: &block.BlockHeader{
+			Nonce:        10,
+			PrevRandSeed: []byte("rand seed"),
+			IsEpochStart: true,
+			Epoch:        epoch,
+		},
+	}
+
+	ihgs.EpochStartPrepare(epochStartBlock)
+
+	// the computed leaving list must be stored on the epoch config, not discarded
+	keys, err := ihgs.GetAllLeavingValidatorsKeys(epoch, false)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(keys))
+	assert.Equal(t, []byte("jailed0"), keys[0])
 }

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -1030,7 +1030,14 @@ func TestNodesCoordinator_SetNodesStoresLeavingListAndGetterReturnsIt(t *testing
 	ihgs, err := NewNodesCoordinator(arguments)
 	require.Nil(t, err)
 
-	leaving := createDummyNodesList(2, "leaving")
+	// build the leaving validators with owner addresses distinct from the
+	// pubkeys (the validator mock drops its owner argument), so the ownerKey
+	// leg below asserts real owner correspondence instead of comparing nils
+	leaving0, err := NewValidator([]byte("owner-leaving-0"), []byte("pk-leaving-0"), DefaultSelectionChances, 0)
+	require.Nil(t, err)
+	leaving1, err := NewValidator([]byte("owner-leaving-1"), []byte("pk-leaving-1"), DefaultSelectionChances, 1)
+	require.Nil(t, err)
+	leaving := []Validator{leaving0, leaving1}
 	epoch := uint32(7)
 	err = ihgs.SetNodes(createDummyNodesList(4, "elected"), createDummyNodesList(1, "eligible"), []Validator{}, leaving, epoch)
 	require.Nil(t, err)
@@ -1132,6 +1139,41 @@ func TestNodesCoordinator_LoadStateWithoutLeavingFieldIsNilSafe(t *testing.T) {
 	electedKeys, err := coordinator.GetAllElectedValidatorsKeys(3, false)
 	require.Nil(t, err)
 	require.Equal(t, 4, len(electedKeys))
+}
+
+func TestNodesCoordinator_LoadStateWithMalformedLeavingValidatorFails(t *testing.T) {
+	t.Parallel()
+
+	// a leaving validator with a nil pubkey must fail the restore instead of
+	// being silently dropped
+	registry := &NodesCoordinatorRegistry{
+		CurrentEpoch: 2,
+		EpochsConfig: map[string]*EpochValidators{
+			"2": {
+				ElectedValidators:  ValidatorArrayToSerializableValidatorArray(createDummyNodesList(4, "malformedElected")),
+				EligibleValidators: ValidatorArrayToSerializableValidatorArray(createDummyNodesList(1, "malformedEligible")),
+				WaitingValidators:  ValidatorArrayToSerializableValidatorArray([]Validator{}),
+				LeavingValidators: []*SerializableValidator{
+					{OwnerAddress: []byte("owner"), PubKey: nil, Index: 1},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(registry)
+	require.Nil(t, err)
+
+	bootStorer := mock.NewStorerMock()
+	savedKey := []byte("malformed-leaving-key")
+	ncInternalKey := append([]byte(core.NodesCoordinatorRegistryKeyPrefix), savedKey...)
+	require.Nil(t, bootStorer.Put(ncInternalKey, raw))
+
+	args := createArguments()
+	args.BootStorer = bootStorer
+	coordinator, err := NewNodesCoordinator(args)
+	require.Nil(t, err)
+
+	err = coordinator.LoadState(savedKey)
+	require.ErrorIs(t, err, ErrNilPubKey)
 }
 
 func TestNodesCoordinator_EpochStartPrepareStoresLeavingList(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #116. Closes #118.

A jailed validator's key never reached the heartbeat peer-type cache, so its node reported `klv_node_type=observer` and `klv_peer_type=observer`, and its heartbeat entry disappeared from `/node/heartbeatstatus` after `HideInactiveValidatorIntervalInSec`. Root cause: the nodes coordinator computed its leaving list (validators with `List == jailed` in `computeNodesConfigFromList`) but then discarded it. `EpochStartPrepare` never handed it to `SetNodes`, `epochNodesConfig.leavingList` was always empty, and the registry did not persist it, so the list was unreachable for the peer-type cache in every scenario (live, epoch start, restart).

## What changed

**Commit 1 (5cc8f9d, #118)**: `PeerTypeProvider.createNewCache` and `validatorsProvider.createNewCache` are now table-driven (`{name, peerType, getter}` plus one loop), so adding a list is one data row instead of an error-prone copy-paste. Semantics preserved exactly: the peerTypeProvider keeps fail-fast (any getter error keeps the previous cache, `log.Warn` with the error), the validatorsProvider keeps its soft-fail overlay. A new subtest pins the soft-fail contract (`failing getter keeps trie-based cache and remaining overlays`), and the empty epoch-start prepare handler got the same explanatory comment as its sibling (sonar go:S1186).

**Commit 2 (49067cc, #116)**: the coordinator now stores, persists and exposes the leaving list, and the peer-type surface consumes it:

- `SetNodes` gained a `leaving` parameter and stores it on the epoch config; `EpochStartPrepare` passes `newNodesConfig.leavingList` (sharding/nodesCoordinator.go).
- The registry serializes it as `leavingValidators` and `LoadState`/the bootstrap path in `cmd/node/node.go` restore it.
- New getter `GetAllLeavingValidatorsKeys(epoch, ownerKey)` on `sharding.NodesCoordinator`; all implementers updated, and the dead `GetAllLeavingValidatorsPublicKeys` mock lookalikes (different name and signature, zero callers) were removed.
- `PeerTypeProvider.createNewCache` seeds the leaving list first, labeled `core.JailedList`; working lists win on any overlap (the numToStay promotion keeps the lists a partition in production).
- New predicate tier `isRegisteredValidatorPeerType` (node/heartbeat/process/heartbeatMessageInfo.go) drives Cleanup shielding (`monitor.go` `shouldSkipValidator`) and `klv_node_type` self-reporting (`sender.go` `updateMetrics`). The gauges are unchanged.

**Commit 3 (015b05f)**: fixes from the first review round: the four `GetAllXValidatorsKeys` getters were consolidated behind one `getAllValidatorsKeys` helper (flagged independently by two reviewers; the fourth copy also risked the SonarQube duplicated-lines gate on new code), the ownerKey test leg now uses real validators with distinct owner addresses (the validator mock drops its owner argument, making the old assertion vacuous), a discarded constructor error in a new test is now asserted, the mock parameter `includeLeaving` was renamed to `ownerKey`, and a new test pins that a malformed leaving validator in the registry fails `LoadState` with `ErrNilPubKey`.

**Commit 4 (bd6804b)**: gate-review nits: the overlay `log.Debug` now includes the error value (errors are never silently discarded), and the precedence comment in the provider scenario test moved to the assertion that actually proves it.

## Design decisions

1. Jailed does **not** count toward `klv_live_validator_nodes`: the gauge remains the working set (elected, eligible, waiting).
2. A jailed validator's node self-reports `klv_node_type=validator`; the punished state is visible as `klv_peer_type=jailed`.
3. Jailed heartbeat entries are shielded from cleanup so operators keep seeing the node; entries are even created from the cache when the node never sent a heartbeat.
4. The reported label is `jailed`, not `leaving`: the coordinator fills the leaving list exclusively from `List == jailed`, and `/validator/statistics` already reports `jailed` from the trie.

The predicate tiers are now: consensus-capable (elected, eligible) inside working validators (plus waiting) inside registered validators (plus jailed), one predicate per tier, with the consumers documented at the definitions.

## Compatibility

- Registry JSON gains `leavingValidators`. Old snapshot on a new binary: field absent, restores an empty list, converges at the next epoch start (pinned by `TestNodesCoordinator_LoadStateWithoutLeavingFieldIsNilSafe`). New snapshot on an old binary (rollback): unknown field is ignored. A malformed leaving entry fails the restore with `ErrNilPubKey` instead of being silently dropped (pinned by `TestNodesCoordinator_LoadStateWithMalformedLeavingValidatorFails`).
- The heartbeat wire format is unchanged and peer types are computed node-locally, so mixed-version networks only differ in their own reporting.

## Operational notes

- `klv_peer_type` gains the value `jailed`. Dashboards or alerts with an enum assumption (elected/eligible/waiting/observer) should be updated; alerts that used `observer` as a proxy for "my validator is broken" change meaning for jailed nodes.
- `klv_live_validator_nodes` now explicitly excludes jailed (doc comment updated); a live jailed node still counts in `klv_connected_nodes`.

## Tests

- Coordinator: `SetNodes` stores the list and the getter returns it (pubkeys and owner addresses, unknown epoch errors), save/load round-trip, legacy registry without the field, malformed leaving entry fails restore, `EpochStartPrepare` stores the computed list end to end, `computeNodesConfigFromList` puts jailed in the leaving list and the numToStay promotion moves the promoted key out of it.
- Providers: scenario tables extended with leaving/jailed rows (fail-fast per getter, partition resolution, keep-previous-cache, precedence on overlap); soft-fail overlay pinned for the validatorsProvider.
- Heartbeat: predicate table test pins jailed as registered and the raw string `leaving` as deliberately not registered; jailed is excluded from both gauges; monitor lifecycle tests pin shielded survival across refresh/cleanup rounds, gauge exclusion for an active jailed node, and demotion plus cleanup once the key leaves the lists; sender table rows pin `jailed` reporting `validator` and `leaving` falling back to `observer`.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean; `golangci-lint` (module mode) reports zero issues on changed files.
- All affected packages green, `-race` clean on `node/heartbeat/...`; full `go test ./...`: 247 packages ok. The two failing packages are baseline: `data/retriever/txpool/memorytests` fails identically on clean develop, and `network/p2p/libp2p` only timed out under full parallel load while passing standalone on both develop and this branch.
- SonarQube API: zero open issues on changed lines (two pre-existing on touched files: go:S107 at cmd/node/node.go:34 and a go:S1135 TODO at nodesCoordinatorStub.go:9).
- Review: seven agent passes (three code-quality, two security, one Go-specific, one metrics); every actionable finding was fixed in commits 3 and 4; the final independent full-diff pass reported no findings.

## Follow-ups (tracked)

- #121: `computeNodesConfigFromList` silently drops validators with `List` leaving, inactive or revoked; they keep reporting observer.
- #122: `validatorsInfo` map is accessed without synchronization (latent data race).
- #123: `selectValidators` bounds guard off-by-one can panic on an index equal to the elected list length.
- #124: numToStay promotion is all-or-nothing; no partial backfill when the leaving list is smaller than the deficit.

Out of scope, tracked separately: the pre-bootstrap epoch seeding window (#113, applies to jailed exactly as it already did to waiting) and the heartbeat monitor concurrency work (#117, #120).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Persist and restore jailed validators in the coordinator’s leaving list.
- Expose leaving-validator keys through `NodesCoordinator`.
- Seed the peer-type cache with `JailedList` entries.
- Keep working-validator classifications higher priority on overlap.
- Keep jailed validators out of `klv_live_validator_nodes`.
- Report jailed validators as `klv_node_type=validator` and `klv_peer_type=jailed`.
- Retain jailed validators in heartbeat status and protect them from cleanup.
- Remove jailed validators from heartbeat tracking after they leave the jailed list.
- Deduplicate validator-list getter and classification logic.
- Preserve fail-fast cache updates in `PeerTypeProvider`.
- Preserve soft-fail overlay behavior in `validatorsProvider`.
- Add compatibility handling for persisted state without a leaving list.

## Blockchain impact

- **Consensus and state management:** The coordinator now carries jailed-validator data across epochs and persistence boundaries. This prevents loss of validator status during restart or epoch changes.
- **Networking and heartbeat:** Jailed validators remain identifiable and visible without being counted as live validators. This improves monitoring and prevents premature cleanup.
- **Transaction processing and KVM:** No direct changes.
- **Node stability:** Cache construction retains the previous cache when `PeerTypeProvider` getters fail. `validatorsProvider` continues to apply available overlays when a getter fails.
- **Data integrity:** Legacy persisted state remains loadable. Malformed leaving-validator data returns an error instead of being silently accepted.
- **Concurrency:** No explicit concurrency model changes are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->