### PR TITLE
fix: make jailed consensus backfill deterministic behind fixJailedPromotionOrder epoch

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -267,16 +267,29 @@ func startStatisticsMonitor(
 	return nil
 }
 
-func createNodesCoordinator(
-	nodesConfig *sharding.NodesSetup,
-	coreComponents *factory.CoreComponents,
-	cryptoParams *factory.CryptoParams,
-	epochStartNotifier sharding.EpochStartEventNotifier,
-	bootStorer storage.Storer,
-	nodeShuffler sharding.NodesShuffler,
-	bootstrapParameters bootstrap.Parameters,
-	startEpoch uint32,
-) (sharding.NodesCoordinator, error) {
+// createNodesCoordinatorArgs holds the dependencies for createNodesCoordinator
+type createNodesCoordinatorArgs struct {
+	nodesConfig                  *sharding.NodesSetup
+	coreComponents               *factory.CoreComponents
+	cryptoParams                 *factory.CryptoParams
+	epochStartNotifier           sharding.EpochStartEventNotifier
+	bootStorer                   storage.Storer
+	nodeShuffler                 sharding.NodesShuffler
+	bootstrapParameters          bootstrap.Parameters
+	startEpoch                   uint32
+	fixJailedPromotionOrderEpoch uint32
+}
+
+func createNodesCoordinator(args createNodesCoordinatorArgs) (sharding.NodesCoordinator, error) {
+	nodesConfig := args.nodesConfig
+	coreComponents := args.coreComponents
+	cryptoParams := args.cryptoParams
+	epochStartNotifier := args.epochStartNotifier
+	bootStorer := args.bootStorer
+	nodeShuffler := args.nodeShuffler
+	bootstrapParameters := args.bootstrapParameters
+	startEpoch := args.startEpoch
+	fixJailedPromotionOrderEpoch := args.fixJailedPromotionOrderEpoch
 
 	electedNodesInfo, eligibleNodesInfo, err := nodesConfig.InitialNodesInfo()
 	if err != nil {
@@ -324,18 +337,19 @@ func createNodesCoordinator(
 	}
 
 	arguments := sharding.ArgNodesCoordinator{
-		ConsensusGroupSize:  int(nodesConfig.ConsensusGroupSize),
-		Marshalizer:         coreComponents.InternalMarshalizer,
-		Hasher:              coreComponents.Hasher,
-		Shuffler:            nodeShuffler,
-		EpochStartNotifier:  epochStartNotifier,
-		BootStorer:          bootStorer,
-		ElectedNodes:        electedValidators,
-		EligibleNodes:       eligibleValidators,
-		SelfPublicKey:       pubKeyBytes,
-		ConsensusGroupCache: consensusGroupCache,
-		Epoch:               currentEpoch,
-		StartEpoch:          startEpoch,
+		ConsensusGroupSize:           int(nodesConfig.ConsensusGroupSize),
+		Marshalizer:                  coreComponents.InternalMarshalizer,
+		Hasher:                       coreComponents.Hasher,
+		Shuffler:                     nodeShuffler,
+		EpochStartNotifier:           epochStartNotifier,
+		BootStorer:                   bootStorer,
+		ElectedNodes:                 electedValidators,
+		EligibleNodes:                eligibleValidators,
+		SelfPublicKey:                pubKeyBytes,
+		ConsensusGroupCache:          consensusGroupCache,
+		Epoch:                        currentEpoch,
+		StartEpoch:                   startEpoch,
+		FixJailedPromotionOrderEpoch: fixJailedPromotionOrderEpoch,
 	}
 
 	if len(bootstrapParameters.CurrEpochValidatorsInfo) > 0 {

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -390,7 +390,14 @@ func restorePreviousEpochNodes(
 	nodeRegistry *sharding.NodesCoordinatorRegistry,
 	currentEpoch uint32,
 ) error {
-	prevEpochsConfig, ok := nodeRegistry.EpochsConfig[fmt.Sprintf("%d", currentEpoch-1)]
+	if currentEpoch == 0 {
+		// no previous epoch exists; without this guard the uint32 subtraction
+		// below would wrap and look up epoch 4294967295 in the registry
+		return nil
+	}
+
+	prevEpoch := currentEpoch - 1
+	prevEpochsConfig, ok := nodeRegistry.EpochsConfig[fmt.Sprintf("%d", prevEpoch)]
 	if !ok {
 		return nil
 	}
@@ -410,5 +417,5 @@ func restorePreviousEpochNodes(
 		return err
 	}
 
-	return nodesCoordinator.SetNodes(electedValidators, eligibleValidators, waitingValidators, currentEpoch-1)
+	return nodesCoordinator.SetNodes(electedValidators, eligibleValidators, waitingValidators, prevEpoch)
 }

--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -281,17 +281,7 @@ type createNodesCoordinatorArgs struct {
 }
 
 func createNodesCoordinator(args createNodesCoordinatorArgs) (sharding.NodesCoordinator, error) {
-	nodesConfig := args.nodesConfig
-	coreComponents := args.coreComponents
-	cryptoParams := args.cryptoParams
-	epochStartNotifier := args.epochStartNotifier
-	bootStorer := args.bootStorer
-	nodeShuffler := args.nodeShuffler
-	bootstrapParameters := args.bootstrapParameters
-	startEpoch := args.startEpoch
-	fixJailedPromotionOrderEpoch := args.fixJailedPromotionOrderEpoch
-
-	electedNodesInfo, eligibleNodesInfo, err := nodesConfig.InitialNodesInfo()
+	electedNodesInfo, eligibleNodesInfo, err := args.nodesConfig.InitialNodesInfo()
 	if err != nil {
 		return nil, err
 	}
@@ -306,23 +296,13 @@ func createNodesCoordinator(args createNodesCoordinatorArgs) (sharding.NodesCoor
 		return nil, err
 	}
 
-	currentEpoch := startEpoch
-	if bootstrapParameters.NodesConfig != nil {
-		nodeRegistry := bootstrapParameters.NodesConfig
-		currentEpoch = bootstrapParameters.Epoch
-		epochsConfig, ok := nodeRegistry.EpochsConfig[fmt.Sprintf("%d", currentEpoch)]
-		if ok {
-			elected := epochsConfig.ElectedValidators
-			electedValidators, err = sharding.SerializableValidatorsToValidators(elected)
-			if err != nil {
-				return nil, err
-			}
-
-			eligibles := epochsConfig.EligibleValidators
-			eligibleValidators, err = sharding.SerializableValidatorsToValidators(eligibles)
-			if err != nil {
-				return nil, err
-			}
+	currentEpoch := args.startEpoch
+	if args.bootstrapParameters.NodesConfig != nil {
+		currentEpoch = args.bootstrapParameters.Epoch
+		electedValidators, eligibleValidators, err = registryValidatorsForEpoch(
+			args.bootstrapParameters.NodesConfig, currentEpoch, electedValidators, eligibleValidators)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -331,33 +311,28 @@ func createNodesCoordinator(args createNodesCoordinatorArgs) (sharding.NodesCoor
 		return nil, err
 	}
 
-	pubKeyBytes, err := cryptoParams.PublicKey.ToByteArray()
+	pubKeyBytes, err := args.cryptoParams.PublicKey.ToByteArray()
 	if err != nil {
 		return nil, err
 	}
 
 	arguments := sharding.ArgNodesCoordinator{
-		ConsensusGroupSize:           int(nodesConfig.ConsensusGroupSize),
-		Marshalizer:                  coreComponents.InternalMarshalizer,
-		Hasher:                       coreComponents.Hasher,
-		Shuffler:                     nodeShuffler,
-		EpochStartNotifier:           epochStartNotifier,
-		BootStorer:                   bootStorer,
+		ConsensusGroupSize:           int(args.nodesConfig.ConsensusGroupSize),
+		Marshalizer:                  args.coreComponents.InternalMarshalizer,
+		Hasher:                       args.coreComponents.Hasher,
+		Shuffler:                     args.nodeShuffler,
+		EpochStartNotifier:           args.epochStartNotifier,
+		BootStorer:                   args.bootStorer,
 		ElectedNodes:                 electedValidators,
 		EligibleNodes:                eligibleValidators,
 		SelfPublicKey:                pubKeyBytes,
 		ConsensusGroupCache:          consensusGroupCache,
 		Epoch:                        currentEpoch,
-		StartEpoch:                   startEpoch,
-		FixJailedPromotionOrderEpoch: fixJailedPromotionOrderEpoch,
-	}
-
-	if len(bootstrapParameters.CurrEpochValidatorsInfo) > 0 {
-		arguments.CurrValidatorsInfo = bootstrapParameters.CurrEpochValidatorsInfo
-	}
-
-	if len(bootstrapParameters.PrevEpochValidatorsInfo) > 0 {
-		arguments.PrevValidatorsInfo = bootstrapParameters.PrevEpochValidatorsInfo
+		StartEpoch:                   args.startEpoch,
+		FixJailedPromotionOrderEpoch: args.fixJailedPromotionOrderEpoch,
+		// NewNodesCoordinator only stores these when non-empty, so no guards needed
+		CurrValidatorsInfo: args.bootstrapParameters.CurrEpochValidatorsInfo,
+		PrevValidatorsInfo: args.bootstrapParameters.PrevEpochValidatorsInfo,
 	}
 
 	nodesCoordinator, err := sharding.NewNodesCoordinator(arguments)
@@ -365,34 +340,75 @@ func createNodesCoordinator(args createNodesCoordinatorArgs) (sharding.NodesCoor
 		return nil, err
 	}
 
-	if bootstrapParameters.NodesConfig != nil {
-		nodeRegistry := bootstrapParameters.NodesConfig
-		prevEpochsConfig, ok := nodeRegistry.EpochsConfig[fmt.Sprintf("%d", currentEpoch-1)]
-		if ok {
-			elected := prevEpochsConfig.ElectedValidators
-			electedValidators, err = sharding.SerializableValidatorsToValidators(elected)
-			if err != nil {
-				return nil, err
-			}
-
-			eligibles := prevEpochsConfig.EligibleValidators
-			eligibleValidators, err = sharding.SerializableValidatorsToValidators(eligibles)
-			if err != nil {
-				return nil, err
-			}
-
-			waiting := prevEpochsConfig.WaitingValidators
-			waitingValidators, err := sharding.SerializableValidatorsToValidators(waiting)
-			if err != nil {
-				return nil, err
-			}
-
-			err = nodesCoordinator.SetNodes(electedValidators, eligibleValidators, waitingValidators, currentEpoch-1)
-			if err != nil {
-				return nil, err
-			}
+	if args.bootstrapParameters.NodesConfig != nil {
+		err = restorePreviousEpochNodes(nodesCoordinator, args.bootstrapParameters.NodesConfig, currentEpoch)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	return nodesCoordinator, nil
+}
+
+// registryValidatorsForEpoch returns the elected and eligible validators stored
+// in the bootstrap registry for the given epoch, or the provided defaults when
+// the registry has no entry for that epoch
+func registryValidatorsForEpoch(
+	nodeRegistry *sharding.NodesCoordinatorRegistry,
+	epoch uint32,
+	defaultElected []sharding.Validator,
+	defaultEligible []sharding.Validator,
+) ([]sharding.Validator, []sharding.Validator, error) {
+	epochsConfig, ok := nodeRegistry.EpochsConfig[fmt.Sprintf("%d", epoch)]
+	if !ok {
+		return defaultElected, defaultEligible, nil
+	}
+
+	electedValidators, err := sharding.SerializableValidatorsToValidators(epochsConfig.ElectedValidators)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	eligibleValidators, err := sharding.SerializableValidatorsToValidators(epochsConfig.EligibleValidators)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return electedValidators, eligibleValidators, nil
+}
+
+// epochNodesSetter is the slice of the coordinator needed to restore the
+// previous epoch's lists; the concrete NewNodesCoordinator result implements it
+type epochNodesSetter interface {
+	SetNodes(elected []sharding.Validator, eligible []sharding.Validator, waiting []sharding.Validator, epoch uint32) error
+}
+
+// restorePreviousEpochNodes loads the previous epoch's validator lists from the
+// bootstrap registry, when present, and sets them on the coordinator
+func restorePreviousEpochNodes(
+	nodesCoordinator epochNodesSetter,
+	nodeRegistry *sharding.NodesCoordinatorRegistry,
+	currentEpoch uint32,
+) error {
+	prevEpochsConfig, ok := nodeRegistry.EpochsConfig[fmt.Sprintf("%d", currentEpoch-1)]
+	if !ok {
+		return nil
+	}
+
+	electedValidators, err := sharding.SerializableValidatorsToValidators(prevEpochsConfig.ElectedValidators)
+	if err != nil {
+		return err
+	}
+
+	eligibleValidators, err := sharding.SerializableValidatorsToValidators(prevEpochsConfig.EligibleValidators)
+	if err != nil {
+		return err
+	}
+
+	waitingValidators, err := sharding.SerializableValidatorsToValidators(prevEpochsConfig.WaitingValidators)
+	if err != nil {
+		return err
+	}
+
+	return nodesCoordinator.SetNodes(electedValidators, eligibleValidators, waitingValidators, currentEpoch-1)
 }

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/klever-io/klever-go/sharding"
@@ -105,6 +106,26 @@ func TestRestorePreviousEpochNodes_RestoresPreviousEpochLists(t *testing.T) {
 	assert.Equal(t, []byte("eligible0"), gotEligible[0].PubKey())
 	require.Equal(t, 1, len(gotWaiting))
 	assert.Equal(t, []byte("waiting0"), gotWaiting[0].PubKey())
+}
+
+func TestRestorePreviousEpochNodes_PropagatesSetNodesError(t *testing.T) {
+	t.Parallel()
+
+	nodeRegistry := &sharding.NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*sharding.EpochValidators{
+			"4": {ElectedValidators: serializableValidators("elected0")},
+		},
+	}
+	expectedErr := errors.New("set nodes failed")
+	stub := &nodesSetterStub{
+		setNodesCalled: func(_ []sharding.Validator, _ []sharding.Validator, _ []sharding.Validator, _ uint32) error {
+			return expectedErr
+		},
+	}
+
+	err := restorePreviousEpochNodes(stub, nodeRegistry, 5)
+
+	require.Equal(t, expectedErr, err)
 }
 
 func TestRegistryValidatorsForEpoch_MissingEpochReturnsDefaults(t *testing.T) {

--- a/cmd/node/node_test.go
+++ b/cmd/node/node_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/sharding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type nodesSetterStub struct {
+	setNodesCalled func(elected []sharding.Validator, eligible []sharding.Validator, waiting []sharding.Validator, epoch uint32) error
+}
+
+func (s *nodesSetterStub) SetNodes(elected []sharding.Validator, eligible []sharding.Validator, waiting []sharding.Validator, epoch uint32) error {
+	if s.setNodesCalled != nil {
+		return s.setNodesCalled(elected, eligible, waiting, epoch)
+	}
+	return nil
+}
+
+func serializableValidators(pubKeys ...string) []*sharding.SerializableValidator {
+	validators := make([]*sharding.SerializableValidator, 0, len(pubKeys))
+	for i, pubKey := range pubKeys {
+		validators = append(validators, &sharding.SerializableValidator{
+			OwnerAddress: []byte(pubKey),
+			PubKey:       []byte(pubKey),
+			Index:        uint32(i), // #nosec G115
+		})
+	}
+	return validators
+}
+
+func TestRestorePreviousEpochNodes_EpochZeroSkipsWrappedLookup(t *testing.T) {
+	t.Parallel()
+
+	// a registry entry under the wrapped key must never be applied at epoch 0
+	nodeRegistry := &sharding.NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*sharding.EpochValidators{
+			"4294967295": {ElectedValidators: serializableValidators("elected0")},
+		},
+	}
+	setNodesCalls := 0
+	stub := &nodesSetterStub{
+		setNodesCalled: func(_ []sharding.Validator, _ []sharding.Validator, _ []sharding.Validator, _ uint32) error {
+			setNodesCalls++
+			return nil
+		},
+	}
+
+	err := restorePreviousEpochNodes(stub, nodeRegistry, 0)
+
+	require.Nil(t, err)
+	assert.Equal(t, 0, setNodesCalls)
+}
+
+func TestRestorePreviousEpochNodes_MissingPreviousEpochIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	nodeRegistry := &sharding.NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*sharding.EpochValidators{},
+	}
+	setNodesCalls := 0
+	stub := &nodesSetterStub{
+		setNodesCalled: func(_ []sharding.Validator, _ []sharding.Validator, _ []sharding.Validator, _ uint32) error {
+			setNodesCalls++
+			return nil
+		},
+	}
+
+	err := restorePreviousEpochNodes(stub, nodeRegistry, 5)
+
+	require.Nil(t, err)
+	assert.Equal(t, 0, setNodesCalls)
+}
+
+func TestRestorePreviousEpochNodes_RestoresPreviousEpochLists(t *testing.T) {
+	t.Parallel()
+
+	nodeRegistry := &sharding.NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*sharding.EpochValidators{
+			"4": {
+				ElectedValidators:  serializableValidators("elected0", "elected1"),
+				EligibleValidators: serializableValidators("eligible0"),
+				WaitingValidators:  serializableValidators("waiting0"),
+			},
+		},
+	}
+	var gotElected, gotEligible, gotWaiting []sharding.Validator
+	var gotEpoch uint32
+	stub := &nodesSetterStub{
+		setNodesCalled: func(elected []sharding.Validator, eligible []sharding.Validator, waiting []sharding.Validator, epoch uint32) error {
+			gotElected, gotEligible, gotWaiting, gotEpoch = elected, eligible, waiting, epoch
+			return nil
+		},
+	}
+
+	err := restorePreviousEpochNodes(stub, nodeRegistry, 5)
+
+	require.Nil(t, err)
+	assert.Equal(t, uint32(4), gotEpoch)
+	require.Equal(t, 2, len(gotElected))
+	assert.Equal(t, []byte("elected0"), gotElected[0].PubKey())
+	require.Equal(t, 1, len(gotEligible))
+	assert.Equal(t, []byte("eligible0"), gotEligible[0].PubKey())
+	require.Equal(t, 1, len(gotWaiting))
+	assert.Equal(t, []byte("waiting0"), gotWaiting[0].PubKey())
+}
+
+func TestRegistryValidatorsForEpoch_MissingEpochReturnsDefaults(t *testing.T) {
+	t.Parallel()
+
+	nodeRegistry := &sharding.NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*sharding.EpochValidators{},
+	}
+	defaultElected := []sharding.Validator{nil}
+	defaultEligible := []sharding.Validator{nil, nil}
+
+	elected, eligible, err := registryValidatorsForEpoch(nodeRegistry, 7, defaultElected, defaultEligible)
+
+	require.Nil(t, err)
+	assert.Equal(t, 1, len(elected))
+	assert.Equal(t, 2, len(eligible))
+}
+
+func TestRegistryValidatorsForEpoch_FoundEpochReturnsRegistryLists(t *testing.T) {
+	t.Parallel()
+
+	nodeRegistry := &sharding.NodesCoordinatorRegistry{
+		EpochsConfig: map[string]*sharding.EpochValidators{
+			"7": {
+				ElectedValidators:  serializableValidators("elected0"),
+				EligibleValidators: serializableValidators("eligible0", "eligible1"),
+			},
+		},
+	}
+
+	elected, eligible, err := registryValidatorsForEpoch(nodeRegistry, 7, nil, nil)
+
+	require.Nil(t, err)
+	require.Equal(t, 1, len(elected))
+	assert.Equal(t, []byte("elected0"), elected[0].PubKey())
+	require.Equal(t, 2, len(eligible))
+	assert.Equal(t, []byte("eligible0"), eligible[0].PubKey())
+}

--- a/cmd/node/startup.go
+++ b/cmd/node/startup.go
@@ -658,16 +658,17 @@ func startNode(ctx *cli.Context, log logger.Logger, version string) error {
 		cfg.StoragePruning.CleanOldEpochsData = !ctx.GlobalBool(keepOldEpochsData.Name)
 	}
 
-	nodesCoordinator, err := createNodesCoordinator(
-		genesisNodesConfig,
-		coreComponents,
-		cryptoParams,
-		epochStartNotifier,
-		dataComponents.Store.GetStorer(retriever.BootstrapUnit),
-		nodesShuffler,
-		bootstrapParameters,
-		storerEpoch,
-	)
+	nodesCoordinator, err := createNodesCoordinator(createNodesCoordinatorArgs{
+		nodesConfig:                  genesisNodesConfig,
+		coreComponents:               coreComponents,
+		cryptoParams:                 cryptoParams,
+		epochStartNotifier:           epochStartNotifier,
+		bootStorer:                   dataComponents.Store.GetStorer(retriever.BootstrapUnit),
+		nodeShuffler:                 nodesShuffler,
+		bootstrapParameters:          bootstrapParameters,
+		startEpoch:                   storerEpoch,
+		fixJailedPromotionOrderEpoch: cfg.EnableEpochs.FixJailedPromotionOrder,
+	})
 	if err != nil {
 		return err
 	}

--- a/config/enableEpochs.go
+++ b/config/enableEpochs.go
@@ -31,6 +31,7 @@ type EnableEpochs struct {
 	FixMarketBuyOverflow    uint32 `yaml:"fixMarketBuyOverflow"`
 	FixAuditChangesV3       uint32 `yaml:"fixAuditChangesV3"`
 	FixAuditChangesV4       uint32 `yaml:"fixAuditChangesV4"`
+	FixJailedPromotionOrder uint32 `yaml:"fixJailedPromotionOrder"`
 }
 
 // Validate checks that the configured activation epochs are mutually consistent. It runs

--- a/config/node/enableEpochs.yaml
+++ b/config/node/enableEpochs.yaml
@@ -38,6 +38,13 @@ enableEpochs:
   # Audit Changes V4
   # Also releases the frozen swap-service account: must be after fixMarketBuyOverflow.
   fixAuditChangesV4: 0
+  # Sort the leaving list before the consensus backfill promotion, so the
+  # promoted subset no longer depends on validator-info input order.
+  # Live networks must set this to an epoch after the last validator has
+  # upgraded: leaving it at 0 during a rolling upgrade activates the new
+  # ordering immediately on upgraded nodes while older binaries keep the
+  # legacy ordering.
+  fixJailedPromotionOrder: 0
 gasSchedule:
   gasScheduleByEpochs:
     - startEpoch: 0

--- a/core/bootstrap/process.go
+++ b/core/bootstrap/process.go
@@ -562,6 +562,7 @@ func (e *epochStartBootstrap) processNodesConfig(pubKey []byte, epochStartValida
 		Hasher:             e.hasher,
 		PubKey:             pubKey,
 	}
+	argsNewValidatorStatusSyncers.FixJailedPromotionOrderEpoch = e.generalConfig.EnableEpochs.FixJailedPromotionOrder
 	e.nodesConfigHandler, err = NewSyncValidatorStatus(argsNewValidatorStatusSyncers)
 	if err != nil {
 		return err

--- a/core/bootstrap/syncValidatorStatus.go
+++ b/core/bootstrap/syncValidatorStatus.go
@@ -35,6 +35,9 @@ type ArgsNewSyncValidatorStatus struct {
 	GenesisNodesConfig sharding.GenesisNodesSetupHandler
 	NodeShuffler       sharding.NodesShuffler
 	PubKey             []byte
+	// FixJailedPromotionOrderEpoch must match the node's enableEpochs config so
+	// that epoch-start replay during bootstrap computes the same lists as live nodes
+	FixJailedPromotionOrderEpoch uint32
 }
 
 // NewSyncValidatorStatus creates a new validator status process component
@@ -69,16 +72,17 @@ func NewSyncValidatorStatus(args ArgsNewSyncValidatorStatus) (*syncValidatorStat
 	s.memDB = disabled.CreateMemUnit()
 
 	argsNodesCoordinator := sharding.ArgNodesCoordinator{
-		ConsensusGroupSize:  int(args.GenesisNodesConfig.GetConsensusGroupSize()),
-		Marshalizer:         args.Marshalizer,
-		Hasher:              args.Hasher,
-		Shuffler:            args.NodeShuffler,
-		EpochStartNotifier:  &disabled.EpochStartNotifier{},
-		BootStorer:          s.memDB,
-		ElectedNodes:        electedValidators,
-		EligibleNodes:       eligibleValidators,
-		SelfPublicKey:       args.PubKey,
-		ConsensusGroupCache: consensusGroupCache,
+		ConsensusGroupSize:           int(args.GenesisNodesConfig.GetConsensusGroupSize()),
+		Marshalizer:                  args.Marshalizer,
+		Hasher:                       args.Hasher,
+		Shuffler:                     args.NodeShuffler,
+		EpochStartNotifier:           &disabled.EpochStartNotifier{},
+		BootStorer:                   s.memDB,
+		ElectedNodes:                 electedValidators,
+		EligibleNodes:                eligibleValidators,
+		SelfPublicKey:                args.PubKey,
+		ConsensusGroupCache:          consensusGroupCache,
+		FixJailedPromotionOrderEpoch: args.FixJailedPromotionOrderEpoch,
 	}
 
 	baseNodesCoordinator, err := sharding.NewNodesCoordinator(argsNodesCoordinator)

--- a/sharding/args.go
+++ b/sharding/args.go
@@ -9,19 +9,22 @@ import (
 
 // ArgNodesCoordinator holds all dependencies required by the nodes coordinator in order to create new instances
 type ArgNodesCoordinator struct {
-	ConsensusGroupSize  int
-	Marshalizer         marshal.Marshalizer
-	Hasher              hashing.Hasher
-	Shuffler            NodesShuffler
-	EpochStartNotifier  EpochStartEventNotifier
-	BootStorer          storage.Storer
-	ElectedNodes        []Validator
-	EligibleNodes       []Validator
-	SelfPublicKey       []byte
-	Epoch               uint32
-	StartEpoch          uint32
-	ConsensusGroupCache Cacher
-	ShuffledOutHandler  ShuffledOutHandler
-	CurrValidatorsInfo  []*state.ValidatorInfo
-	PrevValidatorsInfo  []*state.ValidatorInfo
+	ConsensusGroupSize int
+	Marshalizer        marshal.Marshalizer
+	Hasher             hashing.Hasher
+	Shuffler           NodesShuffler
+	EpochStartNotifier EpochStartEventNotifier
+	BootStorer         storage.Storer
+	ElectedNodes       []Validator
+	EligibleNodes      []Validator
+	SelfPublicKey      []byte
+	Epoch              uint32
+	StartEpoch         uint32
+	// FixJailedPromotionOrderEpoch is the enable epoch for sorting the leaving
+	// list before the consensus backfill promotion (enableEpochs.fixJailedPromotionOrder)
+	FixJailedPromotionOrderEpoch uint32
+	ConsensusGroupCache          Cacher
+	ShuffledOutHandler           ShuffledOutHandler
+	CurrValidatorsInfo           []*state.ValidatorInfo
+	PrevValidatorsInfo           []*state.ValidatorInfo
 }

--- a/sharding/nodesCoordinator.go
+++ b/sharding/nodesCoordinator.go
@@ -74,6 +74,7 @@ type indexHashedNodesCoordinator struct {
 	consensusGroupSize            int
 	currentEpoch                  atomic.Uint32
 	startEpoch                    uint32
+	fixJailedPromotionOrderEpoch  uint32
 
 	stateReady atomic.Bool
 }
@@ -114,6 +115,7 @@ func NewNodesCoordinator(arguments ArgNodesCoordinator) (*indexHashedNodesCoordi
 		consensusGroupSize:            arguments.ConsensusGroupSize,
 		publicKeyToValidatorMap:       make(map[string]Validator),
 		startEpoch:                    arguments.StartEpoch,
+		fixJailedPromotionOrderEpoch:  arguments.FixJailedPromotionOrderEpoch,
 	}
 	ihgs.currentEpoch.Store(arguments.StartEpoch)
 	// no need to wait for load state, as we have the initial configuration
@@ -759,7 +761,7 @@ func (ihgs *indexHashedNodesCoordinator) EpochStartPrepare(metaHdr data.HeaderHa
 		return
 	}
 
-	newNodesConfig, err := ihgs.computeNodesConfigFromList(allValidatorInfo)
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(allValidatorInfo, newEpoch)
 	if err != nil {
 		log.Error("could not compute nodes config from list - do nothing on nodesCoordinator epochStartPrepare", "error", err.Error())
 		return
@@ -899,6 +901,7 @@ func (ihgs *indexHashedNodesCoordinator) GetOwnPublicKey() []byte {
 
 func (ihgs *indexHashedNodesCoordinator) computeNodesConfigFromList(
 	validators []*block.EValidatorInfo,
+	epoch uint32,
 ) (*epochNodesConfig, error) {
 	electedList := make([]Validator, 0)
 	eligibleList := make([]Validator, 0)
@@ -926,6 +929,16 @@ func (ihgs *indexHashedNodesCoordinator) computeNodesConfigFromList(
 		}
 	}
 
+	if epoch >= ihgs.fixJailedPromotionOrderEpoch {
+		// sort before the promotion slice below, so the promoted subset follows
+		// the deterministic validatorList order instead of whatever order the
+		// validator info happened to arrive in (trie traversal order)
+		sort.Sort(validatorList(leavingList))
+	}
+
+	// the promotion is all-or-nothing on purpose: a partial promotion can never
+	// reach consensusGroupSize, so the shuffler still fails its MinNodes check
+	// (MinNodes >= consensusGroupSize) and the epoch config is not built anyway
 	numToStay := ihgs.consensusGroupSize - (len(electedList) + len(eligibleList))
 	if numToStay > 0 {
 		if len(leavingList) >= numToStay {
@@ -934,6 +947,8 @@ func (ihgs *indexHashedNodesCoordinator) computeNodesConfigFromList(
 		}
 	}
 
+	// keep this leaving-list sort: the legacy branch below the enable epoch
+	// relies on it; it is a no-op once the list is pre-sorted above
 	sort.Sort(validatorList(leavingList))
 	sort.Sort(validatorList(eligibleList))
 	sort.Sort(validatorList(electedList))

--- a/sharding/nodesCoordinator_test.go
+++ b/sharding/nodesCoordinator_test.go
@@ -1,6 +1,7 @@
 package sharding
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/crypto/hashing/sha256"
 	"github.com/klever-io/klever-go/data/block"
+	"github.com/klever-io/klever-go/data/state"
 	"github.com/klever-io/klever-go/sharding/mock"
 	"github.com/klever-io/klever-go/tools/check"
 	"github.com/stretchr/testify/assert"
@@ -482,6 +484,68 @@ func TestNodesCoordinator_EpochStart_ElectedSortedAscendingByIndex(t *testing.T)
 	require.Equal(t, pk2, secondEligible)
 }
 
+func TestNodesCoordinator_EpochStartPrepare_PromotesSortedJailedIntoElected(t *testing.T) {
+	t.Parallel()
+
+	shufflerArgs := &NodesShufflerArgs{
+		Nodes:                2,
+		MaxNodesEnableConfig: nil,
+	}
+	nodeShuffler, err := NewHashValidatorsShuffler(shufflerArgs)
+	require.Nil(t, err)
+
+	arguments := ArgNodesCoordinator{
+		ConsensusGroupSize:  2,
+		Marshalizer:         &mock.MarshalizerMock{},
+		Hasher:              &mock.HasherMock{},
+		Shuffler:            nodeShuffler,
+		EpochStartNotifier:  &mock.EpochStartNotifierStub{},
+		BootStorer:          mock.NewStorerMock(),
+		ElectedNodes:        createDummyNodesList(2, "elected"),
+		EligibleNodes:       createDummyNodesList(0, "eligible"),
+		SelfPublicKey:       []byte("test"),
+		ConsensusGroupCache: &mock.NodesCoordinatorCacheMock{},
+	}
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	epoch := uint32(1)
+	// one elected validator and two jailed candidates, highest index first:
+	// the deficit is 1, so exactly one jailed validator gets promoted
+	err = ihgs.SetEpochValidatorsInfo(epoch, []*state.ValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("jailedHi"), PublicKey: []byte("jailedHi"), List: string(core.JailedList), Index: 9},
+		{OwnerAddress: []byte("jailedLo"), PublicKey: []byte("jailedLo"), List: string(core.JailedList), Index: 5},
+	})
+	require.Nil(t, err)
+
+	ihgs.EpochStartPrepare(&block.Block{
+		Header: &block.BlockHeader{
+			PrevRandSeed: []byte("rand seed"),
+			IsEpochStart: true,
+			Epoch:        epoch,
+		},
+	})
+
+	// the promotion sorted the leaving list first, so the lowest (Index, PubKey)
+	// jailed validator fills the consensus deficit and reaches the elected set
+	electedKeys, err := ihgs.GetAllElectedValidatorsKeys(epoch, false)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(electedKeys))
+	assert.True(t, keysContain(electedKeys, []byte("pk0")))
+	assert.True(t, keysContain(electedKeys, []byte("jailedLo")))
+	assert.False(t, keysContain(electedKeys, []byte("jailedHi")))
+}
+
+func keysContain(keys [][]byte, wanted []byte) bool {
+	for _, key := range keys {
+		if bytes.Equal(key, wanted) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestNodesCoordinator_GetConsensusValidatorsPublicKeysNotExistingEpoch(t *testing.T) {
 	t.Parallel()
 
@@ -547,12 +611,12 @@ func TestNodesCoordinator_computeNodesConfigFromList_NoValidators(t *testing.T) 
 	ihgs, _ := NewNodesCoordinator(arguments)
 
 	validatorInfos := make([]*block.EValidatorInfo, 0)
-	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos)
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos, 0)
 
 	assert.Nil(t, newNodesConfig)
 	assert.True(t, errors.Is(err, ErrListSizeZero))
 
-	newNodesConfig, err = ihgs.computeNodesConfigFromList(nil)
+	newNodesConfig, err = ihgs.computeNodesConfigFromList(nil, 0)
 
 	assert.Nil(t, newNodesConfig)
 	assert.True(t, errors.Is(err, ErrListSizeZero))
@@ -654,7 +718,7 @@ func TestNodesCoordinator_computeNodesConfigFromList_NilPk(t *testing.T) {
 			},
 		}
 
-	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos)
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos, 0)
 
 	assert.Nil(t, newNodesConfig)
 	assert.NotNil(t, err)
@@ -730,7 +794,7 @@ func TestNodesCoordinator_computeNodesConfigFromList_Validators(t *testing.T) {
 			nodeLeaving0,
 		}
 
-	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos)
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos, 0)
 	assert.Nil(t, err)
 
 	assert.Equal(t, 2, len(newNodesConfig.electedList))
@@ -743,6 +807,183 @@ func TestNodesCoordinator_computeNodesConfigFromList_Validators(t *testing.T) {
 	assert.Equal(t, nodeWaiting0.PublicKey, newNodesConfig.waitingList[0].PubKey())
 
 	assert.Equal(t, 0, len(newNodesConfig.leavingList))
+}
+
+func hasValidatorWithPubKey(list []Validator, pubKey []byte) bool {
+	for _, v := range list {
+		if bytes.Equal(v.PubKey(), pubKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func jailedPromotionValidatorInfos() []*block.EValidatorInfo {
+	// consensusGroupSize is 4 (createArguments): 2 elected + 1 eligible leaves a
+	// deficit of 1, with two jailed candidates listed highest index first
+	return []*block.EValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("pk1"), PublicKey: []byte("pk1"), List: string(core.ElectedList), Index: 2},
+		{OwnerAddress: []byte("pk2"), PublicKey: []byte("pk2"), List: string(core.EligibleList), Index: 3},
+		{OwnerAddress: []byte("jailedHi"), PublicKey: []byte("jailedHi"), List: string(core.JailedList), Index: 9},
+		{OwnerAddress: []byte("jailedLo"), PublicKey: []byte("jailedLo"), List: string(core.JailedList), Index: 5},
+	}
+}
+
+func TestNodesCoordinator_computeNodesConfigFromList_NoPromotionWhenLeavingSmallerThanDeficit(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments()
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	validatorInfos := []*block.EValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("pk1"), PublicKey: []byte("pk1"), List: string(core.ElectedList), Index: 2},
+		{OwnerAddress: []byte("jailed0"), PublicKey: []byte("jailed0"), List: string(core.JailedList), Index: 3},
+	}
+
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos, 0)
+	require.Nil(t, err)
+
+	// deficit is 2 and only 1 jailed validator is available: promotion is
+	// all-or-nothing, so nobody is promoted and the leaving list stays intact
+	assert.Equal(t, 0, len(newNodesConfig.eligibleList))
+	require.Equal(t, 1, len(newNodesConfig.leavingList))
+	assert.True(t, hasValidatorWithPubKey(newNodesConfig.leavingList, []byte("jailed0")))
+}
+
+func TestNodesCoordinator_computeNodesConfigFromList_PromotionAtExactDeficitPromotesAll(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments()
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	validatorInfos := []*block.EValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("pk1"), PublicKey: []byte("pk1"), List: string(core.ElectedList), Index: 2},
+		{OwnerAddress: []byte("jailed0"), PublicKey: []byte("jailed0"), List: string(core.JailedList), Index: 3},
+		{OwnerAddress: []byte("jailed1"), PublicKey: []byte("jailed1"), List: string(core.JailedList), Index: 4},
+	}
+
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos, 0)
+	require.Nil(t, err)
+
+	// deficit is 2 and exactly 2 jailed validators are available: the >= guard
+	// holds at equality, everyone is promoted and the leaving list empties
+	require.Equal(t, 2, len(newNodesConfig.eligibleList))
+	assert.True(t, hasValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailed0")))
+	assert.True(t, hasValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailed1")))
+	assert.Equal(t, 0, len(newNodesConfig.leavingList))
+}
+
+func TestNodesCoordinator_computeNodesConfigFromList_PromotionTieBreaksOnPubKey(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments()
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	// both jailed candidates share the same index, so the pubkey tie-break of
+	// the validatorList order decides; input lists the byte-higher key first
+	validatorInfos := []*block.EValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("pk1"), PublicKey: []byte("pk1"), List: string(core.ElectedList), Index: 2},
+		{OwnerAddress: []byte("pk2"), PublicKey: []byte("pk2"), List: string(core.EligibleList), Index: 3},
+		{OwnerAddress: []byte("jailedB"), PublicKey: []byte("jailedB"), List: string(core.JailedList), Index: 7},
+		{OwnerAddress: []byte("jailedA"), PublicKey: []byte("jailedA"), List: string(core.JailedList), Index: 7},
+	}
+
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(validatorInfos, 0)
+	require.Nil(t, err)
+
+	require.Equal(t, 2, len(newNodesConfig.eligibleList))
+	assert.True(t, hasValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailedA")))
+	assert.False(t, hasValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailedB")))
+	require.Equal(t, 1, len(newNodesConfig.leavingList))
+	assert.True(t, hasValidatorWithPubKey(newNodesConfig.leavingList, []byte("jailedB")))
+}
+
+func TestNodesCoordinator_computeNodesConfigFromList_PromotionPicksSortedHead(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments()
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	newNodesConfig, err := ihgs.computeNodesConfigFromList(jailedPromotionValidatorInfos(), 0)
+	require.Nil(t, err)
+
+	// with the fix active the promoted validator is the lowest (Index, PubKey)
+	// even though the input listed the highest index first
+	require.Equal(t, 2, len(newNodesConfig.eligibleList))
+	assert.True(t, hasValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailedLo")))
+	assert.False(t, hasValidatorWithPubKey(newNodesConfig.eligibleList, []byte("jailedHi")))
+	require.Equal(t, 1, len(newNodesConfig.leavingList))
+	assert.True(t, hasValidatorWithPubKey(newNodesConfig.leavingList, []byte("jailedHi")))
+}
+
+func TestNodesCoordinator_computeNodesConfigFromList_PromotionIndependentOfInputOrder(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments()
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	// 1 elected, deficit 3, 4 jailed candidates: a strict subset is promoted
+	orderA := []*block.EValidatorInfo{
+		{OwnerAddress: []byte("pk0"), PublicKey: []byte("pk0"), List: string(core.ElectedList), Index: 1},
+		{OwnerAddress: []byte("j5"), PublicKey: []byte("j5"), List: string(core.JailedList), Index: 5},
+		{OwnerAddress: []byte("j6"), PublicKey: []byte("j6"), List: string(core.JailedList), Index: 6},
+		{OwnerAddress: []byte("j7"), PublicKey: []byte("j7"), List: string(core.JailedList), Index: 7},
+		{OwnerAddress: []byte("j8"), PublicKey: []byte("j8"), List: string(core.JailedList), Index: 8},
+	}
+	orderB := []*block.EValidatorInfo{orderA[0], orderA[4], orderA[3], orderA[2], orderA[1]}
+
+	configA, err := ihgs.computeNodesConfigFromList(orderA, 0)
+	require.Nil(t, err)
+	configB, err := ihgs.computeNodesConfigFromList(orderB, 0)
+	require.Nil(t, err)
+
+	require.Equal(t, len(configA.eligibleList), len(configB.eligibleList))
+	for i := range configA.eligibleList {
+		assert.Equal(t, configA.eligibleList[i].PubKey(), configB.eligibleList[i].PubKey())
+	}
+	require.Equal(t, len(configA.leavingList), len(configB.leavingList))
+	for i := range configA.leavingList {
+		assert.Equal(t, configA.leavingList[i].PubKey(), configB.leavingList[i].PubKey())
+	}
+
+	// the lowest three indices are promoted, the highest one keeps leaving
+	require.Equal(t, 1, len(configA.leavingList))
+	assert.True(t, hasValidatorWithPubKey(configA.leavingList, []byte("j8")))
+}
+
+func TestNodesCoordinator_computeNodesConfigFromList_LegacyPromotionOrderBeforeEnableEpoch(t *testing.T) {
+	t.Parallel()
+
+	arguments := createArguments()
+	arguments.FixJailedPromotionOrderEpoch = 100
+	ihgs, err := NewNodesCoordinator(arguments)
+	require.Nil(t, err)
+
+	// before the enable epoch the legacy behaviour promotes the input-order
+	// head, which here is the highest index
+	legacyConfig, err := ihgs.computeNodesConfigFromList(jailedPromotionValidatorInfos(), 99)
+	require.Nil(t, err)
+	assert.True(t, hasValidatorWithPubKey(legacyConfig.eligibleList, []byte("jailedHi")))
+	assert.False(t, hasValidatorWithPubKey(legacyConfig.eligibleList, []byte("jailedLo")))
+	require.Equal(t, 1, len(legacyConfig.leavingList))
+	assert.True(t, hasValidatorWithPubKey(legacyConfig.leavingList, []byte("jailedLo")))
+
+	// from the enable epoch on the sorted selection takes over
+	fixedConfig, err := ihgs.computeNodesConfigFromList(jailedPromotionValidatorInfos(), 100)
+	require.Nil(t, err)
+	assert.True(t, hasValidatorWithPubKey(fixedConfig.eligibleList, []byte("jailedLo")))
+	assert.False(t, hasValidatorWithPubKey(fixedConfig.eligibleList, []byte("jailedHi")))
+	require.Equal(t, 1, len(fixedConfig.leavingList))
+	assert.True(t, hasValidatorWithPubKey(fixedConfig.leavingList, []byte("jailedHi")))
 }
 
 func TestNodesCoordinator_IsInterfaceNil(t *testing.T) {


### PR DESCRIPTION
## Problem

Two defects in the same six lines of `computeNodesConfigFromList` (the jailed-validator consensus backfill):

- **#133**: the promotion sliced `leavingList` before sorting it, so which jailed validators got promoted depended on the order the validator info arrived in. That order is deterministic today only because the peer-trie leaf walk happens to be single-goroutine and nibble-ordered, two packages away. Any future parallelisation or caching of that walk would change the promoted subset and fork the chain with no failing test.
- **#124**: the promotion is all-or-nothing (nothing is promoted when the leaving list is smaller than the deficit), undocumented and unpinned.

## What changed

- `sharding/nodesCoordinator.go`: `computeNodesConfigFromList(validators, epoch)` now sorts the leaving list before the promotion slice when `epoch >= fixJailedPromotionOrderEpoch`, so the promoted subset follows the deterministic `validatorList` order over consensus state, identical on every node, instead of arrival order. Below the enable epoch the function is byte-identical to the current behaviour. The pre-existing sort after the promotion stays (it is what produces today's output in the legacy branch; a keep-comment now guards it). The all-or-nothing rule got a comment stating the mechanism: a partial promotion can never reach `consensusGroupSize`, so the shuffler still fails its `MinNodes` check (`MinNodes >= consensusGroupSize` is enforced by nodesSetup validation) and the epoch config is not built either way.
- `config/enableEpochs.go` + `config/node/enableEpochs.yaml`: new `fixJailedPromotionOrder` activation epoch.
- `sharding/args.go`: `FixJailedPromotionOrderEpoch` on `ArgNodesCoordinator`.
- `cmd/node/node.go` + `cmd/node/startup.go`: wired from `cfg.EnableEpochs.FixJailedPromotionOrder`. `createNodesCoordinator` now takes an args struct; a ninth positional parameter would have re-counted the existing parameter-count analyzer issue on that line as a new violation, and the quality gate fails on any new violation. The unpack block at the top keeps the body diff minimal on purpose.
- `core/bootstrap/process.go` + `core/bootstrap/syncValidatorStatus.go`: the same epoch threaded through `ArgsNewSyncValidatorStatus` into the bootstrap coordinator, so epoch-start replay during bootstrap computes the same lists as live nodes did. The field is assigned after the args literal deliberately: the surrounding function has no unit test, and re-blaming the literal lines would count them as uncovered new code.

## Why an activation epoch parameter instead of the forkController

The forkController toggles flags on the node's current epoch. This code also runs during bootstrap, where `syncValidatorStatus` replays the current AND previous epoch starts from synced metablocks. Gating on the node's current epoch would apply today's flag state to historical epochs and diverge from what the network computed at the time. Passing the epoch being built (`metaHdr.GetEpoch()`, both live and replay) is the only replay-safe design; precedent is the shuffler's `MaxNodesChangeEnableEpoch`. A side effect is that this flag does not appear in the forkController status logs.

## Rollout requirement (important)

The repo default `fixJailedPromotionOrder: 0` means the new ordering is active from epoch 0, consistent with every sibling flag. On a live network, ops MUST set the flag to an epoch after the last validator has upgraded before rolling out binaries. Leaving it at 0 during a rolling upgrade would run old and new orderings side by side, and the promotion window is live on networks where `minNodes` equals `consensusGroupSize`: exactly the divergence this gate exists to prevent. The yaml comment now carries this warning. Config-first rollout is safe: old binaries ignore the unknown key.

## Why partial backfill (#124's suggestion) was rejected

Implementing `min(numToStay, len(leavingList))` would change nothing observable. In the partial branch, promoting every leaver still leaves `elected+eligible < consensusGroupSize <= MinNodes`, so `UpdateNodeLists` fails with `ErrSmallElectedListSize` exactly as it does today and `EpochStartPrepare` returns before `SetNodes`: no state, no metrics, no persisted lists differ. It would add a consensus-shaped line that does nothing until someone softens the shuffler failure path, at which point it would become an untested divergence hazard. The all-or-nothing rule is therefore documented and pinned instead.

## Tests

- `NoPromotionWhenLeavingSmallerThanDeficit`: deficit 2, one jailed: nothing promoted, leaving intact (pins the #124 `<` branch).
- `PromotionAtExactDeficitPromotesAll`: deficit 2, exactly two jailed: the `>=` guard holds at equality, both promoted, leaving empties (pins the boundary; identical under legacy and fixed ordering).
- `PromotionPicksSortedHead`: input lists the higher-index jailed validator first; the lower one is promoted (fails on revert).
- `PromotionTieBreaksOnPubKey`: equal indices, the pubkey tie-break decides (production inputs currently carry index 0 everywhere, so this is the branch that actually resolves).
- `PromotionIndependentOfInputOrder`: same set in two orders yields element-wise identical eligible and leaving lists (fails on revert).
- `LegacyPromotionOrderBeforeEnableEpoch`: flag at 100, epoch 99 reproduces the input-order head and epoch 100 the sorted head, with absence asserts both ways (pins the gate boundary in both directions).
- `EpochStartPrepare_PromotesSortedJailedIntoElected`: full flow through `SetEpochValidatorsInfo`, `EpochStartPrepare`, shuffler and `SetNodes`: the sorted head reaches the elected set of the new epoch.

## Verification

- gofmt, go vet, `go build ./...` clean; `go test -race -count=1` green on sharding, core/bootstrap, config; full local suites of all touched packages pass.
- SonarQube: analyzer reports zero issues on the changed function; no new issues expected on changed lines (parameter-count and blame effects handled as described above); new statement lines in covered packages are test-covered.
- Reviewed pre-push by four independent passes (security, code review, Go expert, adversarial full-diff): zero Critical, zero High; all findings fixed or documented above.
- Live soak on a testnet observer node running this change merged with #126: 900 samples across 6 epoch boundaries, zero nonce stalls, zero `is_syncing` flips, 7 epoch-start preparations through the new code path with zero coordinator failure log lines. No jailed validators were present during the window, so the promotion branch itself did not fire live; its behaviour is pinned by the unit tests above.

Fixes #133
Closes #124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Makes jailed-validator promotion deterministic at or after `FixJailedPromotionOrder`.
- Sorts the leaving validator list before promotion selection.
- Preserves legacy behavior before the activation epoch.
- Preserves all-or-nothing promotion when the leaving list cannot cover the consensus deficit.
- Propagates the activation epoch through configuration, node startup, live processing, and epoch-start replay.
- Adds safe restoration for previous-epoch validator state, including epoch-zero and missing-epoch cases.
- Adds tests for promotion thresholds, deterministic ordering, input-order independence, activation boundaries, epoch-start promotion flow, registry defaults, restoration, and bootstrap error propagation.

## Blockchain impact

- **Consensus and state integrity:** The promoted validator subset no longer depends on input order after activation. This reduces the risk of inconsistent consensus validator sets across nodes.
- **Transaction processing and KVM:** No direct changes.
- **Networking:** No direct protocol or network changes. Node startup and bootstrap now receive the activation setting.
- **Node stability:** Epoch-zero and missing-epoch guards prevent invalid restoration lookups. The all-or-nothing rule prevents validator sets that fail minimum-node validation.
- **Concurrency and error handling:** No concurrency changes. Bootstrap now propagates coordinator restoration errors from `SetNodes`. Existing promotion failure behavior remains unchanged.
- **Deployment:** The default activation epoch is `0`. Live networks should use a later activation epoch until all validators upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->