### PR TITLE
fix: request headers when a node falsely reports itself synchronized

### DIFF
--- a/core/process/constants.go
+++ b/core/process/constants.go
@@ -36,9 +36,6 @@ const MaxSyncWithErrorsAllowed = 10
 // SlotModulusTrigger defines a slot modulus on which a trigger for an action will be released
 const SlotModulusTrigger = 5
 
-// SlotModulusTriggerWhenSyncIsStuck defines a slot modulus on which a trigger for an action when sync is stuck will be released
-const SlotModulusTriggerWhenSyncIsStuck = 20
-
 // MinForkSlot represents the minimum fork slot set by a notarized header received
 const MinForkSlot = uint64(0)
 

--- a/core/process/headerCheck/headerSignatureVerify.go
+++ b/core/process/headerCheck/headerSignatureVerify.go
@@ -1,6 +1,7 @@
 package headerCheck
 
 import (
+	"errors"
 	"math/bits"
 
 	logger "github.com/klever-io/klever-go-logger"
@@ -113,6 +114,7 @@ func (hsv *HeaderSigVerifier) VerifySignature(header data.HeaderHandler) error {
 		epoch,
 	)
 	if err != nil {
+		logIfEpochConfigMissing(err, header, epoch, "signature")
 		return err
 	}
 
@@ -293,9 +295,42 @@ func (hsv *HeaderSigVerifier) getLeader(header data.HeaderHandler) (crypto.Publi
 
 	headerConsensusGroup, err := hsv.nodesCoordinator.ComputeConsensusGroup(prevRandSeed, header.GetSlot(), epoch)
 	if err != nil {
+		logIfEpochConfigMissing(err, header, epoch, "leader")
 		return nil, err
 	}
 
 	leaderPubKeyValidator := headerConsensusGroup[0]
 	return hsv.keyGen.PublicKeyFromByteArray(leaderPubKeyValidator.PubKey())
+}
+
+// logIfEpochConfigMissing emits a dedicated line when a header is rejected only
+// because the consensus configuration for its epoch has not been built yet. That
+// configuration is created when the epoch-start block is committed, so between an
+// epoch boundary and that commit every new-epoch header fails here, on gossip, on
+// self-requested headers and on the consensus topic alike (issue #90).
+//
+// Kept at debug level on purpose: an unauthenticated peer can trigger this path
+// with a header carrying an arbitrary future epoch, so a louder level would be a
+// cheap log-flood lever. Enable process/headerCheck:DEBUG to measure how many
+// slots the window actually spans. The header hash is deliberately absent for the
+// same reason: it is not computed yet at this point, and computing one here would
+// put a marshal plus a hash on a path an unauthenticated peer can drive.
+//
+// lookupEpoch is the epoch whose configuration was actually missing, which is not
+// the header's own epoch for an epoch-start header: both callers verify those
+// against the previous epoch. Both values are logged so the line cannot send an
+// operator looking for the wrong configuration.
+func logIfEpochConfigMissing(err error, header data.HeaderHandler, lookupEpoch uint32, stage string) {
+	if !errors.Is(err, sharding.ErrEpochNodesConfigDoesNotExist) {
+		return
+	}
+
+	log.Debug("header rejected, epoch consensus config not built yet",
+		"stage", stage,
+		"missing config for epoch", lookupEpoch,
+		"header epoch", header.GetEpoch(),
+		"nonce", header.GetNonce(),
+		"slot", header.GetSlot(),
+		"is epoch start", header.GetIsEpochStart(),
+	)
 }

--- a/core/process/headerCheck/headerSignatureVerify_test.go
+++ b/core/process/headerCheck/headerSignatureVerify_test.go
@@ -3,8 +3,10 @@ package headerCheck_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 
+	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common"
 	cMock "github.com/klever-io/klever-go/common/mock"
 	"github.com/klever-io/klever-go/core/process"
@@ -725,4 +727,140 @@ func TestHeaderSigVerifier_VerifySignatureOkWhenFallbackThresholdCouldBeApplied(
 	err := hdrSigVerifier.VerifySignature(header)
 	require.Nil(t, err)
 	require.True(t, wasCalled)
+}
+
+// epochConfigLogFormatter keeps everything except the epoch-config rejection line
+// out of the observer buffer, so unrelated log output from other tests in this
+// package cannot make the assertions below flaky. Same idiom as
+// core/process/transactionLog/printTxLogProcessor_test.go.
+type epochConfigLogFormatter struct {
+	logger.PlainFormatter
+}
+
+func (f *epochConfigLogFormatter) Output(line logger.LogLineHandler) []byte {
+	if line.GetMessage() != "header rejected, epoch consensus config not built yet" {
+		return nil
+	}
+
+	return f.PlainFormatter.Output(line)
+}
+
+// The epoch consensus configuration is only built when the epoch-start block is
+// committed, so between an epoch boundary and that commit every new-epoch header
+// is rejected here (issue #90).
+//
+// Two things must hold. The sentinel has to reach the caller intact, because the
+// worker's blacklist suppression keys off it (core/consensus/slot/worker.go) and
+// a header rejected only for this reason is early rather than invalid. And the
+// rejection has to be observable, because counting the slots it spans is how the
+// window's real duration gets measured.
+//
+// Not parallel: it mutates the global log level and observer list.
+func TestHeaderSigVerifier_EpochNodesConfigMissingIsSurfacedIntact(t *testing.T) {
+	const missingEpoch = uint32(7)
+
+	previousPattern := logger.GetLogLevelPattern()
+	require.Nil(t, logger.SetLogLevel("*:DEBUG"))
+
+	buff := &bytes.Buffer{}
+	require.Nil(t, logger.AddLogObserver(buff, &epochConfigLogFormatter{}))
+
+	t.Cleanup(func() {
+		require.Nil(t, logger.RemoveLogObserver(buff))
+		require.Nil(t, logger.SetLogLevel(previousPattern))
+	})
+
+	newArgsRejectingEpochConfig := func() *headerCheck.ArgsHeaderSigVerifier {
+		args := createHeaderSigVerifierArgs()
+		args.NodesCoordinator = &cMock.NodesCoordinatorMock{
+			ComputeValidatorsGroupCalled: func(_ []byte, _ uint64, epoch uint32) ([]sharding.Validator, error) {
+				// Same wrapping the real coordinator applies, so the test also
+				// pins that errors.Is survives it.
+				return nil, fmt.Errorf("%w epoch=%v", sharding.ErrEpochNodesConfigDoesNotExist, epoch)
+			},
+		}
+
+		return args
+	}
+
+	t.Run("leader lookup path", func(t *testing.T) {
+		hdrSigVerifier, err := headerCheck.NewHeaderSigVerifier(newArgsRejectingEpochConfig())
+		require.Nil(t, err)
+
+		header := &block.Block{Header: &block.BlockHeader{Epoch: missingEpoch, Nonce: 42, Slot: 43}}
+
+		err = hdrSigVerifier.VerifyRandSeed(header)
+
+		require.True(t, errors.Is(err, sharding.ErrEpochNodesConfigDoesNotExist), "got %v", err)
+		require.Contains(t, buff.String(), "leader")
+	})
+
+	t.Run("signature path", func(t *testing.T) {
+		hdrSigVerifier, err := headerCheck.NewHeaderSigVerifier(newArgsRejectingEpochConfig())
+		require.Nil(t, err)
+
+		header := &block.Block{
+			Header:        &block.BlockHeader{Epoch: missingEpoch, Nonce: 42, Slot: 43},
+			PubKeysBitmap: []byte("1"),
+		}
+
+		err = hdrSigVerifier.VerifySignature(header)
+
+		require.True(t, errors.Is(err, sharding.ErrEpochNodesConfigDoesNotExist), "got %v", err)
+		require.Contains(t, buff.String(), "signature")
+	})
+
+	// The emitted lines must carry the fields an operator needs to count how many
+	// slots the window spans, not just the message.
+	t.Run("emitted lines carry epoch, nonce and slot", func(t *testing.T) {
+		output := buff.String()
+
+		require.Contains(t, output, "missing config for epoch")
+		require.Contains(t, output, "header epoch")
+		require.Contains(t, output, "nonce")
+		require.Contains(t, output, "slot")
+		require.Contains(t, output, "42")
+		require.Contains(t, output, "43")
+	})
+
+	// For an epoch-start header both callers verify against the previous epoch,
+	// so the line must name that epoch as the missing one. Reporting the header's
+	// own epoch would send an operator looking for the wrong configuration.
+	t.Run("epoch-start header names the previous epoch as the missing one", func(t *testing.T) {
+		buff.Reset()
+
+		hdrSigVerifier, err := headerCheck.NewHeaderSigVerifier(newArgsRejectingEpochConfig())
+		require.Nil(t, err)
+
+		header := &block.Block{
+			Header: &block.BlockHeader{Epoch: missingEpoch, Nonce: 42, Slot: 43, IsEpochStart: true},
+		}
+
+		err = hdrSigVerifier.VerifyRandSeed(header)
+		require.True(t, errors.Is(err, sharding.ErrEpochNodesConfigDoesNotExist), "got %v", err)
+
+		require.Contains(t, buff.String(), "missing config for epoch = 6")
+		require.Contains(t, buff.String(), "header epoch = 7")
+	})
+
+	// A different error must leave the diagnostic silent, otherwise the line stops
+	// meaning "the epoch window is open".
+	t.Run("stays silent for an unrelated error", func(t *testing.T) {
+		buff.Reset()
+
+		args := createHeaderSigVerifierArgs()
+		args.NodesCoordinator = &cMock.NodesCoordinatorMock{
+			ComputeValidatorsGroupCalled: func(_ []byte, _ uint64, _ uint32) ([]sharding.Validator, error) {
+				return nil, errors.New("some other failure")
+			},
+		}
+
+		hdrSigVerifier, err := headerCheck.NewHeaderSigVerifier(args)
+		require.Nil(t, err)
+
+		err = hdrSigVerifier.VerifyRandSeed(&block.Block{Header: &block.BlockHeader{}})
+		require.NotNil(t, err)
+
+		require.Empty(t, buff.String())
+	})
 }

--- a/core/process/headerCheck/headerSignatureVerify_test.go
+++ b/core/process/headerCheck/headerSignatureVerify_test.go
@@ -810,17 +810,27 @@ func TestHeaderSigVerifier_EpochNodesConfigMissingIsSurfacedIntact(t *testing.T)
 		require.Contains(t, buff.String(), "signature")
 	})
 
