### PR TITLE
refactor: replace hand-built SliceHeader in wasmer2 memory view with unsafe.Slice

### DIFF
--- a/kvm/wasmer2/wasmer2InstanceMemory.go
+++ b/kvm/wasmer2/wasmer2InstanceMemory.go
@@ -26,8 +26,10 @@ func (memory *Wasmer2Memory) Data() []byte {
 	var data = (*uint8)(cWasmerMemoryData(memory.cgoInstance))
 
 	// #nosec G103: bounded []byte view over wasmer-owned linear memory;
-	// pointer and length come from the same live instance and every caller
-	// copies in or out under the instance mutex without retaining the view.
+	// pointer and length come from the same live instance. The production
+	// callers (MemLoadFromMemory, MemStoreToMemory) copy in or out under the
+	// instance mutex without retaining the view; test-only MemDump returns
+	// the view directly but only within the instance lifetime.
 	return unsafe.Slice(data, length)
 }
 

--- a/kvm/wasmer2/wasmer2InstanceMemory.go
+++ b/kvm/wasmer2/wasmer2InstanceMemory.go
@@ -2,7 +2,6 @@ package wasmer2
 
 import (
 	"fmt"
-	"reflect"
 	"unsafe"
 
 	"github.com/klever-io/klever-go/kvm/executor"
@@ -10,7 +9,7 @@ import (
 
 var _ = (executor.Memory)((*Wasmer2Memory)(nil))
 
-// Wasmer2Instance represents a WebAssembly instance.
+// Wasmer2Memory represents the memory of a WebAssembly instance.
 type Wasmer2Memory struct {
 	// The underlying WebAssembly instance.
 	cgoInstance *cWasmerInstanceT
@@ -22,22 +21,14 @@ func (memory *Wasmer2Memory) Length() uint32 {
 }
 
 // Data returns a slice of bytes over the WebAssembly memory.
-// nolint
 func (memory *Wasmer2Memory) Data() []byte {
 	var length = memory.Length()
 	var data = (*uint8)(cWasmerMemoryData(memory.cgoInstance))
 
-	var header reflect.SliceHeader
-	// #nosec G103: unsafe.Pointer is used to convert to reflect.SliceHeader
-	header = *(*reflect.SliceHeader)(unsafe.Pointer(&header))
-
-	// #nosec G103: unsafe.Pointer is used to convert to uintptr
-	header.Data = uintptr(unsafe.Pointer(data))
-	header.Len = int(length)
-	header.Cap = int(length)
-
-	// #nosec G103: unsafe.Pointer is used to convert to []byte
-	return *(*[]byte)(unsafe.Pointer(&header))
+	// #nosec G103: bounded []byte view over wasmer-owned linear memory;
+	// pointer and length come from the same live instance and every caller
+	// copies in or out under the instance mutex without retaining the view.
+	return unsafe.Slice(data, length)
 }
 
 // Grow the memory by a number of pages (65kb each).
@@ -62,6 +53,8 @@ func (memory *Wasmer2Memory) Grow(numberOfPages uint32) error {
 
 // Destroy destroys inner memory. Does nothing in wasmer2.
 func (memory *Wasmer2Memory) Destroy() {
+	// Intentionally empty: the linear memory is owned by the native wasmer
+	// instance and is released by cWasmerInstanceDestroy via Clean.
 }
 
 // IsInterfaceNil returns true if underlying object is nil

--- a/kvm/wasmer2/wasmer2InstanceMemory_test.go
+++ b/kvm/wasmer2/wasmer2InstanceMemory_test.go
@@ -1,0 +1,45 @@
+package wasmer2
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/kvm/executor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWasmer2Memory_DataRoundTrip pins the behaviour of the []byte view that
+// Data() builds over the wasmer-owned linear memory: bytes stored through the
+// view must read back identically, and the view must span the full memory.
+func TestWasmer2Memory_DataRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	instance := newLiveInstance(t)
+	defer func() {
+		require.True(t, instance.Clean())
+	}()
+
+	memoryLength := instance.MemLength()
+	require.NotZero(t, memoryLength)
+
+	payload := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	require.NoError(t, instance.MemStore(executor.MemPtr(0), payload))
+
+	loaded, err := instance.MemLoad(executor.MemPtr(0), executor.MemLength(len(payload)))
+	require.NoError(t, err)
+	assert.Equal(t, payload, loaded)
+
+	dump := instance.MemDump()
+	require.Equal(t, int(memoryLength), len(dump))
+	require.Equal(t, int(memoryLength), cap(dump))
+	assert.Equal(t, payload, dump[:len(payload)])
+
+	// Destroy is a documented no-op; the direct call (bypassing the instance
+	// mutex) is safe because this test is sequential and the body is empty.
+	// The memory must remain readable until Clean destroys the instance.
+	instance.memory.Destroy()
+
+	reloaded, err := instance.MemLoad(executor.MemPtr(0), executor.MemLength(len(payload)))
+	require.NoError(t, err)
+	assert.Equal(t, payload, reloaded)
+}

--- a/kvm/wasmer2/wasmer2InstanceMemory_test.go
+++ b/kvm/wasmer2/wasmer2InstanceMemory_test.go
@@ -34,12 +34,19 @@ func TestWasmer2Memory_DataRoundTrip(t *testing.T) {
 	require.Equal(t, int(memoryLength), cap(dump))
 	assert.Equal(t, payload, dump[:len(payload)])
 
+	// Prove the returned view aliases live linear memory rather than copying
+	// it: a write through the view must be observable via MemLoad.
+	dump[0] ^= 0xFF
+	loaded, err = instance.MemLoad(executor.MemPtr(0), executor.MemLength(len(payload)))
+	require.NoError(t, err)
+	assert.Equal(t, dump[:len(payload)], loaded)
+
 	// Destroy is a documented no-op; the direct call (bypassing the instance
-	// mutex) is safe because this test is sequential and the body is empty.
-	// The memory must remain readable until Clean destroys the instance.
+	// mutex) is safe because the instance is local to this test goroutine and
+	// the body is empty. Memory must stay readable until Clean destroys it.
 	instance.memory.Destroy()
 
 	reloaded, err := instance.MemLoad(executor.MemPtr(0), executor.MemLength(len(payload)))
 	require.NoError(t, err)
-	assert.Equal(t, payload, reloaded)
+	assert.Equal(t, dump[:len(payload)], reloaded)
 }


### PR DESCRIPTION
## Summary

Resolves the two mechanical items of #129: the `go vet` findings on the hand-built `reflect.SliceHeader` in `Wasmer2Memory.Data()` are resolved instead of suppressed.

## What changed, per item

**Item 1, dead code (`kvm/wasmer2/wasmer2InstanceMemory.go`)**
The self-assignment `header = *(*reflect.SliceHeader)(unsafe.Pointer(&header))` was a no-op on a freshly declared zero value, fully overwritten directly after, and carried two `#nosec G103` suppressions. Deleted.

**Item 2, SliceHeader construction (`kvm/wasmer2/wasmer2InstanceMemory.go:24-32`)**
`Data()` now builds the `[]byte` view over the wasmer-owned linear memory with `unsafe.Slice(data, length)`, the canonical replacement for the `reflect.SliceHeader` pattern (deprecated since Go 1.21, staticcheck SA1019). The `reflect` import and the blanket `// nolint` are gone.

**Ride-alongs in the same file**
- The empty `Destroy()` body now carries a nested comment explaining the ownership. This resolves the open SonarQube `go:S1186` issue on this file (open since 2024).
- The type doc comment misnamed `Wasmer2Memory` as "Wasmer2Instance"; corrected.

## Why this is safe

- The construction is semantically identical for every reachable input class: non-empty memory, empty memory, and the nil/zero pairing all produce byte-identical views (`unsafe.Slice` sets cap equal to len, matching the old explicit `Cap` assignment).
- The only divergent case, a nil base pointer with a non-zero length, requires the prebuilt wasmer library to contradict its own documented NULL contract. The old code produced a poisoned slice and an undefined-behaviour segfault under wasmer's signal handlers; the new code fails with a deterministic panic that lands in the existing recover path (`kvm/vmhost/hostCore/host.go:502` and `:575`, `ErrExecutionPanicked`), so the node survives and the transaction fails.
- No gas, output, or state change; old and new binaries interoperate on a mixed network, so no epoch gate is needed.
- All four consumers of `Data()` were enumerated: `executor.MemLoadFromMemory` and `executor.MemStoreToMemory` (`kvm/executor/executorMemory.go:37`, `:73`; both bounds-checked and copying), test-only `MemDump`, and a mock that never touches this type. Every production path copies under the instance mutex behind the cleaned-instance guards, and none retains the view.

## Static-analysis delta, stated honestly

- Resolved: the three `go vet` SliceHeader findings and the staticcheck SA1019 deprecation.
- Replaced: one blanket `// nolint` plus three `#nosec G103` comments make way for a single targeted `#nosec G103` with a written justification on the `unsafe.Slice` line, because gosec's audit rule also matches `unsafe.Slice`. Zero open linter findings on the changed files under the repo config.
- `go vet ./kvm/wasmer2/` now reports only the context-pointer finding in `wasmer2ImportsCgoHelper.go`, which is tracked separately (see #129).

## Test that pins the behaviour

New `kvm/wasmer2/wasmer2InstanceMemory_test.go` (`TestWasmer2Memory_DataRoundTrip`) runs against a live native instance: a store/load round-trip through separately obtained views (proves `Data()` returns a live aliasing view, not a per-call copy), `len` and `cap` both equal to `Length()`, and a re-read after the no-op `Destroy()`. This brings the changed lines to 100% in-package coverage under the CI coverage command.

## Verification

- `go build ./...`, `gofmt`, and the CI-identical `go vet -unsafeptr=false` over all packages: clean.
- `go test -count=1` on `kvm/wasmer2` (also with `-race`, which enables checkptr), `kvm/executor/...`, and the full `kvm/vmhost/hosttest` contract suite: green.
- SonarQube analysis of both final files: 0 issues; the pre-existing open `S1186` on this file is resolved by this PR.
- Audited pre-push by four independent review passes (security, code review, Go specialist, and an adversarial full-diff pass); every finding was fixed before this PR was opened.

Closes #129


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates the KVM `kvm/wasmer2` memory bridge.
- Replaces manual `reflect.SliceHeader` construction with `unsafe.Slice`.
- Removes unused code, imports, suppressions, and blanket lint directives.
- Documents native Wasmer memory ownership and corrects `Wasmer2Memory` documentation.
- Adds a parallelized native-instance round-trip test for aliasing, length, capacity, cleanup, and post-`Destroy()` reads.
- Resolves related `go vet`, staticcheck, and SonarQube findings while retaining targeted `#nosec G103` justification.

## Impact

- Consensus, transaction processing, state management, and networking logic are unchanged.
- The change affects KVM memory access only.
- The memory view preserves existing pointer, length, capacity, and aliasing behavior.
- The test verifies data integrity and continued read access after the no-op `Destroy()` call.
- Native Wasmer retains ownership of the memory and releases it during `Destroy()`.
- No node stability, error-handling, or production concurrency behavior changes.
- Build, formatting, vet, race tests, package tests, and host contract-suite checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->