-	// The emitted lines must carry the fields an operator needs to count how many
-	// slots the window spans, not just the message.
-	t.Run("emitted lines carry epoch, nonce and slot", func(t *testing.T) {
-		output := buff.String()
+	// A single emitted line must carry the fields an operator needs to count how
+	// many slots the window spans. Asserting on one line rather than on the
+	// accumulated buffer is what makes this meaningful: over the concatenation of
+	// several lines the field assertions would still pass with a field missing
+	// from one of them.
+	t.Run("a single emitted line carries epoch, nonce and slot", func(t *testing.T) {
+		buff.Reset()
 
-		require.Contains(t, output, "missing config for epoch")
-		require.Contains(t, output, "header epoch")
-		require.Contains(t, output, "nonce")
-		require.Contains(t, output, "slot")
-		require.Contains(t, output, "42")
-		require.Contains(t, output, "43")
+		hdrSigVerifier, err := headerCheck.NewHeaderSigVerifier(newArgsRejectingEpochConfig())
+		require.Nil(t, err)
+
+		header := &block.Block{Header: &block.BlockHeader{Epoch: missingEpoch, Nonce: 42, Slot: 43}}
+
+		err = hdrSigVerifier.VerifyRandSeed(header)
+		require.True(t, errors.Is(err, sharding.ErrEpochNodesConfigDoesNotExist), "got %v", err)
+
+		output := buff.String()
+		require.Contains(t, output, "missing config for epoch = 7")
+		require.Contains(t, output, "header epoch = 7")
+		require.Contains(t, output, "nonce = 42")
+		require.Contains(t, output, "slot = 43")
 	})
 
 	// For an epoch-start header both callers verify against the previous epoch,

--- a/core/process/sync/baseForkDetector.go
+++ b/core/process/sync/baseForkDetector.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/klever-io/klever-go/core/consensus"
@@ -52,6 +53,10 @@ type baseForkDetector struct {
 	genesisSlot        uint64
 	maxForkHeaderEpoch uint32
 	tmpStuck           time.Time
+	// lastCheckpointAheadWarnSlot throttles the checkpoint-ahead warning to once
+	// per slot; CheckFork can run on every sync-loop iteration while the node is
+	// not synchronized.
+	lastCheckpointAheadWarnSlot atomic.Int64
 }
 
 // SetRollBackNonce sets the nonce where the chain should roll back
@@ -606,17 +611,18 @@ func (bfd *baseForkDetector) isConsensusStuck() bool {
 
 	currentSlot := tools.SafeI64ToU64(bfd.slotManager.Index())
 	lastCheckpointSlot := bfd.lastCheckpoint().slot
-	if currentSlot < lastCheckpointSlot {
+	slotsDifference, err := tools.SafeSubUint64(currentSlot, lastCheckpointSlot)
+	if err != nil {
 		// The last checkpoint is ahead of our own slot index, so no slots have
 		// elapsed since it. Subtracting would wrap around on uint64 and report an
 		// enormous lag, which clears the threshold below and forces a rollback of
 		// a block that was just committed. checkBlockBasicValidity deliberately
 		// accepts headers one slot ahead of the local index, so a node whose clock
 		// trails its peers can reach this state without any peer misbehaving.
+		bfd.warnOnceCheckpointAheadOfSlotIndex(currentSlot, lastCheckpointSlot)
 		return false
 	}
 
-	slotsDifference := currentSlot - lastCheckpointSlot
 	if slotsDifference <= process.MaxSlotsWithoutCommittedBlock {
 		return false
 	}
@@ -626,6 +632,31 @@ func (bfd *baseForkDetector) isConsensusStuck() bool {
 	}
 
 	return true
+}
+
+// warnOnceCheckpointAheadOfSlotIndex surfaces the clock-trails-tip state. While
+// it lasts, the node is otherwise silent: incoming headers are dropped below the
+// default log level because their slot exceeds the local index, the
+// bootstrapper's slot lag reads zero so its stall warning cannot fire, and the
+// node keeps reporting NsSynchronized. After an NTP step-back or a VM resume
+// this can hold for a long time, so this line is the only operator-visible
+// signal. Throttled to once per slot because CheckFork runs on every sync-loop
+// iteration while the node is not synchronized.
+//
+// The format does happen under mutNodeState, since CheckFork's only production
+// caller holds it. That is accepted here, unlike for the stall warning that was
+// moved out of that lock: the throttle caps this at one format per slot, and
+// the state has no out-of-lock observer to move it to.
+func (bfd *baseForkDetector) warnOnceCheckpointAheadOfSlotIndex(currentSlot uint64, checkpointSlot uint64) {
+	slotIndex := bfd.slotManager.Index()
+	if bfd.lastCheckpointAheadWarnSlot.Swap(slotIndex) == slotIndex {
+		return
+	}
+
+	log.Warn("last checkpoint is ahead of the local slot index, node clock appears to trail the network",
+		"local slot index", currentSlot,
+		"checkpoint slot", checkpointSlot,
+		"checkpoint nonce", bfd.lastCheckpoint().nonce)
 }
 
 func (bfd *baseForkDetector) isSyncing() bool {

--- a/core/process/sync/baseForkDetector.go
+++ b/core/process/sync/baseForkDetector.go
@@ -604,7 +604,19 @@ func (bfd *baseForkDetector) isConsensusStuck() bool {
 		return false
 	}
 
-	slotsDifference := tools.SafeI64ToU64(bfd.slotManager.Index()) - bfd.lastCheckpoint().slot
+	currentSlot := tools.SafeI64ToU64(bfd.slotManager.Index())
+	lastCheckpointSlot := bfd.lastCheckpoint().slot
+	if currentSlot < lastCheckpointSlot {
+		// The last checkpoint is ahead of our own slot index, so no slots have
+		// elapsed since it. Subtracting would wrap around on uint64 and report an
+		// enormous lag, which clears the threshold below and forces a rollback of
+		// a block that was just committed. checkBlockBasicValidity deliberately
+		// accepts headers one slot ahead of the local index, so a node whose clock
+		// trails its peers can reach this state without any peer misbehaving.
+		return false
+	}
+
+	slotsDifference := currentSlot - lastCheckpointSlot
 	if slotsDifference <= process.MaxSlotsWithoutCommittedBlock {
 		return false
 	}

--- a/core/process/sync/baseSync.go
+++ b/core/process/sync/baseSync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -358,17 +359,68 @@ func (boot *baseBootstrap) shouldTryToRequestHeaders() bool {
 		return true
 	}
 
-	return boot.slotManager.Index()%process.SlotModulusTriggerWhenSyncIsStuck == 0
+	// The node believes it is synchronized, but that belief comes from the fork
+	// detector, whose counters only move for headers that were accepted. While
+	// header intake is blocked (for instance right after an epoch boundary, when
+	// the new epoch's consensus config does not exist yet) the node sits at a
+	// stale nonce and still reports itself synced. The slot lag is derived from
+	// the slot manager and the last committed block instead, so it stays truthful
+	// in exactly that state.
+	//
+	// This replaces a slot-index modulus trigger (every 20th slot) that could
+	// never fire here: baseForkDetector.isConsensusStuck uses the same lag
+	// threshold and fires on process.SlotModulusTrigger (5), so every slot that
+	// satisfied the old modulus of 20 also produced a forced-rollback ForkInfo,
+	// which the isForcedRollBackOneBlock guard above short-circuits on.
+	// Requesting on the slots in between is what keeps the fork detector out of
+	// that forced-rollback loop: once a requested header lands, isSyncing() turns
+	// true and the next stuck check stands down.
+	//
+	// Fires at most once per slot, because syncBlock returns before registering
+	// the defer that clears isNodeStateCalculated, so computeNodeState short
+	// circuits for the rest of the slot while the node believes it is synced.
+	slotLag := boot.slotsSinceLastCommittedBlock()
+	if slotLag <= process.MaxSlotsWithoutNewBlockReceived {
+		return false
+	}
+
+	// Warn rather than debug, because this is the only signal the node emits for
+	// this state: MetricIsSyncing still reads 0 and GetNodeState still answers
+	// synchronized throughout. It cannot be driven by a peer, since both operands
+	// are local (own slot index, own last committed block), and it is bounded to
+	// once per slot.
+	log.Warn("node believes it is synchronized but has not committed a block for a while",
+		"slots since last committed block", slotLag,
+		"last committed nonce", boot.getNonceForCurrentBlock(),
+		"fork detector highest nonce", boot.forkDetector.ProbableHighestNonce())
+
+	return true
 }
 
-func (boot *baseBootstrap) requestHeadersIfSyncIsStuck() {
+// slotsSinceLastCommittedBlock returns how many slots have passed since the slot
+// of the last committed block. It deliberately avoids the fork detector, so that
+// it remains meaningful when header intake is blocked and the fork detector's
+// counters are frozen.
+func (boot *baseBootstrap) slotsSinceLastCommittedBlock() uint64 {
 	lastSyncedSlot := boot.chainHandler.GetGenesisHeader().GetSlot()
 	currHeader := boot.chainHandler.GetCurrentBlockHeader()
 	if !check.IfNil(currHeader) {
 		lastSyncedSlot = currHeader.GetSlot()
 	}
 
-	slotDiff := tools.SafeI64ToU64(boot.slotManager.Index()) - lastSyncedSlot
+	currentSlot := tools.SafeI64ToU64(boot.slotManager.Index())
+	if currentSlot < lastSyncedSlot {
+		// The last committed block is ahead of our own slot index, so no slots
+		// have elapsed since it. Subtracting would wrap around on uint64 and
+		// report an enormous lag, which now gates a per-slot request path.
+		return 0
+	}
+
+	return currentSlot - lastSyncedSlot
+}
+
+func (boot *baseBootstrap) requestHeadersIfSyncIsStuck() {
+	slotDiff := boot.slotsSinceLastCommittedBlock()
 	if slotDiff <= process.MaxSlotsWithoutNewBlockReceived {
 		return
 	}
@@ -531,7 +583,7 @@ func (boot *baseBootstrap) syncBlocks(ctx context.Context) {
 
 func (boot *baseBootstrap) doJobOnSyncBlockFail(headerHandler data.HeaderHandler, err error) {
 	processBlockStarted := !check.IfNil(headerHandler)
-	isProcessWithError := processBlockStarted && err != process.ErrTimeIsOut
+	isProcessWithError := processBlockStarted && !errors.Is(err, process.ErrTimeIsOut)
 
 	numSyncedWithErrors := boot.incrementSyncedWithErrorsForNonce(boot.getNonceForNextBlock())
 	allowedSyncWithErrorsLimitReached := numSyncedWithErrors >= process.MaxSyncWithErrorsAllowed

--- a/core/process/sync/baseSync.go
+++ b/core/process/sync/baseSync.go
@@ -376,6 +376,16 @@ func (boot *baseBootstrap) shouldTryToRequestHeaders() bool {
 	// that forced-rollback loop: once a requested header lands, isSyncing() turns
 	// true and the next stuck check stands down.
 	//
+	// Import mode is excluded because the once-per-slot bound below does not hold
+	// there: GetNodeState always answers NsNotSynchronized while importing, so
+	// syncBlock never takes its early return, the defer clearing
+	// isNodeStateCalculated runs on every pass, and computeNodeState re-enters
+	// every sleepTime. Replaying historical blocks also produces an unbounded
+	// slot lag by construction, and there are no peers to request from.
+	if boot.isInImportMode {
+		return false
+	}
+
 	// Fires at most once per slot, because syncBlock returns before registering
 	// the defer that clears isNodeStateCalculated, so computeNodeState short
 	// circuits for the rest of the slot while the node believes it is synced.
@@ -628,6 +638,12 @@ func (boot *baseBootstrap) syncBlock() error {
 	boot.computeNodeState()
 	nodeState := boot.GetNodeState()
 	if nodeState != core.NsNotSynchronized {
+		// Returning here leaves isNodeStateCalculated set, so computeNodeState
+		// short circuits for the rest of the slot. That is what bounds the
+		// slot-lag warning and the stuck-request goroutine in
+		// shouldTryToRequestHeaders to once per slot rather than once per
+		// sleepTime. Hoisting the defer above this return would make both fire
+		// on every loop iteration.
 		return nil
 	}
 

--- a/core/process/sync/baseSync.go
+++ b/core/process/sync/baseSync.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	logger "github.com/klever-io/klever-go-logger"
@@ -112,8 +113,11 @@ type baseBootstrap struct {
 	indexer           process.Indexer
 	isInImportMode    bool
 	mutRequestHeaders sync.Mutex
-	cancelFunc        func()
-	hasStarted        bool
+	// lastStuckRequestSlot caps the stuck-recovery burst and its warning to once
+	// per slot, regardless of how often the trigger path runs.
+	lastStuckRequestSlot atomic.Int64
+	cancelFunc           func()
+	hasStarted           bool
 
 	// For Backtest Purpose
 	chanStopNodeProcess chan endProcess.ArgEndProcess
@@ -341,7 +345,7 @@ func (boot *baseBootstrap) computeNodeState() {
 		"isNodeSynchronized", boot.isNodeSynchronized)
 
 	if boot.shouldTryToRequestHeaders() {
-		go boot.requestHeadersIfSyncIsStuck()
+		go boot.requestHeadersIfSyncIsStuck(boot.isNodeSynchronized)
 	}
 }
 
@@ -376,35 +380,16 @@ func (boot *baseBootstrap) shouldTryToRequestHeaders() bool {
 	// that forced-rollback loop: once a requested header lands, isSyncing() turns
 	// true and the next stuck check stands down.
 	//
-	// Import mode is excluded because the once-per-slot bound below does not hold
-	// there: GetNodeState always answers NsNotSynchronized while importing, so
-	// syncBlock never takes its early return, the defer clearing
-	// isNodeStateCalculated runs on every pass, and computeNodeState re-enters
-	// every sleepTime. Replaying historical blocks also produces an unbounded
-	// slot lag by construction, and there are no peers to request from.
+	// Import mode replays historical blocks, so the slot lag is unbounded by
+	// construction and there are no peers to request from.
 	if boot.isInImportMode {
 		return false
 	}
 
-	// Fires at most once per slot, because syncBlock returns before registering
-	// the defer that clears isNodeStateCalculated, so computeNodeState short
-	// circuits for the rest of the slot while the node believes it is synced.
-	slotLag := boot.slotsSinceLastCommittedBlock()
-	if slotLag <= process.MaxSlotsWithoutNewBlockReceived {
-		return false
-	}
-
-	// Warn rather than debug, because this is the only signal the node emits for
-	// this state: MetricIsSyncing still reads 0 and GetNodeState still answers
-	// synchronized throughout. It cannot be driven by a peer, since both operands
-	// are local (own slot index, own last committed block), and it is bounded to
-	// once per slot.
-	log.Warn("node believes it is synchronized but has not committed a block for a while",
-		"slots since last committed block", slotLag,
-		"last committed nonce", boot.getNonceForCurrentBlock(),
-		"fork detector highest nonce", boot.forkDetector.ProbableHighestNonce())
-
-	return true
+	// The resulting burst and its warning are capped to once per slot by
+	// lastStuckRequestSlot inside requestHeadersIfSyncIsStuck, independently of
+	// how often this predicate is evaluated.
+	return boot.slotsSinceLastCommittedBlock() > process.MaxSlotsWithoutNewBlockReceived
 }
 
 // slotsSinceLastCommittedBlock returns how many slots have passed since the slot
@@ -418,21 +403,55 @@ func (boot *baseBootstrap) slotsSinceLastCommittedBlock() uint64 {
 		lastSyncedSlot = currHeader.GetSlot()
 	}
 
-	currentSlot := tools.SafeI64ToU64(boot.slotManager.Index())
-	if currentSlot < lastSyncedSlot {
+	lag, err := tools.SafeSubUint64(tools.SafeI64ToU64(boot.slotManager.Index()), lastSyncedSlot)
+	if err != nil {
 		// The last committed block is ahead of our own slot index, so no slots
 		// have elapsed since it. Subtracting would wrap around on uint64 and
-		// report an enormous lag, which now gates a per-slot request path.
+		// report an enormous lag, which gates a per-slot request path. Debug
+		// rather than warn on purpose: this can run under mutNodeState, and the
+		// operator-facing warning for this state lives in
+		// baseForkDetector.isConsensusStuck, which observes the same condition.
+		log.Debug("last committed block is ahead of the local slot index",
+			"local slot index", boot.slotManager.Index(),
+			"last committed block slot", lastSyncedSlot)
 		return 0
 	}
 
-	return currentSlot - lastSyncedSlot
+	return lag
 }
 
-func (boot *baseBootstrap) requestHeadersIfSyncIsStuck() {
+// requestHeadersIfSyncIsStuck fires the recovery burst once the node has not
+// committed a block for more than MaxSlotsWithoutNewBlockReceived slots.
+// stalledWhileSynced tells it whether the node believed it was synchronized at
+// the moment the burst was decided; that state deserves a warning, because the
+// node advertises NsSynchronized and MetricIsSyncing reads 0 throughout, while
+// an honestly syncing node passing through here is just catching up.
+func (boot *baseBootstrap) requestHeadersIfSyncIsStuck(stalledWhileSynced bool) {
 	slotDiff := boot.slotsSinceLastCommittedBlock()
 	if slotDiff <= process.MaxSlotsWithoutNewBlockReceived {
 		return
+	}
+
+	// Self-enforcing once-per-slot cap. Before this field the bound depended on
+	// computeNodeState's per-slot memoization, which in turn depended on the
+	// position of a defer in syncBlock; a refactor there would have silently put
+	// this burst on the 5 ms sync loop. The swap also keeps concurrent callers
+	// in the same slot down to one burst.
+	currentSlot := boot.slotManager.Index()
+	if boot.lastStuckRequestSlot.Swap(currentSlot) == currentSlot {
+		return
+	}
+
+	if stalledWhileSynced {
+		// Warn level, and emitted here rather than in shouldTryToRequestHeaders:
+		// this goroutine runs outside mutNodeState, which consensus contends on
+		// through GetNodeState, so log formatting stays out of that lock. It
+		// cannot be driven by a peer, since both operands are local (own slot
+		// index, own last committed block).
+		log.Warn("node believes it is synchronized but has not committed a block for a while",
+			"slots since last committed block", slotDiff,
+			"last committed nonce", boot.getNonceForCurrentBlock(),
+			"fork detector highest nonce", boot.forkDetector.ProbableHighestNonce())
 	}
 
 	fromNonce := boot.getNonceForNextBlock()
@@ -639,11 +658,10 @@ func (boot *baseBootstrap) syncBlock() error {
 	nodeState := boot.GetNodeState()
 	if nodeState != core.NsNotSynchronized {
 		// Returning here leaves isNodeStateCalculated set, so computeNodeState
-		// short circuits for the rest of the slot. That is what bounds the
-		// slot-lag warning and the stuck-request goroutine in
-		// shouldTryToRequestHeaders to once per slot rather than once per
-		// sleepTime. Hoisting the defer above this return would make both fire
-		// on every loop iteration.
+		// short circuits for the rest of the slot. The stuck-recovery burst and
+		// its warning carry their own once-per-slot cap (lastStuckRequestSlot),
+		// so hoisting the defer above this return would waste work but no
+		// longer changes how often they fire.
 		return nil
 	}
 

--- a/core/process/sync/baseSync_test.go
+++ b/core/process/sync/baseSync_test.go
@@ -1,0 +1,245 @@
+package sync
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/klever-io/klever-go/common/mock"
+	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
+	"github.com/klever-io/klever-go/core/process"
+	"github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/data/block"
+	"github.com/klever-io/klever-go/storage"
+)
+
+func headerAtSlot(slot uint64) data.HeaderHandler {
+	return &block.Block{Header: &block.BlockHeader{Slot: slot}}
+}
+
+func headerAt(slot uint64, nonce uint64) data.HeaderHandler {
+	return &block.Block{Header: &block.BlockHeader{Slot: slot, Nonce: nonce}}
+}
+
+// blockBootstrapperStub is the smallest blockBootstrapper that
+// requestHeadersIfSyncIsStuck exercises: it records the nonces requested and
+// reports nothing as already present in the pool.
+type blockBootstrapperStub struct {
+	requestedNonces []uint64
+}
+
+func (s *blockBootstrapperStub) getCurrHeader() (data.HeaderHandler, error) { return nil, nil }
+
+func (s *blockBootstrapperStub) getPrevHeader(data.HeaderHandler, storage.Storer) (data.HeaderHandler, error) {
+	return nil, nil
+}
+
+func (s *blockBootstrapperStub) getHeaderWithHashRequestingIfMissing([]byte) (data.HeaderHandler, error) {
+	return nil, nil
+}
+
+func (s *blockBootstrapperStub) getHeaderWithNonceRequestingIfMissing(uint64) (data.HeaderHandler, error) {
+	return nil, nil
+}
+
+func (s *blockBootstrapperStub) haveHeaderInPoolWithNonce(uint64) bool { return false }
+
+func (s *blockBootstrapperStub) isForkTriggeredByMeta() bool { return false }
+
+func (s *blockBootstrapperStub) requestHeaderByNonce(nonce uint64) {
+	s.requestedNonces = append(s.requestedNonces, nonce)
+}
+
+// newBootstrapForRequestGating builds the minimal baseBootstrap that
+// shouldTryToRequestHeaders and slotsSinceLastCommittedBlock touch. Every other
+// field stays zero-valued because neither path reads it.
+func newBootstrapForRequestGating(
+	slotIndex int64,
+	genesisSlot uint64,
+	currentHeader data.HeaderHandler,
+) *baseBootstrap {
+	return &baseBootstrap{
+		slotManager: &consensusMock.SlotManagerMock{SlotIndex: slotIndex},
+		chainHandler: &mock.BlockChainMock{
+			GetGenesisHeaderCalled: func() data.HeaderHandler {
+				return headerAtSlot(genesisSlot)
+			},
+			GetCurrentBlockHeaderCalled: func() data.HeaderHandler {
+				return currentHeader
+			},
+		},
+		forkInfo: &process.ForkInfo{},
+		// Populated even for the predicate tests: shouldTryToRequestHeaders logs
+		// the fork detector's nonce, so a nil here panics instead of failing.
+		forkDetector: &mock.ForkDetectorMock{
+			ProbableHighestNonceCalled: func() uint64 { return 0 },
+		},
+	}
+}
+
+// A node whose header intake is blocked keeps a frozen fork detector, so it
+// reports itself synchronized while the chain moves on (issue #90). It must then
+// react to the slot lag on every slot, not only on the every-20th-slot cadence
+// this replaced.
+func TestShouldTryToRequestHeaders_SyncedNodeReactsToSlotLagOnEverySlot(t *testing.T) {
+	t.Parallel()
+
+	const lastCommittedSlot = uint64(0)
+
+	for slotIndex := int64(1); slotIndex <= 40; slotIndex++ {
+		boot := newBootstrapForRequestGating(slotIndex, 0, headerAtSlot(lastCommittedSlot))
+		boot.isNodeSynchronized = true
+
+		// #nosec G115 -- slotIndex is a small positive loop bound
+		expected := uint64(slotIndex) > process.MaxSlotsWithoutNewBlockReceived
+
+		assert.Equal(t, expected, boot.shouldTryToRequestHeaders(),
+			"slot index %d, lag %d", slotIndex, slotIndex)
+	}
+}
+
+func TestShouldTryToRequestHeaders_NotSynchronizedAlwaysRequests(t *testing.T) {
+	t.Parallel()
+
+	// No lag at all, so only the pre-existing unsynchronized branch can be what
+	// returns true here.
+	boot := newBootstrapForRequestGating(3, 0, headerAtSlot(3))
+	boot.isNodeSynchronized = false
+
+	assert.True(t, boot.shouldTryToRequestHeaders())
+}
+
+func TestShouldTryToRequestHeaders_GuardsShortCircuitBeforeSlotLag(t *testing.T) {
+	t.Parallel()
+
+	// Every case below carries a lag far past the threshold, so a true result
+	// would prove the guard no longer runs before the slot-lag check.
+	const laggingSlotIndex = int64(100)
+
+	t.Run("before genesis", func(t *testing.T) {
+		t.Parallel()
+
+		boot := newBootstrapForRequestGating(laggingSlotIndex, 0, headerAtSlot(0))
+		boot.isNodeSynchronized = true
+		boot.slotManager = &consensusMock.SlotManagerMock{
+			SlotIndex:           laggingSlotIndex,
+			BeforeGenesisCalled: func() bool { return true },
+		}
+
+		assert.False(t, boot.shouldTryToRequestHeaders())
+	})
+
+	t.Run("forced roll back one block", func(t *testing.T) {
+		t.Parallel()
+
+		boot := newBootstrapForRequestGating(laggingSlotIndex, 0, headerAtSlot(0))
+		boot.isNodeSynchronized = true
+		boot.forkInfo = &process.ForkInfo{IsDetected: true, Nonce: math.MaxUint64}
+
+		assert.False(t, boot.shouldTryToRequestHeaders())
+	})
+
+	t.Run("forced roll back to nonce", func(t *testing.T) {
+		t.Parallel()
+
+		boot := newBootstrapForRequestGating(laggingSlotIndex, 0, headerAtSlot(0))
+		boot.isNodeSynchronized = true
+		boot.forkInfo = &process.ForkInfo{IsDetected: true, Slot: math.MaxUint64}
+
+		assert.False(t, boot.shouldTryToRequestHeaders())
+	})
+}
+
+func TestSlotsSinceLastCommittedBlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses the current header slot", func(t *testing.T) {
+		t.Parallel()
+
+		boot := newBootstrapForRequestGating(30, 0, headerAtSlot(12))
+
+		assert.Equal(t, uint64(18), boot.slotsSinceLastCommittedBlock())
+	})
+
+	t.Run("falls back to the genesis slot without a current header", func(t *testing.T) {
+		t.Parallel()
+
+		boot := newBootstrapForRequestGating(30, 5, nil)
+
+		assert.Equal(t, uint64(25), boot.slotsSinceLastCommittedBlock())
+	})
+
+	// Subtracting without this guard wraps around on uint64 and reports an
+	// enormous lag, which would make the node request headers every single slot.
+	t.Run("reports no lag when the committed block is ahead of the slot index", func(t *testing.T) {
+		t.Parallel()
+
+		boot := newBootstrapForRequestGating(50, 0, headerAtSlot(100))
+
+		assert.Equal(t, uint64(0), boot.slotsSinceLastCommittedBlock())
+
+		boot.isNodeSynchronized = true
+		assert.False(t, boot.shouldTryToRequestHeaders())
+	})
+}
+
+// requestHeadersIfSyncIsStuck is what actually drives recovery once the node
+// notices it is behind, and the size of each burst is what operators observe in
+// the logs. This pins that formula: min(MaxHeadersToRequestInAdvance, lag-1)
+// starting at the nonce after the last committed block (issue #90).
+func TestRequestHeadersIfSyncIsStuck(t *testing.T) {
+	t.Parallel()
+
+	newBoot := func(slotIndex int64, currentHeader data.HeaderHandler) (*baseBootstrap, *blockBootstrapperStub) {
+		stub := &blockBootstrapperStub{}
+		boot := newBootstrapForRequestGating(slotIndex, 0, currentHeader)
+		boot.blockBootstrapper = stub
+
+		return boot, stub
+	}
+
+	t.Run("does nothing at or below the threshold", func(t *testing.T) {
+		t.Parallel()
+
+		// Lag is exactly MaxSlotsWithoutNewBlockReceived, so the guard holds.
+		boot, stub := newBoot(int64(process.MaxSlotsWithoutNewBlockReceived), headerAt(0, 7))
+		boot.requestHeadersIfSyncIsStuck()
+
+		assert.Empty(t, stub.requestedNonces)
+	})
+
+	t.Run("requests lag-1 headers just past the threshold", func(t *testing.T) {
+		t.Parallel()
+
+		// Lag 11 -> min(20, 10) = 10 headers, starting at nonce 8.
+		boot, stub := newBoot(int64(process.MaxSlotsWithoutNewBlockReceived)+1, headerAt(0, 7))
+		boot.requestHeadersIfSyncIsStuck()
+
+		assert.Equal(t, []uint64{8, 9, 10, 11, 12, 13, 14, 15, 16, 17}, stub.requestedNonces)
+	})
+
+	t.Run("caps the burst at MaxHeadersToRequestInAdvance", func(t *testing.T) {
+		t.Parallel()
+
+		// Lag 500 would ask for 499, the cap holds it to 20.
+		boot, stub := newBoot(500, headerAt(0, 7))
+		boot.requestHeadersIfSyncIsStuck()
+
+		assert.Len(t, stub.requestedNonces, process.MaxHeadersToRequestInAdvance)
+		assert.Equal(t, uint64(8), stub.requestedNonces[0])
+		assert.Equal(t, uint64(27), stub.requestedNonces[len(stub.requestedNonces)-1])
+	})
+
+	// Without the underflow guard in slotsSinceLastCommittedBlock the subtraction
+	// wraps to a huge uint64, the threshold is trivially cleared, and the node
+	// requests a full burst of nonces that cannot exist yet.
+	t.Run("requests nothing when the committed block is ahead of the slot index", func(t *testing.T) {
+		t.Parallel()
+
+		boot, stub := newBoot(50, headerAt(100, 7))
+		boot.requestHeadersIfSyncIsStuck()
+
+		assert.Empty(t, stub.requestedNonces)
+	})
+}

--- a/core/process/sync/baseSync_test.go
+++ b/core/process/sync/baseSync_test.go
@@ -1,18 +1,23 @@
 package sync
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common/mock"
 	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/data"
 	"github.com/klever-io/klever-go/data/block"
+	"github.com/klever-io/klever-go/statusHandler"
 	"github.com/klever-io/klever-go/storage"
 )
 
@@ -72,8 +77,8 @@ func newBootstrapForRequestGating(
 			},
 		},
 		forkInfo: &process.ForkInfo{},
-		// Populated even for the predicate tests: shouldTryToRequestHeaders logs
-		// the fork detector's nonce, so a nil here panics instead of failing.
+		// Needed by requestHeadersIfSyncIsStuck, whose logging reads the fork
+		// detector's nonce; the predicate itself is side-effect-free.
 		forkDetector: &mock.ForkDetectorMock{
 			ProbableHighestNonceCalled: func() uint64 { return 0 },
 		},
@@ -226,7 +231,7 @@ func TestRequestHeadersIfSyncIsStuck(t *testing.T) {
 
 		// Lag is exactly MaxSlotsWithoutNewBlockReceived, so the guard holds.
 		boot, stub := newBoot(int64(process.MaxSlotsWithoutNewBlockReceived), headerAt(0, 7))
-		boot.requestHeadersIfSyncIsStuck()
+		boot.requestHeadersIfSyncIsStuck(false)
 
 		assert.Empty(t, stub.requestedNonces)
 	})
@@ -236,7 +241,7 @@ func TestRequestHeadersIfSyncIsStuck(t *testing.T) {
 
 		// Lag 11 -> min(20, 10) = 10 headers, starting at nonce 8.
 		boot, stub := newBoot(int64(process.MaxSlotsWithoutNewBlockReceived)+1, headerAt(0, 7))
-		boot.requestHeadersIfSyncIsStuck()
+		boot.requestHeadersIfSyncIsStuck(false)
 
 		assert.Equal(t, []uint64{8, 9, 10, 11, 12, 13, 14, 15, 16, 17}, stub.requestedNonces)
 	})
@@ -246,7 +251,7 @@ func TestRequestHeadersIfSyncIsStuck(t *testing.T) {
 
 		// Lag 500 would ask for 499, the cap holds it to 20.
 		boot, stub := newBoot(500, headerAt(0, 7))
-		boot.requestHeadersIfSyncIsStuck()
+		boot.requestHeadersIfSyncIsStuck(false)
 
 		assert.Len(t, stub.requestedNonces, process.MaxHeadersToRequestInAdvance)
 		assert.Equal(t, uint64(8), stub.requestedNonces[0])
@@ -260,7 +265,7 @@ func TestRequestHeadersIfSyncIsStuck(t *testing.T) {
 		t.Parallel()
 
 		boot, stub := newBoot(50, headerAt(100, 7))
-		boot.requestHeadersIfSyncIsStuck()
+		boot.requestHeadersIfSyncIsStuck(false)
 
 		assert.Empty(t, stub.requestedNonces)
 	})
@@ -334,4 +339,156 @@ func TestDoJobOnSyncBlockFail(t *testing.T) {
 
 		assert.False(t, *rolledBack)
 	})
+}
+
+// newStuckRequestBoot builds the fixture requestHeadersIfSyncIsStuck needs: the
+// gating fixture plus a recording blockBootstrapper.
+func newStuckRequestBoot(slotIndex int64, currentHeader data.HeaderHandler) (*baseBootstrap, *blockBootstrapperStub) {
+	stub := &blockBootstrapperStub{}
+	boot := newBootstrapForRequestGating(slotIndex, 0, currentHeader)
+	boot.blockBootstrapper = stub
+
+	return boot, stub
+}
+
+// The once-per-slot cap must be enforced by the function itself, not by how
+// often callers happen to invoke it: before lastStuckRequestSlot existed the
+// bound depended on computeNodeState's memoization, which a refactor in
+// syncBlock could silently remove with every test still green.
+func TestRequestHeadersIfSyncIsStuck_FiresAtMostOncePerSlot(t *testing.T) {
+	t.Parallel()
+
+	boot, stub := newStuckRequestBoot(int64(process.MaxSlotsWithoutNewBlockReceived)+1, headerAt(0, 7))
+
+	boot.requestHeadersIfSyncIsStuck(false)
+	firstBurst := len(stub.requestedNonces)
+	assert.Equal(t, 10, firstBurst)
+
+	// Same slot: a second invocation must not produce a second burst.
+	boot.requestHeadersIfSyncIsStuck(false)
+	assert.Len(t, stub.requestedNonces, firstBurst)
+
+	// Next slot: the cap releases and the burst fires again.
+	boot.slotManager.(*consensusMock.SlotManagerMock).SlotIndex++
+	boot.requestHeadersIfSyncIsStuck(false)
+	assert.Greater(t, len(stub.requestedNonces), firstBurst)
+}
+
+type stallWarnFormatter struct {
+	logger.PlainFormatter
+}
+
+func (f *stallWarnFormatter) Output(line logger.LogLineHandler) []byte {
+	if line.GetMessage() != "node believes it is synchronized but has not committed a block for a while" {
+		return nil
+	}
+
+	return f.PlainFormatter.Output(line)
+}
+
+// The warning must fire exactly when the burst was decided while the node
+// believed it was synchronized: that state advertises NsSynchronized with
+// MetricIsSyncing at 0, so this line is its only signal. An honestly syncing
+// node passing through the same code path is just catching up and must stay
+// quiet. Not parallel: it registers a global log observer.
+func TestRequestHeadersIfSyncIsStuck_WarnsOnlyWhenStalledWhileSynced(t *testing.T) {
+	buff := &bytes.Buffer{}
+	require.Nil(t, logger.AddLogObserver(buff, &stallWarnFormatter{}))
+	t.Cleanup(func() {
+		require.Nil(t, logger.RemoveLogObserver(buff))
+	})
+
+	t.Run("warns when the node believed it was synchronized", func(t *testing.T) {
+		buff.Reset()
+		boot, _ := newStuckRequestBoot(int64(process.MaxSlotsWithoutNewBlockReceived)+1, headerAt(0, 7))
+
+		boot.requestHeadersIfSyncIsStuck(true)
+
+		require.Contains(t, buff.String(), "node believes it is synchronized")
+		require.Contains(t, buff.String(), "slots since last committed block")
+	})
+
+	t.Run("stays silent while honestly syncing", func(t *testing.T) {
+		buff.Reset()
+		boot, stub := newStuckRequestBoot(int64(process.MaxSlotsWithoutNewBlockReceived)+1, headerAt(0, 7))
+
+		boot.requestHeadersIfSyncIsStuck(false)
+
+		require.NotEmpty(t, stub.requestedNonces, "the burst itself must still fire")
+		require.Empty(t, buff.String())
+	})
+
+	t.Run("warning shares the once-per-slot cap", func(t *testing.T) {
+		buff.Reset()
+		boot, _ := newStuckRequestBoot(int64(process.MaxSlotsWithoutNewBlockReceived)+1, headerAt(0, 7))
+
+		boot.requestHeadersIfSyncIsStuck(true)
+		firstLen := buff.Len()
+		require.Greater(t, firstLen, 0)
+
+		boot.requestHeadersIfSyncIsStuck(true)
+		require.Equal(t, firstLen, buff.Len())
+	})
+}
+
+// signalingBlockBootstrapperStub closes done once the full burst has been
+// requested, giving the wiring test below a race-free point to observe the
+// goroutine's output.
+type signalingBlockBootstrapperStub struct {
+	blockBootstrapperStub
+	remaining int
+	done      chan struct{}
+}
+
+func (s *signalingBlockBootstrapperStub) requestHeaderByNonce(nonce uint64) {
+	s.blockBootstrapperStub.requestHeaderByNonce(nonce)
+	s.remaining--
+	if s.remaining == 0 {
+		close(s.done)
+	}
+}
+
+// Pins the spawn-site wiring in computeNodeState: the goroutine must receive
+// the freshly computed isNodeSynchronized. Every other test injects that flag
+// directly, so with the argument hard-wired to false at the spawn site the
+// package would stay green while the stalled state loses its only signal.
+// Not parallel: it registers a global log observer.
+func TestComputeNodeState_StalledWhileSyncedWiresWarnIntoBurst(t *testing.T) {
+	buff := &bytes.Buffer{}
+	require.Nil(t, logger.AddLogObserver(buff, &stallWarnFormatter{}))
+	t.Cleanup(func() {
+		require.Nil(t, logger.RemoveLogObserver(buff))
+	})
+
+	stub := &signalingBlockBootstrapperStub{
+		remaining: process.MaxHeadersToRequestInAdvance,
+		done:      make(chan struct{}),
+	}
+
+	// Last committed block at slot 0 / nonce 7 while the slot index is 30: a
+	// stalled node. The fork detector reports no fork and a probable highest
+	// nonce equal to the committed one, which is exactly the frozen state that
+	// computes isNodeSynchronized as true.
+	boot := newBootstrapForRequestGating(30, 0, headerAt(0, 7))
+	boot.blockBootstrapper = stub
+	boot.hasStarted = true
+	boot.statusHandler = statusHandler.NewNilStatusHandler()
+	boot.networkWatcher = &mock.MessengerStub{
+		IsConnectedToTheNetworkCalled: func() bool { return true },
+	}
+	boot.forkDetector = &mock.ForkDetectorMock{
+		CheckForkCalled:            func() *process.ForkInfo { return process.NewForkInfo() },
+		ProbableHighestNonceCalled: func() uint64 { return 7 },
+	}
+
+	boot.computeNodeState()
+	require.True(t, boot.isNodeSynchronized)
+
+	select {
+	case <-stub.done:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "the stuck-recovery burst never fired")
+	}
+
+	require.Contains(t, buff.String(), "node believes it is synchronized but has not committed a block for a while")
 }

--- a/core/process/sync/baseSync_test.go
+++ b/core/process/sync/baseSync_test.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"testing"
 
@@ -97,6 +99,26 @@ func TestShouldTryToRequestHeaders_SyncedNodeReactsToSlotLagOnEverySlot(t *testi
 		assert.Equal(t, expected, boot.shouldTryToRequestHeaders(),
 			"slot index %d, lag %d", slotIndex, slotIndex)
 	}
+}
+
+// Import mode replays historical blocks, so the slot lag is unbounded by
+// construction and there are no peers to request from. It also lacks the
+// once-per-slot latch the branch relies on, since GetNodeState always answers
+// NsNotSynchronized while importing, which would put the warning and the request
+// goroutine on the 5 ms sync loop instead.
+func TestShouldTryToRequestHeaders_ImportModeIgnoresSlotLag(t *testing.T) {
+	t.Parallel()
+
+	boot := newBootstrapForRequestGating(100, 0, headerAtSlot(0))
+	boot.isNodeSynchronized = true
+	boot.isInImportMode = true
+
+	assert.False(t, boot.shouldTryToRequestHeaders())
+
+	// The very same lag outside import mode does trigger a request, so the
+	// assertion above cannot pass for the wrong reason.
+	boot.isInImportMode = false
+	assert.True(t, boot.shouldTryToRequestHeaders())
 }
 
 func TestShouldTryToRequestHeaders_NotSynchronizedAlwaysRequests(t *testing.T) {
@@ -241,5 +263,75 @@ func TestRequestHeadersIfSyncIsStuck(t *testing.T) {
 		boot.requestHeadersIfSyncIsStuck()
 
 		assert.Empty(t, stub.requestedNonces)
+	})
+}
+
+// doJobOnSyncBlockFail decides whether a failed sync attempt rolls the chain
+// back. The decision hinges on comparing the failure against
+// process.ErrTimeIsOut: a timeout is expected and must not roll back, anything
+// else must. Comparing with != instead of errors.Is silently rolls back on a
+// wrapped timeout, so both forms are pinned here.
+func TestDoJobOnSyncBlockFail(t *testing.T) {
+	t.Parallel()
+
+	// Not a multiple of process.SlotModulusTrigger, so the synced-with-errors
+	// limit branch cannot reach the rollback and only the error decides.
+	const notAProperSlot = int64(3)
+
+	newBoot := func() (*baseBootstrap, *bool) {
+		rolledBack := false
+		boot := newBootstrapForRequestGating(notAProperSlot, 0, headerAt(1, 1))
+		boot.mapNonceSyncedWithErrors = make(map[uint64]uint32)
+		boot.marshalizer = &mock.MarshalizerMock{}
+		boot.hasher = &mock.HasherMock{}
+		boot.headers = &mock.HeadersCacherStub{}
+		boot.forkDetector = &mock.ForkDetectorMock{
+			ProbableHighestNonceCalled: func() uint64 { return 0 },
+			RemoveHeaderCalled: func(_ uint64, _ []byte) {
+				// Reached only from inside the rollback branch, and before
+				// rollBack itself, which bails out on the nil header store.
+				rolledBack = true
+			},
+		}
+
+		return boot, &rolledBack
+	}
+
+	header := headerAt(1, 1)
+
+	t.Run("plain timeout does not roll back", func(t *testing.T) {
+		t.Parallel()
+
+		boot, rolledBack := newBoot()
+		boot.doJobOnSyncBlockFail(header, process.ErrTimeIsOut)
+
+		assert.False(t, *rolledBack)
+	})
+
+	t.Run("wrapped timeout does not roll back", func(t *testing.T) {
+		t.Parallel()
+
+		boot, rolledBack := newBoot()
+		boot.doJobOnSyncBlockFail(header, fmt.Errorf("process block: %w", process.ErrTimeIsOut))
+
+		assert.False(t, *rolledBack)
+	})
+
+	t.Run("any other error rolls back", func(t *testing.T) {
+		t.Parallel()
+
+		boot, rolledBack := newBoot()
+		boot.doJobOnSyncBlockFail(header, errors.New("something else"))
+
+		assert.True(t, *rolledBack)
+	})
+
+	t.Run("no header means processing never started, so no roll back", func(t *testing.T) {
+		t.Parallel()
+
+		boot, rolledBack := newBoot()
+		boot.doJobOnSyncBlockFail(nil, errors.New("something else"))
+
+		assert.False(t, *rolledBack)
 	})
 }

--- a/core/process/sync/metaForkDetector.go
+++ b/core/process/sync/metaForkDetector.go
@@ -47,6 +47,13 @@ func NewMetaForkDetector(
 	bfd.fork.rollBackNonce = math.MaxUint64
 	bfd.fork.probableHighestNonce = bfd.genesisNonce
 	bfd.fork.highestNonceReceived = bfd.genesisNonce
+	// Sentinels below any real slot index: the zero values would otherwise
+	// collide with slot index 0. For the warn throttle that swallows the first
+	// checkpoint-ahead warning; for lastSlotWithForcedFork it makes
+	// isConsensusStuck treat the genesis slot as if a forced fork just happened
+	// and skip its entire body.
+	bfd.lastCheckpointAheadWarnSlot.Store(math.MinInt64)
+	bfd.fork.lastSlotWithForcedFork = math.MinInt64
 
 	mfd := metaForkDetector{
 		baseForkDetector: bfd,

--- a/core/process/sync/metaForkDetector_test.go
+++ b/core/process/sync/metaForkDetector_test.go
@@ -276,3 +276,31 @@ func TestMetaForkDetector_CheckpointAheadWarnsOncePerSlot(t *testing.T) {
 	_ = bfd.CheckFork()
 	require.Greater(t, buff.Len(), firstLen)
 }
+
+// Slot index 0 is the one value that would collide with an uninitialized
+// throttle field: without the MinInt64 sentinel stored at construction, the
+// first Swap(0) returns the zero value and swallows the warning entirely.
+func TestMetaForkDetector_CheckpointAheadWarnsAtSlotIndexZero(t *testing.T) {
+	buff := &bytes.Buffer{}
+	require.Nil(t, logger.AddLogObserver(buff, &checkpointAheadWarnFormatter{}))
+	t.Cleanup(func() {
+		require.Nil(t, logger.RemoveLogObserver(buff))
+	})
+
+	sloterMock := &consensusMock.SlotManagerMock{
+		SlotIndex:          0,
+		TimeDurationCalled: func() time.Duration { return 0 },
+	}
+	bfd, err := sync.NewMetaForkDetector(sloterMock, &mock.BlackListHandlerStub{}, 0)
+	require.Nil(t, err)
+
+	// checkBlockBasicValidity accepts headers one slot ahead of the local index,
+	// so a checkpoint at slot 1 is reachable while the index still reads 0.
+	hdr := &block.Block{Header: &block.BlockHeader{Nonce: 1, Slot: 1}}
+	require.Nil(t, bfd.AddHeader(hdr, []byte("hash"), process.BHProcessed, nil, nil))
+
+	forkInfo := bfd.CheckFork()
+	require.False(t, forkInfo.IsDetected)
+
+	require.Contains(t, buff.String(), "last checkpoint is ahead of the local slot index")
+}

--- a/core/process/sync/metaForkDetector_test.go
+++ b/core/process/sync/metaForkDetector_test.go
@@ -1,6 +1,7 @@
 package sync_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -152,4 +153,70 @@ func TestMetaForkDetector_AddHeaderHigherNonceThanSlotShouldErr(t *testing.T) {
 		nil,
 	)
 	assert.Equal(t, sync.ErrHigherNonceInBlock, err)
+}
+
+// isConsensusStuck derives its slot lag the same way the bootstrapper does, and
+// on this path the wrapped value does not merely trigger a wasted header request:
+// it produces the ForkInfo that isForcedRollBackOneBlock matches, so the node
+// reverts a block it just committed. checkBlockBasicValidity deliberately accepts
+// headers one slot ahead of the local index, so a node whose clock trails its
+// peers reaches this state without any peer misbehaving.
+func TestMetaForkDetector_CheckForkNoForcedRollBackWhenCheckpointIsAheadOfSlotIndex(t *testing.T) {
+	t.Parallel()
+
+	// A multiple of process.SlotModulusTrigger, so IsInProperSlot holds and only
+	// the underflow guard can keep the forced rollback from firing.
+	const laggingSlotIndex = int64(50)
+	const checkpointSlot = uint64(100)
+
+	sloterMock := &consensusMock.SlotManagerMock{
+		SlotIndex:          int64(checkpointSlot),
+		TimeDurationCalled: func() time.Duration { return 0 },
+	}
+	bfd, err := sync.NewMetaForkDetector(sloterMock, &mock.BlackListHandlerStub{}, 0)
+	assert.Nil(t, err)
+
+	hdr := &block.Block{Header: &block.BlockHeader{Nonce: 5, Slot: checkpointSlot}}
+	err = bfd.AddHeader(hdr, []byte("hash"), process.BHProcessed, nil, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, checkpointSlot, bfd.LastCheckpointSlot())
+
+	// The local slot index now trails the committed block's slot.
+	sloterMock.SlotIndex = laggingSlotIndex
+
+	forkInfo := bfd.CheckFork()
+
+	assert.False(t, forkInfo.IsDetected)
+}
+
+// The counterpart of the guard above: with the checkpoint genuinely behind the
+// slot index, the consensus-stuck detection must still fire. Without this the
+// guard could disable the mechanism entirely and no test would notice.
+func TestMetaForkDetector_CheckForkStillDetectsStuckConsensusWhenCheckpointIsBehind(t *testing.T) {
+	t.Parallel()
+
+	// A multiple of process.SlotModulusTrigger, with a lag well past
+	// process.MaxSlotsWithoutCommittedBlock.
+	const checkpointSlot = uint64(1)
+	const laggingSlotIndex = int64(50)
+
+	sloterMock := &consensusMock.SlotManagerMock{
+		SlotIndex:          int64(checkpointSlot),
+		TimeDurationCalled: func() time.Duration { return 0 },
+	}
+	bfd, err := sync.NewMetaForkDetector(sloterMock, &mock.BlackListHandlerStub{}, 0)
+	assert.Nil(t, err)
+
+	hdr := &block.Block{Header: &block.BlockHeader{Nonce: 1, Slot: checkpointSlot}}
+	err = bfd.AddHeader(hdr, []byte("hash"), process.BHProcessed, nil, nil)
+	assert.Nil(t, err)
+
+	sloterMock.SlotIndex = laggingSlotIndex
+
+	forkInfo := bfd.CheckFork()
+
+	assert.True(t, forkInfo.IsDetected)
+	// The shape isForcedRollBackOneBlock matches.
+	assert.Equal(t, uint64(math.MaxUint64), forkInfo.Nonce)
+	assert.Nil(t, forkInfo.Hash)
 }

--- a/core/process/sync/metaForkDetector_test.go
+++ b/core/process/sync/metaForkDetector_test.go
@@ -1,16 +1,19 @@
 package sync_test
 
 import (
+	"bytes"
 	"math"
 	"testing"
 	"time"
 
+	logger "github.com/klever-io/klever-go-logger"
 	"github.com/klever-io/klever-go/common/mock"
 	consensusMock "github.com/klever-io/klever-go/core/consensus/mock"
 	"github.com/klever-io/klever-go/core/process"
 	"github.com/klever-io/klever-go/core/process/sync"
 	"github.com/klever-io/klever-go/data/block"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMetaForkDetector_NilSlotManagerShouldErr(t *testing.T) {
@@ -219,4 +222,57 @@ func TestMetaForkDetector_CheckForkStillDetectsStuckConsensusWhenCheckpointIsBeh
 	// The shape isForcedRollBackOneBlock matches.
 	assert.Equal(t, uint64(math.MaxUint64), forkInfo.Nonce)
 	assert.Nil(t, forkInfo.Hash)
+}
+
+type checkpointAheadWarnFormatter struct {
+	logger.PlainFormatter
+}
+
+func (f *checkpointAheadWarnFormatter) Output(line logger.LogLineHandler) []byte {
+	if line.GetMessage() != "last checkpoint is ahead of the local slot index, node clock appears to trail the network" {
+		return nil
+	}
+
+	return f.PlainFormatter.Output(line)
+}
+
+// In the clock-trails-tip state this warning is the node's only signal, but
+// CheckFork can run on every 5 ms sync-loop iteration while the node is not
+// synchronized, so it must be throttled to once per slot or it becomes hundreds
+// of lines per second. Not parallel: it registers a global log observer.
+func TestMetaForkDetector_CheckpointAheadWarnsOncePerSlot(t *testing.T) {
+	buff := &bytes.Buffer{}
+	require.Nil(t, logger.AddLogObserver(buff, &checkpointAheadWarnFormatter{}))
+	t.Cleanup(func() {
+		require.Nil(t, logger.RemoveLogObserver(buff))
+	})
+
+	const checkpointSlot = uint64(100)
+
+	sloterMock := &consensusMock.SlotManagerMock{
+		SlotIndex:          int64(checkpointSlot),
+		TimeDurationCalled: func() time.Duration { return 0 },
+	}
+	bfd, err := sync.NewMetaForkDetector(sloterMock, &mock.BlackListHandlerStub{}, 0)
+	require.Nil(t, err)
+
+	hdr := &block.Block{Header: &block.BlockHeader{Nonce: 5, Slot: checkpointSlot}}
+	require.Nil(t, bfd.AddHeader(hdr, []byte("hash"), process.BHProcessed, nil, nil))
+
+	sloterMock.SlotIndex = 50
+	forkInfo := bfd.CheckFork()
+	require.False(t, forkInfo.IsDetected)
+
+	firstLen := buff.Len()
+	require.Greater(t, firstLen, 0)
+	require.Contains(t, buff.String(), "last checkpoint is ahead of the local slot index")
+
+	// Same slot: throttled.
+	_ = bfd.CheckFork()
+	require.Equal(t, firstLen, buff.Len())
+
+	// Next slot: the state persists, so it warns again.
+	sloterMock.SlotIndex = 51
+	_ = bfd.CheckFork()
+	require.Greater(t, buff.Len(), firstLen)
 }

--- a/core/process/sync/metablock.go
+++ b/core/process/sync/metablock.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"math"
 
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
@@ -64,6 +65,10 @@ func NewMetaBootstrap(arguments ArgMetaBootstrapper) (*MetaBootstrap, error) {
 		isInImportMode:  arguments.IsInImportMode,
 		hasStarted:      arguments.SlotManager.BeforeGenesis() || arguments.IsInImportMode || arguments.StartWithInSync,
 	}
+	// Sentinel below any real slot index, mirroring the fork detector's warning
+	// throttle: the zero value would equal slot index 0 and swallow the first
+	// burst there.
+	base.lastStuckRequestSlot.Store(math.MinInt64)
 
 	if base.hasStarted {
 		log.Warn("node starting inSync state")


### PR DESCRIPTION
## The problem

A node whose header intake is blocked keeps a frozen fork detector. `computeNodeState` derives `hasLastBlock` from `probableHighestNonce` (`core/process/sync/baseSync.go:304`), and that counter only moves for headers that were *accepted*. So a node that is rejecting every incoming header sits at a stale nonce, computes `hasLastBlock = true`, reports `NsSynchronized`, and writes `MetricIsSyncing = 0`. `syncBlock` then returns early (`:605-607`) and the node stops asking for anything.

Issue #90 reaches this through an epoch boundary: `nodesConfig[newEpoch]` is only built when the epoch-start block commits, so until then every new-epoch header fails validation on all three intake paths (gossip, self-requested headers, and the consensus topic). But nothing about the mechanism is epoch-specific.

## What this changes

`shouldTryToRequestHeaders` now derives the lag from the slot manager and the last committed block instead of from the fork detector, so it stays truthful in exactly that state.

**This replaces the previous `slotIndex % 20` trigger rather than adding to it, and the reason matters.** That trigger could never fire in this state: `baseForkDetector.isConsensusStuck` (`:598-617`) uses the same lag against the same threshold of 10 and fires on `process.SlotModulusTrigger` (5). Since 20 is a multiple of 5, every slot that satisfied the old modulus also produced a forced-rollback `ForkInfo{IsDetected: true, Nonce: MaxUint64, Hash: nil}`, which is exactly what `isForcedRollBackOneBlock` matches, and `shouldTryToRequestHeaders` short-circuits on that guard before reaching the modulus.

So the baseline behaviour was not a quiet idle. Every fifth slot the node ran `rollBackOneBlockForced`, reverting state and dropping out of consensus for that slot. Requesting on the four slots in between is what keeps the fork detector out of that loop: once a requested header lands, `isSyncing()` turns true and the next stuck check stands down. `SlotModulusTriggerWhenSyncIsStuck` had no other user and is removed, so nobody tunes a constant that does nothing.

`isNodeSynchronized` is deliberately untouched. It gates consensus participation through `initCurrentSlot` (`core/consensus/slot/bls/subslotStartSlot.go:102-106`), so making it slot-lag-aware would push every validator out of consensus during a genuine network-wide halt.

## Also in this change

**A second, higher-impact underflow.** `isConsensusStuck` had the identical unguarded `SafeI64ToU64(Index()) - lastCheckpoint().slot`. There a wrapped lag does not merely waste a header request: it clears the threshold and forces a rollback of a block that was just committed. `checkBlockBasicValidity` deliberately accepts headers one slot ahead of the local index, so a node whose clock trails its peers reaches this without any peer misbehaving.

**A warning at default log level.** Everything about this state was previously invisible: `MetricIsSyncing` reads 0, `GetNodeState` answers synchronized, and both relevant log lines are debug while the node default is info. A node that stalls and simply receives nothing produced no signal at all. The new line fires at most once per slot and both its operands are local (own slot index, own last committed block), so a peer cannot drive it.

**A dedicated debug line for the epoch-config rejection**, from both verification entry points in `core/process/headerCheck`. It stays at debug on purpose: an unauthenticated peer can reach that path with a header carrying an arbitrary epoch, because `isEpochCorrect` admits any `epoch >= trigger.Epoch()`. It names the epoch actually looked up as well as the header's own epoch, which differ for an epoch-start header, so it cannot send an operator to the wrong configuration. The header hash is deliberately absent: it is not computed at that point, and computing one would put a marshal plus a hash on an attacker-drivable path.

**`errors.Is` for the `ErrTimeIsOut` comparison** in `doJobOnSyncBlockFail`, which `errorlint` flags and which fails on wrapped errors.

## What this does not do

It does not remove the false `NsSynchronized` report. During the window the node still advertises synchronized and `MetricIsSyncing` still reads 0; only the request path and the new warning react. Detection latency is unchanged at 11 slots (~44 s at `slotInterval: 4000`); what changes is that past that threshold the node reacts on the next slot rather than on the next multiple of 20, and that it no longer sits in the forced-rollback loop while waiting.

It also does not change `isConsensusStuck`'s semantics beyond the underflow guard. During a genuine network-wide halt the forced-rollback loop still runs. Whether that is correct is an open question that needs the measurement the new diagnostics provide, not a guess.

## Tests

Every production change is pinned by a test that fails without it, verified by reverting each change in a scratch copy:

- `TestShouldTryToRequestHeaders_SyncedNodeReactsToSlotLagOnEverySlot` sweeps slot indices 1 to 40. Without the change it fails on 28 of them (11-19 and 21-39), the ones the old modulus missed.
- `TestShouldTryToRequestHeaders_GuardsShortCircuitBeforeSlotLag` pins that `BeforeGenesis` and both forced-rollback guards still run first, using a lag of 100 so a regression cannot hide.
- `TestSlotsSinceLastCommittedBlock` covers the current-header path, the genesis fallback, and the underflow guard.
- `TestRequestHeadersIfSyncIsStuck` pins the burst formula operators see in the logs: `min(MaxHeadersToRequestInAdvance, lag-1)` starting at the nonce after the last committed block, the cap at 20, and that the underflow guard prevents a burst for nonces that cannot exist.
- `TestMetaForkDetector_CheckForkNoForcedRollBackWhenCheckpointIsAheadOfSlotIndex` and its counterpart `...StillDetectsStuckConsensusWhenCheckpointIsBehind` cover both directions of the fork-detector guard, so it cannot silently disable the mechanism.
- `TestHeaderSigVerifier_EpochNodesConfigMissingIsSurfacedIntact` asserts the sentinel survives both entry points (the consensus worker's blacklist suppression keys off it) and, through a log observer, that the line is actually emitted, carries the fields needed to measure the window, names the previous epoch for an epoch-start header, and stays silent for an unrelated error.

## Verification

`gofmt` clean, `go build ./...` clean, `go vet` clean, `golangci-lint` reports 0 issues on both touched packages, `go test -race` green on both, and `go test ./core/... ./sharding/...` is 75 ok with no failures.

Changed-line coverage: `shouldTryToRequestHeaders`, `slotsSinceLastCommittedBlock` and `logIfEpochConfigMissing` at 100%, and the new fork-detector guard covered in both directions. One new line is uncovered, the `errors.Is` fix in `doJobOnSyncBlockFail`, a function at 0% coverage whose fixture is disproportionate to a one-line lint fix.

Two pre-existing conditions worth knowing, neither caused here: `golangci-lint` cannot run with the repo's own config because `.golangci.yml` sets `modules-download-mode: vendor` and there is no `vendor/` tree, so `--modules-download-mode=mod` was used; and CI runs the lint step as `golangci-lint run ... || true` (#94), so it cannot fail the build.

Refs #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fix header synchronization requests when stale fork-detector state reports false synchronization.
- Calculate synchronization lag from the slot manager and last committed block.
- Enforce one header-request burst and warning per slot.
- Exclude import-db mode from slot-lag requests.
- Prevent slot underflow during synchronization and consensus-stuck checks.
- Preserve existing synchronization and consensus-participation behavior.
- Detect wrapped `ErrTimeIsOut` errors with `errors.Is`.
- Add throttled warnings for stalled synchronized nodes and checkpoint-ahead conditions.
- Add debug logs for missing epoch configuration during header verification.
- Remove the obsolete `SlotModulusTriggerWhenSyncIsStuck` constant.
- Add regression tests for request guards, import mode, lag calculations, underflow handling, fork-detector behavior, request throttling, timeout errors, warning conditions, and epoch configuration errors.

## Impact

- **Consensus and networking:** Header recovery uses local slot lag and handles stale fork-detector state. Consensus-stuck detection avoids rollback decisions when the checkpoint is ahead of the local slot.
- **Node stability:** Underflow guards prevent incorrect recovery decisions. Throttled warnings improve diagnosis of stalled nodes.
- **Data integrity:** The change does not modify committed blockchain data, transaction processing, state management, or KVM behavior.
- **Concurrency and performance:** Atomic slot tracking limits request bursts and warning frequency. The change does not add multi-slot backoff, so recovery is not delayed.
- **Error handling:** Wrapped timeout errors remain detectable. Missing epoch configuration errors remain intact and include diagnostic logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->