### PR TITLE
[KLC-2642] feat(indexer): list the contracts a transaction took part in on its document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ test-output.json
 # CI report
 report.xml
 report.json
+/indexer-backfill
+/cmd/indexer-backfill/indexer-backfill

--- a/cmd/indexer-backfill/backfill.go
+++ b/cmd/indexer-backfill/backfill.go
@@ -1,0 +1,469 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/klever-io/klever-go/core"
+	nodeData "github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/data/indexer"
+	"github.com/klever-io/klever-go/data/transaction"
+	"github.com/klever-io/klever-go/indexer/data"
+)
+
+const (
+	logsIndex         = "logs"
+	transactionsAlias = "transactions"
+	fieldName         = "scAddresses"
+)
+
+type options struct {
+	sourceURL, sourceUser string
+	targetURL, targetUser string
+	batchSize             int
+	pause                 time.Duration
+	scrollKeepAlive       time.Duration
+	timestampFrom         int64
+	timestampTo           int64
+	dryRun                bool
+	verifyOnly            bool
+}
+
+// logDocument is the slice of a logs document the derivation needs.
+type logDocument struct {
+	Address string `json:"address"`
+	Events  []struct {
+		Address string `json:"address"`
+	} `json:"events"`
+}
+
+// deriveFunc turns log documents, keyed by transaction hash, into the scAddresses each
+// transaction gets. Hashes whose logs name no contract are absent from the result.
+type deriveFunc func(docs map[string]logDocument) map[string][]string
+
+// logsExtractor is the one indexer method the derivation relies on.
+type logsExtractor interface {
+	ExtractDataFromLogs(pool *indexer.Pool, txs []*data.Transaction, timestamp int64) *data.PreparedLogsResults
+}
+
+// newDerivation feeds each log document to the indexer exactly as the indexer would have
+// received it from the node: addresses decoded back to bytes, the hash decoded back to the
+// raw bytes ExtractDataFromLogs hex-encodes to find the transaction. Whatever the indexer
+// derives is what gets written. An address that does not decode is skipped as if it were
+// not a contract, which is also what the indexer does with a wallet.
+func newDerivation(extractor logsExtractor, converter core.PubkeyConverter) deriveFunc {
+	decode := func(address string) []byte {
+		decoded, err := converter.Decode(address)
+		if err != nil {
+			return nil
+		}
+
+		return decoded
+	}
+
+	return func(docs map[string]logDocument) map[string][]string {
+		txs := make([]*data.Transaction, 0, len(docs))
+		pool := &indexer.Pool{Logs: make([]*nodeData.LogData, 0, len(docs))}
+
+		for hash, doc := range docs {
+			rawHash, err := hex.DecodeString(hash)
+			if err != nil {
+				continue
+			}
+
+			events := make([]*transaction.Event, 0, len(doc.Events))
+			for _, event := range doc.Events {
+				events = append(events, &transaction.Event{Address: decode(event.Address)})
+			}
+
+			txs = append(txs, &data.Transaction{Hash: hash})
+			pool.Logs = append(pool.Logs, &nodeData.LogData{
+				LogHandler: &transaction.Log{Address: decode(doc.Address), Events: events},
+				TxHash:     string(rawHash),
+			})
+		}
+
+		extractor.ExtractDataFromLogs(pool, txs, 0)
+
+		derived := make(map[string][]string, len(txs))
+		for _, tx := range txs {
+			if len(tx.SCAddresses) > 0 {
+				derived[tx.Hash] = tx.SCAddresses
+			}
+		}
+
+		return derived
+	}
+}
+
+type backfiller struct {
+	source, target *elasticsearch.Client
+	derive         deriveFunc
+	opts           options
+	out            io.Writer
+}
+
+// logf writes progress; a failed write to the progress writer is not a reason to stop a backfill.
+func (b *backfiller) logf(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(b.out, format, args...)
+}
+
+func newBackfiller(source, target *elasticsearch.Client, derive deriveFunc, opts options, out io.Writer) *backfiller {
+	return &backfiller{source: source, target: target, derive: derive, opts: opts, out: out}
+}
+
+// tally is what a run reports at the end.
+type tally struct {
+	read, withContracts, updated, unchanged, missing, failed int
+}
+
+func (b *backfiller) run(ctx context.Context) error {
+	index, err := resolveSingleIndex(ctx, b.target, transactionsAlias)
+	if err != nil {
+		return err
+	}
+	b.logf("target: %s (alias %s)\n", index, transactionsAlias)
+
+	var totals tally
+	err = b.scroll(ctx, func(docs map[string]logDocument) error {
+		derived := b.derive(docs)
+		totals.read += len(docs)
+		totals.withContracts += len(derived)
+
+		if b.opts.dryRun {
+			return nil
+		}
+
+		result, err := b.apply(ctx, index, derived)
+		if err != nil {
+			return err
+		}
+		totals.updated += result.updated
+		totals.unchanged += result.unchanged
+		totals.missing += result.missing
+		totals.failed += result.failed
+
+		if b.opts.pause > 0 {
+			time.Sleep(b.opts.pause)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	mode := "written"
+	if b.opts.dryRun {
+		mode = "dry run, nothing written"
+	}
+	b.logf("logs read: %d, with contracts: %d (%s)\n", totals.read, totals.withContracts, mode)
+	if !b.opts.dryRun {
+		b.logf("updated: %d, already set: %d, no such transaction: %d, failed: %d\n",
+			totals.updated, totals.unchanged, totals.missing, totals.failed)
+		if totals.failed > 0 {
+			return fmt.Errorf("%d updates failed; rerun after fixing the cause, the run is idempotent", totals.failed)
+		}
+	}
+
+	return nil
+}
+
+// resolveSingleIndex returns the one concrete index behind alias. A bulk update addressed
+// to an alias needs a single index behind it, so an alias spanning several (a rollover)
+// is refused up front with the list, rather than failing item by item.
+func resolveSingleIndex(ctx context.Context, client *elasticsearch.Client, alias string) (string, error) {
+	res, err := client.Indices.GetAlias(client.Indices.GetAlias.WithContext(ctx), client.Indices.GetAlias.WithName(alias))
+	if err != nil {
+		return "", fmt.Errorf("resolve alias %s: %w", alias, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.IsError() {
+		return "", fmt.Errorf("resolve alias %s: %s", alias, res.String())
+	}
+
+	var indices map[string]json.RawMessage
+	if err := json.NewDecoder(res.Body).Decode(&indices); err != nil {
+		return "", fmt.Errorf("resolve alias %s: %w", alias, err)
+	}
+
+	names := make([]string, 0, len(indices))
+	for name := range indices {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if len(names) != 1 {
+		return "", fmt.Errorf("alias %s must point at exactly one index, found %d: %s", alias, len(names), strings.Join(names, ", "))
+	}
+
+	return names[0], nil
+}
+
+// scroll walks the whole source logs index in batches and hands each batch to visit.
+func (b *backfiller) scroll(ctx context.Context, visit func(map[string]logDocument) error) error {
+	body, err := json.Marshal(b.searchBody())
+	if err != nil {
+		return err
+	}
+
+	res, err := b.source.Search(
+		b.source.Search.WithContext(ctx),
+		b.source.Search.WithIndex(logsIndex),
+		b.source.Search.WithBody(bytes.NewReader(body)),
+		b.source.Search.WithSize(b.opts.batchSize),
+		b.source.Search.WithScroll(b.opts.scrollKeepAlive),
+		b.source.Search.WithSource("address", "events.address"),
+	)
+	if err != nil {
+		return fmt.Errorf("search %s: %w", logsIndex, err)
+	}
+
+	scrollID := ""
+	defer func() {
+		if scrollID == "" {
+			return
+		}
+		clear, err := b.source.ClearScroll(b.source.ClearScroll.WithScrollID(scrollID))
+		if err == nil {
+			_ = clear.Body.Close()
+		}
+	}()
+
+	for {
+		page, err := readPage(res)
+		if err != nil {
+			return err
+		}
+		scrollID = page.scrollID
+
+		if len(page.docs) == 0 {
+			return nil
+		}
+		if err := visit(page.docs); err != nil {
+			return err
+		}
+
+		res, err = b.source.Scroll(
+			b.source.Scroll.WithContext(ctx),
+			b.source.Scroll.WithScrollID(scrollID),
+			b.source.Scroll.WithScroll(b.opts.scrollKeepAlive),
+		)
+		if err != nil {
+			return fmt.Errorf("scroll %s: %w", logsIndex, err)
+		}
+	}
+}
+
+func (b *backfiller) searchBody() map[string]interface{} {
+	query := map[string]interface{}{"match_all": map[string]interface{}{}}
+	if b.opts.timestampFrom > 0 || b.opts.timestampTo > 0 {
+		bounds := map[string]interface{}{}
+		if b.opts.timestampFrom > 0 {
+			bounds["gte"] = b.opts.timestampFrom
+		}
+		if b.opts.timestampTo > 0 {
+			bounds["lte"] = b.opts.timestampTo
+		}
+		query = map[string]interface{}{"range": map[string]interface{}{"timestamp": bounds}}
+	}
+
+	return map[string]interface{}{
+		"query": query,
+		"sort":  []interface{}{"_doc"},
+	}
+}
+
+type page struct {
+	scrollID string
+	docs     map[string]logDocument
+}
+
+func readPage(res *esapi.Response) (page, error) {
+	defer func() { _ = res.Body.Close() }()
+
+	if res.IsError() {
+		return page{}, fmt.Errorf("search %s: %s", logsIndex, res.String())
+	}
+
+	var body struct {
+		ScrollID string `json:"_scroll_id"`
+		Hits     struct {
+			Hits []struct {
+				ID     string      `json:"_id"`
+				Source logDocument `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return page{}, fmt.Errorf("search %s: %w", logsIndex, err)
+	}
+
+	docs := make(map[string]logDocument, len(body.Hits.Hits))
+	for _, hit := range body.Hits.Hits {
+		docs[hit.ID] = hit.Source
+	}
+
+	return page{scrollID: body.ScrollID, docs: docs}, nil
+}
+
+type applyResult struct {
+	updated, unchanged, missing, failed int
+}
+
+// apply writes one batch of derived fields as partial updates. A transaction the target
+// does not hold is counted, not failed: a logs index can hold a hash its transactions
+// index never received, and a missing document is not something this tool should create.
+func (b *backfiller) apply(ctx context.Context, index string, derived map[string][]string) (applyResult, error) {
+	if len(derived) == 0 {
+		return applyResult{}, nil
+	}
+
+	body, err := bulkBody(index, derived)
+	if err != nil {
+		return applyResult{}, err
+	}
+
+	res, err := b.target.Bulk(bytes.NewReader(body), b.target.Bulk.WithContext(ctx))
+	if err != nil {
+		return applyResult{}, fmt.Errorf("bulk update: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.IsError() {
+		return applyResult{}, fmt.Errorf("bulk update: %s", res.String())
+	}
+
+	return readBulkResult(res.Body, b.out)
+}
+
+// bulkBody builds the NDJSON for one batch: an update action per transaction, each carrying
+// only the field, in hash order so a body is reproducible.
+func bulkBody(index string, derived map[string][]string) ([]byte, error) {
+	hashes := make([]string, 0, len(derived))
+	for hash := range derived {
+		hashes = append(hashes, hash)
+	}
+	sort.Strings(hashes)
+
+	var body bytes.Buffer
+	for _, hash := range hashes {
+		action, err := json.Marshal(map[string]interface{}{"update": map[string]string{"_index": index, "_id": hash}})
+		if err != nil {
+			return nil, err
+		}
+		doc, err := json.Marshal(map[string]interface{}{"doc": map[string]interface{}{fieldName: derived[hash]}})
+		if err != nil {
+			return nil, err
+		}
+		body.Write(action)
+		body.WriteByte('\n')
+		body.Write(doc)
+		body.WriteByte('\n')
+	}
+
+	return body.Bytes(), nil
+}
+
+func readBulkResult(body io.Reader, out io.Writer) (applyResult, error) {
+	var response struct {
+		Items []struct {
+			Update struct {
+				ID     string `json:"_id"`
+				Status int    `json:"status"`
+				Result string `json:"result"`
+				Error  *struct {
+					Type   string `json:"type"`
+					Reason string `json:"reason"`
+				} `json:"error"`
+			} `json:"update"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(body).Decode(&response); err != nil {
+		return applyResult{}, fmt.Errorf("bulk response: %w", err)
+	}
+
+	var result applyResult
+	for _, item := range response.Items {
+		switch {
+		case item.Update.Error != nil && item.Update.Error.Type == "document_missing_exception":
+			result.missing++
+		case item.Update.Error != nil:
+			result.failed++
+			_, _ = fmt.Fprintf(out, "failed %s: %s: %s\n", item.Update.ID, item.Update.Error.Type, item.Update.Error.Reason)
+		case item.Update.Result == "noop":
+			result.unchanged++
+		default:
+			result.updated++
+		}
+	}
+
+	return result, nil
+}
+
+// report prints the two counts that say whether the backfill is complete on the target:
+// smart contract transactions the indexer saw logs for, against transactions carrying the
+// field. The first minus the second is what is still missing.
+func report(ctx context.Context, target *elasticsearch.Client, out io.Writer) error {
+	withLogs, err := count(ctx, target, map[string]interface{}{
+		"query": map[string]interface{}{"bool": map[string]interface{}{"filter": []interface{}{
+			map[string]interface{}{"term": map[string]interface{}{"contract.type": 63}},
+			map[string]interface{}{"term": map[string]interface{}{"hasLogs": true}},
+		}}},
+	})
+	if err != nil {
+		return err
+	}
+
+	withField, err := count(ctx, target, map[string]interface{}{
+		"query": map[string]interface{}{"exists": map[string]interface{}{"field": fieldName}},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(out, "target %s: smart contract transactions with logs: %d, carrying %s: %d, missing: %d\n",
+		transactionsAlias, withLogs, fieldName, withField, withLogs-withField)
+
+	return nil
+}
+
+func count(ctx context.Context, client *elasticsearch.Client, query map[string]interface{}) (int64, error) {
+	body, err := json.Marshal(query)
+	if err != nil {
+		return 0, err
+	}
+
+	res, err := client.Count(
+		client.Count.WithContext(ctx),
+		client.Count.WithIndex(transactionsAlias),
+		client.Count.WithBody(bytes.NewReader(body)),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("count: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.IsError() {
+		return 0, fmt.Errorf("count: %s", res.String())
+	}
+
+	var response struct {
+		Count int64 `json:"count"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+		return 0, fmt.Errorf("count: %w", err)
+	}
+
+	return response.Count, nil
+}

--- a/cmd/indexer-backfill/backfill.go
+++ b/cmd/indexer-backfill/backfill.go
@@ -339,12 +339,19 @@ func (b *backfiller) clearScroll(scrollID string) {
 
 	body, err := json.Marshal(map[string]interface{}{"scroll_id": []string{scrollID}})
 	if err != nil {
+		b.logf("clear scroll: %v\n", err)
 		return
 	}
 
 	cleared, err := b.source.ClearScroll(b.source.ClearScroll.WithContext(ctx), b.source.ClearScroll.WithBody(bytes.NewReader(body)))
-	if err == nil {
-		_ = cleared.Body.Close()
+	if err != nil {
+		b.logf("clear scroll: %v; the source frees the cursor when the keepalive expires\n", err)
+		return
+	}
+	defer func() { _ = cleared.Body.Close() }()
+
+	if cleared.IsError() {
+		b.logf("clear scroll: %s; the source frees the cursor when the keepalive expires\n", cleared.String())
 	}
 }
 
@@ -502,7 +509,7 @@ func readBulkResult(body io.Reader, out io.Writer) (applyResult, error) {
 // derives the field from a log, and only a smart contract transaction's log names one.
 func smartContractTransactionsWithLogs() []interface{} {
 	return []interface{}{
-		map[string]interface{}{"term": map[string]interface{}{"contract.type": 63}},
+		map[string]interface{}{"term": map[string]interface{}{"contract.type": int32(transaction.TXContract_SmartContractType)}},
 		map[string]interface{}{"term": map[string]interface{}{"hasLogs": true}},
 	}
 }

--- a/cmd/indexer-backfill/backfill.go
+++ b/cmd/indexer-backfill/backfill.go
@@ -348,7 +348,11 @@ func (b *backfiller) clearScroll(scrollID string) {
 		b.logf("clear scroll: %v; the source frees the cursor when the keepalive expires\n", err)
 		return
 	}
-	defer func() { _ = cleared.Body.Close() }()
+	defer func() {
+		if closeErr := cleared.Body.Close(); closeErr != nil {
+			b.logf("clear scroll: close response: %v\n", closeErr)
+		}
+	}()
 
 	if cleared.IsError() {
 		b.logf("clear scroll: %s; the source frees the cursor when the keepalive expires\n", cleared.String())

--- a/cmd/indexer-backfill/backfill.go
+++ b/cmd/indexer-backfill/backfill.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,12 +19,22 @@ import (
 	"github.com/klever-io/klever-go/data/indexer"
 	"github.com/klever-io/klever-go/data/transaction"
 	"github.com/klever-io/klever-go/indexer/data"
+	"github.com/klever-io/klever-go/indexer/templates"
 )
 
 const (
 	logsIndex         = "logs"
 	transactionsAlias = "transactions"
 	fieldName         = "scAddresses"
+
+	// retriesOnConflict is how often an update is retried when the live indexer upserts
+	// the same transaction in between; a version conflict on the newest documents is
+	// expected while the chain moves and is not a reason to fail the run.
+	retriesOnConflict = 3
+
+	// clearScrollTimeout bounds the clean-up of the source cursor, which runs after the
+	// context that drove the scroll may already have been cancelled.
+	clearScrollTimeout = 10 * time.Second
 )
 
 type options struct {
@@ -53,6 +64,12 @@ type deriveFunc func(docs map[string]logDocument) map[string][]string
 // logsExtractor is the one indexer method the derivation relies on.
 type logsExtractor interface {
 	ExtractDataFromLogs(pool *indexer.Pool, txs []*data.Transaction, timestamp int64) *data.PreparedLogsResults
+}
+
+// mappingClient is the slice of the indexer's client the mapping step relies on.
+type mappingClient interface {
+	CheckFieldMapping(index string, properties templates.Object) ([]string, error)
+	CheckAndUpdateMapping(index string, properties templates.Object) error
 }
 
 // newDerivation feeds each log document to the indexer exactly as the indexer would have
@@ -107,9 +124,14 @@ func newDerivation(extractor logsExtractor, converter core.PubkeyConverter) deri
 
 type backfiller struct {
 	source, target *elasticsearch.Client
+	mapping        mappingClient
 	derive         deriveFunc
 	opts           options
 	out            io.Writer
+}
+
+func newBackfiller(source, target *elasticsearch.Client, mapping mappingClient, derive deriveFunc, opts options, out io.Writer) *backfiller {
+	return &backfiller{source: source, target: target, mapping: mapping, derive: derive, opts: opts, out: out}
 }
 
 // logf writes progress; a failed write to the progress writer is not a reason to stop a backfill.
@@ -117,21 +139,21 @@ func (b *backfiller) logf(format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(b.out, format, args...)
 }
 
-func newBackfiller(source, target *elasticsearch.Client, derive deriveFunc, opts options, out io.Writer) *backfiller {
-	return &backfiller{source: source, target: target, derive: derive, opts: opts, out: out}
-}
-
 // tally is what a run reports at the end.
 type tally struct {
 	read, withContracts, updated, unchanged, missing, failed int
 }
 
-func (b *backfiller) run(ctx context.Context) error {
+func (b *backfiller) backfill(ctx context.Context) error {
 	index, err := resolveSingleIndex(ctx, b.target, transactionsAlias)
 	if err != nil {
 		return err
 	}
 	b.logf("target: %s (alias %s)\n", index, transactionsAlias)
+
+	if err := b.ensureMapping(index); err != nil {
+		return err
+	}
 
 	var totals tally
 	err = b.scroll(ctx, func(docs map[string]logDocument) error {
@@ -152,11 +174,7 @@ func (b *backfiller) run(ctx context.Context) error {
 		totals.missing += result.missing
 		totals.failed += result.failed
 
-		if b.opts.pause > 0 {
-			time.Sleep(b.opts.pause)
-		}
-
-		return nil
+		return pause(ctx, b.opts.pause)
 	})
 	if err != nil {
 		return err
@@ -176,6 +194,48 @@ func (b *backfiller) run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// ensureMapping brings the target's mapping up to date before anything is written, through
+// the indexer's own client: the first document carrying an unmapped field would type it
+// dynamically as text, and every node built with the field would then refuse to start
+// against that index. A dry run reads and reports, and refuses only when the field is
+// already mapped with another type, which no run can repair.
+func (b *backfiller) ensureMapping(index string) error {
+	properties := templates.Object{"properties": templates.TransactionsAddedProperties}
+
+	if !b.opts.dryRun {
+		return b.mapping.CheckAndUpdateMapping(index, properties)
+	}
+
+	missing, err := b.mapping.CheckFieldMapping(index, properties)
+	if err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		b.logf("mapping: %s not mapped on %s yet; a real run puts it before writing\n", strings.Join(missing, ", "), index)
+		return nil
+	}
+	b.logf("mapping: up to date on %s\n", index)
+
+	return nil
+}
+
+// pause waits between batches without outliving a cancelled run.
+func pause(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // resolveSingleIndex returns the one concrete index behind alias. A bulk update addressed
@@ -210,7 +270,9 @@ func resolveSingleIndex(ctx context.Context, client *elasticsearch.Client, alias
 	return names[0], nil
 }
 
-// scroll walks the whole source logs index in batches and hands each batch to visit.
+// scroll walks the whole source logs index in batches and hands each batch to visit. The
+// cursor travels in the request body, not the URL: its size grows with the source's shard
+// count and a URL has a length limit the body does not.
 func (b *backfiller) scroll(ctx context.Context, visit func(map[string]logDocument) error) error {
 	body, err := json.Marshal(b.searchBody())
 	if err != nil {
@@ -234,34 +296,55 @@ func (b *backfiller) scroll(ctx context.Context, visit func(map[string]logDocume
 		if scrollID == "" {
 			return
 		}
-		clear, err := b.source.ClearScroll(b.source.ClearScroll.WithScrollID(scrollID))
-		if err == nil {
-			_ = clear.Body.Close()
-		}
+		b.clearScroll(scrollID)
 	}()
 
 	for {
-		page, err := readPage(res)
+		current, err := readPage(res)
 		if err != nil {
 			return err
 		}
-		scrollID = page.scrollID
+		scrollID = current.scrollID
 
-		if len(page.docs) == 0 {
+		if len(current.docs) == 0 {
 			return nil
 		}
-		if err := visit(page.docs); err != nil {
+		if err := visit(current.docs); err != nil {
 			return err
 		}
 
-		res, err = b.source.Scroll(
-			b.source.Scroll.WithContext(ctx),
-			b.source.Scroll.WithScrollID(scrollID),
-			b.source.Scroll.WithScroll(b.opts.scrollKeepAlive),
-		)
+		next, err := json.Marshal(map[string]interface{}{"scroll_id": scrollID, "scroll": esDuration(b.opts.scrollKeepAlive)})
+		if err != nil {
+			return err
+		}
+		res, err = b.source.Scroll(b.source.Scroll.WithContext(ctx), b.source.Scroll.WithBody(bytes.NewReader(next)))
 		if err != nil {
 			return fmt.Errorf("scroll %s: %w", logsIndex, err)
 		}
+	}
+}
+
+// esDuration renders a keepalive the way the client renders its own query parameters:
+// whole milliseconds. Go's Duration.String() form ("1m0s") is not an Elasticsearch time
+// value and is rejected.
+func esDuration(d time.Duration) string {
+	return strconv.FormatInt(d.Milliseconds(), 10) + "ms"
+}
+
+// clearScroll releases the source's cursor on a context of its own, so an interrupted run
+// still frees it and a source that stops answering cannot hold the run open.
+func (b *backfiller) clearScroll(scrollID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), clearScrollTimeout)
+	defer cancel()
+
+	body, err := json.Marshal(map[string]interface{}{"scroll_id": []string{scrollID}})
+	if err != nil {
+		return
+	}
+
+	cleared, err := b.source.ClearScroll(b.source.ClearScroll.WithContext(ctx), b.source.ClearScroll.WithBody(bytes.NewReader(body)))
+	if err == nil {
+		_ = cleared.Body.Close()
 	}
 }
 
@@ -358,7 +441,11 @@ func bulkBody(index string, derived map[string][]string) ([]byte, error) {
 
 	var body bytes.Buffer
 	for _, hash := range hashes {
-		action, err := json.Marshal(map[string]interface{}{"update": map[string]string{"_index": index, "_id": hash}})
+		action, err := json.Marshal(map[string]interface{}{"update": map[string]interface{}{
+			"_index":            index,
+			"_id":               hash,
+			"retry_on_conflict": retriesOnConflict,
+		}})
 		if err != nil {
 			return nil, err
 		}
@@ -411,35 +498,52 @@ func readBulkResult(body io.Reader, out io.Writer) (applyResult, error) {
 	return result, nil
 }
 
-// report prints the two counts that say whether the backfill is complete on the target:
-// smart contract transactions the indexer saw logs for, against transactions carrying the
-// field. The first minus the second is what is still missing.
+// smartContractTransactionsWithLogs is the population a backfill can reach: the indexer
+// derives the field from a log, and only a smart contract transaction's log names one.
+func smartContractTransactionsWithLogs() []interface{} {
+	return []interface{}{
+		map[string]interface{}{"term": map[string]interface{}{"contract.type": 63}},
+		map[string]interface{}{"term": map[string]interface{}{"hasLogs": true}},
+	}
+}
+
+// report prints what is left to do on the target, counted directly rather than as a
+// difference of two totals: smart contract transactions with logs, how many of those carry
+// the field, and how many do not. The last number may not reach zero: a log that names no
+// contract (a failed deploy logs under the sender) leaves its transaction without a field,
+// on a backfill and on a fresh index alike.
 func report(ctx context.Context, target *elasticsearch.Client, out io.Writer) error {
-	withLogs, err := count(ctx, target, map[string]interface{}{
-		"query": map[string]interface{}{"bool": map[string]interface{}{"filter": []interface{}{
-			map[string]interface{}{"term": map[string]interface{}{"contract.type": 63}},
-			map[string]interface{}{"term": map[string]interface{}{"hasLogs": true}},
-		}}},
-	})
+	population := smartContractTransactionsWithLogs()
+	hasField := map[string]interface{}{"exists": map[string]interface{}{"field": fieldName}}
+
+	withLogs, err := count(ctx, target, map[string]interface{}{"bool": map[string]interface{}{"filter": population}})
 	if err != nil {
 		return err
 	}
 
-	withField, err := count(ctx, target, map[string]interface{}{
-		"query": map[string]interface{}{"exists": map[string]interface{}{"field": fieldName}},
-	})
+	withField, err := count(ctx, target, map[string]interface{}{"bool": map[string]interface{}{
+		"filter": append(append([]interface{}{}, population...), hasField),
+	}})
 	if err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(out, "target %s: smart contract transactions with logs: %d, carrying %s: %d, missing: %d\n",
-		transactionsAlias, withLogs, fieldName, withField, withLogs-withField)
+	withoutField, err := count(ctx, target, map[string]interface{}{"bool": map[string]interface{}{
+		"filter":   population,
+		"must_not": []interface{}{hasField},
+	}})
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(out, "target %s: smart contract transactions with logs: %d, of which carrying %s: %d, without it: %d\n",
+		transactionsAlias, withLogs, fieldName, withField, withoutField)
 
 	return nil
 }
 
 func count(ctx context.Context, client *elasticsearch.Client, query map[string]interface{}) (int64, error) {
-	body, err := json.Marshal(query)
+	body, err := json.Marshal(map[string]interface{}{"query": query})
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/indexer-backfill/backfill_test.go
+++ b/cmd/indexer-backfill/backfill_test.go
@@ -141,6 +141,7 @@ type fakeES struct {
 	counts      []int64
 	failBulk    bool
 	failCount   bool
+	failClear   bool
 	requests    []string // "METHOD path?query"
 	bulkBody    bytes.Buffer
 	scrollNext  []byte
@@ -180,6 +181,9 @@ func (f *fakeES) handler() http.Handler {
 				hits = append(hits, map[string]interface{}{"_id": hash, "_source": doc})
 			}
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"_scroll_id": "cursor-1", "hits": map[string]interface{}{"hits": hits}})
+		case r.URL.Path == "/_search/scroll" && r.Method == http.MethodDelete && f.failClear:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"error":{"type":"search_context_missing_exception"}}`)
 		case r.URL.Path == "/_search/scroll" && r.Method == http.MethodDelete:
 			f.scrollClear, _ = io.ReadAll(r.Body)
 			_, _ = io.WriteString(w, `{"succeeded":true}`)
@@ -203,6 +207,11 @@ func (f *fakeES) handler() http.Handler {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = io.WriteString(w, `{"error":{"type":"search_phase_execution_exception"}}`)
 		case r.URL.Path == "/"+transactionsAlias+"/_count":
+			if len(f.counts) == 0 {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"error":{"type":"fake_out_of_counts","reason":"the test queued fewer counts than the tool asked for"}}`)
+				return
+			}
 			count := f.counts[0]
 			f.counts = f.counts[1:]
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"count": count})
@@ -211,6 +220,21 @@ func (f *fakeES) handler() http.Handler {
 			_, _ = io.WriteString(w, `{"error":{"type":"resource_not_found_exception"}}`)
 		}
 	})
+}
+
+// sentBulkBody and scrollBodies read what the handler wrote, under the same mutex.
+func (f *fakeES) sentBulkBody() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.bulkBody.String()
+}
+
+func (f *fakeES) scrollBodies() (next, clear []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.scrollNext, f.scrollClear
 }
 
 // paths returns the recorded requests without their query strings, in order.
@@ -308,7 +332,7 @@ func TestBackfill_WritesWhatTheIndexerDerives(t *testing.T) {
 	require.NoError(t, err)
 	want, err := bulkBody("transactions-000001", derive(cluster.logs))
 	require.NoError(t, err)
-	require.Equal(t, string(want), cluster.bulkBody.String(), "the bulk body must be exactly the derived updates")
+	require.Equal(t, string(want), cluster.sentBulkBody(), "the bulk body must be exactly the derived updates")
 
 	paths := cluster.paths()
 	require.Equal(t, 1, cluster.countPath("/_bulk"))
@@ -319,9 +343,10 @@ func TestBackfill_WritesWhatTheIndexerDerives(t *testing.T) {
 	require.Contains(t, search, "scroll=60000ms", "the first page must open a scroll with the keepalive")
 	require.Contains(t, search, "size=10", "the page size must follow the batch size")
 	require.Contains(t, search, "_source=address%2Cevents.address")
-	require.JSONEq(t, `{"scroll_id":"cursor-1","scroll":"60000ms"}`, string(cluster.scrollNext),
+	next, clear := cluster.scrollBodies()
+	require.JSONEq(t, `{"scroll_id":"cursor-1","scroll":"60000ms"}`, string(next),
 		"the follow-up must carry the cursor and the keepalive in the body, in the unit Elasticsearch accepts")
-	require.JSONEq(t, `{"scroll_id":["cursor-2"]}`, string(cluster.scrollClear), "the last cursor must be cleared through the body")
+	require.JSONEq(t, `{"scroll_id":["cursor-2"]}`, string(clear), "the last cursor must be cleared through the body")
 	require.Contains(t, out.String(), "logs read: 2, with contracts: 1")
 	require.Contains(t, out.String(), "updated: 1, already set: 0, no such transaction: 0, failed: 0")
 }
@@ -397,6 +422,18 @@ func TestBackfill_SurfacesABulkFailure(t *testing.T) {
 	}})
 
 	require.ErrorContains(t, cluster.backfiller(t, options{}, io.Discard).backfill(context.Background()), "bulk update")
+}
+
+// TestBackfill_ReportsAFailedScrollCleanup keeps the clean-up non-fatal but visible: a
+// cursor the source refuses to release stays open until the keepalive expires, and the
+// operator should read that in the output rather than nothing.
+func TestBackfill_ReportsAFailedScrollCleanup(t *testing.T) {
+	cluster := startFake(t, &fakeES{failClear: true, aliases: []string{"transactions-000001"}, fieldType: "keyword", logs: map[string]logDocument{}})
+
+	var out bytes.Buffer
+	require.NoError(t, cluster.backfiller(t, options{}, &out).backfill(context.Background()))
+	require.Contains(t, out.String(), "clear scroll: ")
+	require.Contains(t, out.String(), "the source frees the cursor when the keepalive expires")
 }
 
 func TestPause_StopsWhenTheRunIsCancelled(t *testing.T) {

--- a/cmd/indexer-backfill/backfill_test.go
+++ b/cmd/indexer-backfill/backfill_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/klever-io/klever-go/common"
+	"github.com/klever-io/klever-go/core"
+	"github.com/klever-io/klever-go/crypto/pubkeyConverter"
+	"github.com/stretchr/testify/require"
+)
+
+// contractBytes builds a 32-byte address core.IsSmartContractAddress accepts.
+func contractBytes(tail byte) []byte {
+	address := make([]byte, 32)
+	copy(address[core.NumInitCharactersForScAddress-core.VMTypeLen:], common.WasmVirtualMachine)
+	address[31] = tail
+
+	return address
+}
+
+func walletBytes(tail byte) []byte {
+	address := bytes.Repeat([]byte{0xAB}, 32)
+	address[31] = tail
+
+	return address
+}
+
+func bech32(t *testing.T, address []byte) string {
+	t.Helper()
+
+	converter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength)
+	require.NoError(t, err)
+
+	return converter.Encode(address)
+}
+
+func hashOf(raw string) string { return hex.EncodeToString([]byte(raw)) }
+
+func eventsOf(addresses ...string) []struct {
+	Address string `json:"address"`
+} {
+	events := make([]struct {
+		Address string `json:"address"`
+	}, 0, len(addresses))
+	for _, address := range addresses {
+		events = append(events, struct {
+			Address string `json:"address"`
+		}{Address: address})
+	}
+
+	return events
+}
+
+// TestDerivation_IsTheIndexersOwn feeds log documents through the real indexer processor,
+// wired exactly as main wires it, and checks the field comes out as the indexer writes it:
+// the invoked contract and the inner contract, once each, sorted; the wallet and the empty
+// system address left out; a transaction whose log names no contract absent.
+func TestDerivation_IsTheIndexersOwn(t *testing.T) {
+	derive, err := indexerDerivation()
+	require.NoError(t, err)
+
+	invoked, inner := bech32(t, contractBytes(1)), bech32(t, contractBytes(2))
+	wallet, empty := bech32(t, walletBytes(9)), bech32(t, make([]byte, 32))
+
+	derived := derive(map[string]logDocument{
+		hashOf("swap"):   {Address: invoked, Events: eventsOf(inner, invoked, wallet, empty)},
+		hashOf("plain"):  {Address: wallet, Events: eventsOf(wallet)},
+		"not-hex-at-all": {Address: invoked},
+	})
+
+	want := []string{invoked, inner}
+	if invoked > inner {
+		want = []string{inner, invoked}
+	}
+	require.Equal(t, map[string][]string{hashOf("swap"): want}, derived,
+		"only the transaction with contracts gets an entry, and it lists the contracts sorted")
+}
+
+func TestBulkBody_IsOneUpdatePerTransactionInHashOrder(t *testing.T) {
+	body, err := bulkBody("transactions-000001", map[string][]string{
+		"bb": {"klv1two"},
+		"aa": {"klv1one", "klv1three"},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, strings.Join([]string{
+		`{"update":{"_id":"aa","_index":"transactions-000001"}}`,
+		`{"doc":{"scAddresses":["klv1one","klv1three"]}}`,
+		`{"update":{"_id":"bb","_index":"transactions-000001"}}`,
+		`{"doc":{"scAddresses":["klv1two"]}}`,
+		``,
+	}, "\n"), string(body))
+}
+
+func TestReadBulkResult_TalliesEveryOutcome(t *testing.T) {
+	var out bytes.Buffer
+	result, err := readBulkResult(strings.NewReader(`{"items":[
+		{"update":{"_id":"a","status":200,"result":"updated"}},
+		{"update":{"_id":"b","status":200,"result":"noop"}},
+		{"update":{"_id":"c","status":404,"error":{"type":"document_missing_exception","reason":"[c]: document missing"}}},
+		{"update":{"_id":"d","status":400,"error":{"type":"mapper_parsing_exception","reason":"bad"}}}
+	]}`), &out)
+	require.NoError(t, err)
+
+	require.Equal(t, applyResult{updated: 1, unchanged: 1, missing: 1, failed: 1}, result)
+	require.Contains(t, out.String(), "failed d: mapper_parsing_exception: bad")
+}
+
+// fakeES is the slice of Elasticsearch the tool talks to. The product header is what the
+// client checks before trusting a server.
+type fakeES struct {
+	t        *testing.T
+	aliases  []string
+	logs     map[string]logDocument
+	counts   []int64
+	bulkBody *bytes.Buffer
+	bulkHits int
+}
+
+func (f *fakeES) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/":
+			_, _ = io.WriteString(w, `{"version":{"number":"8.4.0"},"tagline":"You Know, for Search"}`)
+		case r.URL.Path == "/_alias/"+transactionsAlias:
+			indices := map[string]interface{}{}
+			for _, name := range f.aliases {
+				indices[name] = map[string]interface{}{"aliases": map[string]interface{}{transactionsAlias: map[string]interface{}{}}}
+			}
+			_ = json.NewEncoder(w).Encode(indices)
+		case r.URL.Path == "/"+logsIndex+"/_search":
+			require.Contains(f.t, r.URL.Query().Get("_source"), "events.address")
+			hits := make([]map[string]interface{}, 0, len(f.logs))
+			for hash, doc := range f.logs {
+				hits = append(hits, map[string]interface{}{"_id": hash, "_source": doc})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"_scroll_id": "cursor-1", "hits": map[string]interface{}{"hits": hits}})
+		case strings.HasPrefix(r.URL.Path, "/_search/scroll") && r.Method == http.MethodDelete:
+			_, _ = io.WriteString(w, `{"succeeded":true}`)
+		case r.URL.Path == "/_search/scroll":
+			_, _ = io.WriteString(w, `{"_scroll_id":"cursor-2","hits":{"hits":[]}}`)
+		case r.URL.Path == "/_bulk":
+			f.bulkHits++
+			raw, _ := io.ReadAll(r.Body)
+			f.bulkBody.Write(raw)
+			var items []map[string]interface{}
+			for _, line := range bytes.Split(bytes.TrimSpace(raw), []byte("\n")) {
+				if bytes.HasPrefix(line, []byte(`{"update"`)) {
+					items = append(items, map[string]interface{}{"update": map[string]interface{}{"status": 200, "result": "updated"}})
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+		case r.URL.Path == "/"+transactionsAlias+"/_count":
+			count := f.counts[0]
+			f.counts = f.counts[1:]
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"count": count})
+		default:
+			f.t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func clientFor(t *testing.T, url string) *elasticsearch.Client {
+	t.Helper()
+
+	client, err := elasticsearch.NewClient(elasticsearch.Config{Addresses: []string{url}})
+	require.NoError(t, err)
+
+	return client
+}
+
+// TestRun_WritesWhatTheIndexerDerives is the whole tool against a fake cluster: the logs
+// come in, the indexer's derivation runs, and exactly one update per transaction with
+// contracts reaches the target, addressed to the concrete index behind the alias.
+func TestRun_WritesWhatTheIndexerDerives(t *testing.T) {
+	invoked, inner, wallet := bech32(t, contractBytes(1)), bech32(t, contractBytes(2)), bech32(t, walletBytes(3))
+	fake := &fakeES{t: t, aliases: []string{"transactions-000001"}, bulkBody: &bytes.Buffer{}, logs: map[string]logDocument{
+		hashOf("swap"):  {Address: invoked, Events: eventsOf(inner)},
+		hashOf("plain"): {Address: wallet},
+	}}
+	server := httptest.NewServer(fake.handler())
+	defer server.Close()
+
+	derive, err := indexerDerivation()
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), derive, options{batchSize: 10}, &out)
+	require.NoError(t, b.run(t.Context()))
+
+	want, err := bulkBody("transactions-000001", derive(fake.logs))
+	require.NoError(t, err)
+	require.Equal(t, string(want), fake.bulkBody.String(), "the bulk body must be exactly the derived updates")
+	require.Equal(t, 1, fake.bulkHits)
+	require.Contains(t, out.String(), "logs read: 2, with contracts: 1")
+	require.Contains(t, out.String(), "updated: 1, already set: 0, no such transaction: 0, failed: 0")
+}
+
+func TestRun_DryRunWritesNothing(t *testing.T) {
+	invoked := bech32(t, contractBytes(1))
+	fake := &fakeES{t: t, aliases: []string{"transactions-000001"}, bulkBody: &bytes.Buffer{}, logs: map[string]logDocument{
+		hashOf("swap"): {Address: invoked},
+	}}
+	server := httptest.NewServer(fake.handler())
+	defer server.Close()
+
+	derive, err := indexerDerivation()
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), derive, options{batchSize: 10, dryRun: true}, &out)
+	require.NoError(t, b.run(t.Context()))
+
+	require.Equal(t, 0, fake.bulkHits, "a dry run must not touch the target")
+	require.Contains(t, out.String(), "with contracts: 1 (dry run, nothing written)")
+}
+
+// TestRun_RefusesAnAliasSpanningSeveralIndices covers the rollover case: a bulk update
+// addressed to such an alias fails per item, so the run must stop before the first batch
+// and name the indices.
+func TestRun_RefusesAnAliasSpanningSeveralIndices(t *testing.T) {
+	fake := &fakeES{t: t, aliases: []string{"transactions-000002", "transactions-000001"}, bulkBody: &bytes.Buffer{}}
+	server := httptest.NewServer(fake.handler())
+	defer server.Close()
+
+	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), func(map[string]logDocument) map[string][]string { return nil }, options{batchSize: 10}, io.Discard)
+	err := b.run(t.Context())
+
+	require.ErrorContains(t, err, "exactly one index")
+	require.ErrorContains(t, err, "transactions-000001, transactions-000002")
+	require.Equal(t, 0, fake.bulkHits)
+}
+
+func TestReport_PrintsWhatIsStillMissing(t *testing.T) {
+	fake := &fakeES{t: t, counts: []int64{480483, 479460}}
+	server := httptest.NewServer(fake.handler())
+	defer server.Close()
+
+	var out bytes.Buffer
+	require.NoError(t, report(t.Context(), clientFor(t, server.URL), &out))
+	require.Contains(t, out.String(), "smart contract transactions with logs: 480483, carrying scAddresses: 479460, missing: 1023")
+}

--- a/cmd/indexer-backfill/backfill_test.go
+++ b/cmd/indexer-backfill/backfill_test.go
@@ -2,18 +2,22 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/klever-io/klever-go/common"
 	"github.com/klever-io/klever-go/core"
 	"github.com/klever-io/klever-go/crypto/pubkeyConverter"
+	"github.com/klever-io/klever-go/indexer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,12 +97,12 @@ func TestBulkBody_IsOneUpdatePerTransactionInHashOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, strings.Join([]string{
-		`{"update":{"_id":"aa","_index":"transactions-000001"}}`,
+		`{"update":{"_id":"aa","_index":"transactions-000001","retry_on_conflict":3}}`,
 		`{"doc":{"scAddresses":["klv1one","klv1three"]}}`,
-		`{"update":{"_id":"bb","_index":"transactions-000001"}}`,
+		`{"update":{"_id":"bb","_index":"transactions-000001","retry_on_conflict":3}}`,
 		`{"doc":{"scAddresses":["klv1two"]}}`,
 		``,
-	}, "\n"), string(body))
+	}, "\n"), string(body), "a version conflict with the live indexer must be retried, not failed")
 }
 
 func TestReadBulkResult_TalliesEveryOutcome(t *testing.T) {
@@ -115,23 +119,42 @@ func TestReadBulkResult_TalliesEveryOutcome(t *testing.T) {
 	require.Contains(t, out.String(), "failed d: mapper_parsing_exception: bad")
 }
 
-// fakeES is the slice of Elasticsearch the tool talks to. The product header is what the
-// client checks before trusting a server.
+func TestSearchBody_BoundsTheScrollOnlyWhenAsked(t *testing.T) {
+	unbounded := (&backfiller{opts: options{}}).searchBody()
+	require.Equal(t, map[string]interface{}{"match_all": map[string]interface{}{}}, unbounded["query"])
+
+	lower := (&backfiller{opts: options{timestampFrom: 100}}).searchBody()
+	require.Equal(t, map[string]interface{}{"range": map[string]interface{}{"timestamp": map[string]interface{}{"gte": int64(100)}}}, lower["query"])
+
+	both := (&backfiller{opts: options{timestampFrom: 100, timestampTo: 200}}).searchBody()
+	require.Equal(t, map[string]interface{}{"range": map[string]interface{}{"timestamp": map[string]interface{}{"gte": int64(100), "lte": int64(200)}}}, both["query"])
+}
+
+// fakeES is the slice of Elasticsearch the tool talks to, recording every request so a test
+// asserts afterwards, on the test goroutine, what was sent and in which order. The product
+// header is what the client checks on the first response before trusting a server.
 type fakeES struct {
-	failBulk  bool
-	failCount bool
-	t         *testing.T
-	aliases   []string
-	logs      map[string]logDocument
-	counts    []int64
-	bulkBody  *bytes.Buffer
-	bulkHits  int
+	mu          sync.Mutex
+	aliases     []string
+	fieldType   string // "" means scAddresses is not mapped on the target
+	logs        map[string]logDocument
+	counts      []int64
+	failBulk    bool
+	failCount   bool
+	requests    []string // "METHOD path?query"
+	bulkBody    bytes.Buffer
+	scrollNext  []byte
+	scrollClear []byte
 }
 
 func (f *fakeES) handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Elastic-Product", "Elasticsearch")
 		w.Header().Set("Content-Type", "application/json")
+
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.requests = append(f.requests, r.Method+" "+r.URL.Path+"?"+r.URL.RawQuery)
 
 		switch {
 		case r.URL.Path == "/":
@@ -142,22 +165,31 @@ func (f *fakeES) handler() http.Handler {
 				indices[name] = map[string]interface{}{"aliases": map[string]interface{}{transactionsAlias: map[string]interface{}{}}}
 			}
 			_ = json.NewEncoder(w).Encode(indices)
+		case strings.HasSuffix(r.URL.Path, "/_mapping/field/"+fieldName):
+			if f.fieldType == "" {
+				_, _ = io.WriteString(w, `{"transactions-000001":{"mappings":{}}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"transactions-000001":{"mappings":{"scAddresses":{"full_name":"scAddresses","mapping":{"scAddresses":{"type":"`+f.fieldType+`"}}}}}}`)
+		case strings.HasSuffix(r.URL.Path, "/_mapping") && r.Method == http.MethodPut:
+			f.fieldType = "keyword"
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
 		case r.URL.Path == "/"+logsIndex+"/_search":
-			require.Contains(f.t, r.URL.Query().Get("_source"), "events.address")
 			hits := make([]map[string]interface{}, 0, len(f.logs))
 			for hash, doc := range f.logs {
 				hits = append(hits, map[string]interface{}{"_id": hash, "_source": doc})
 			}
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"_scroll_id": "cursor-1", "hits": map[string]interface{}{"hits": hits}})
-		case strings.HasPrefix(r.URL.Path, "/_search/scroll") && r.Method == http.MethodDelete:
+		case r.URL.Path == "/_search/scroll" && r.Method == http.MethodDelete:
+			f.scrollClear, _ = io.ReadAll(r.Body)
 			_, _ = io.WriteString(w, `{"succeeded":true}`)
 		case r.URL.Path == "/_search/scroll":
+			f.scrollNext, _ = io.ReadAll(r.Body)
 			_, _ = io.WriteString(w, `{"_scroll_id":"cursor-2","hits":{"hits":[]}}`)
 		case r.URL.Path == "/_bulk" && f.failBulk:
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = io.WriteString(w, `{"error":{"type":"cluster_block_exception"}}`)
 		case r.URL.Path == "/_bulk":
-			f.bulkHits++
 			raw, _ := io.ReadAll(r.Body)
 			f.bulkBody.Write(raw)
 			var items []map[string]interface{}
@@ -175,130 +207,269 @@ func (f *fakeES) handler() http.Handler {
 			f.counts = f.counts[1:]
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"count": count})
 		default:
-			f.t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"error":{"type":"resource_not_found_exception"}}`)
 		}
 	})
 }
 
-func clientFor(t *testing.T, url string) *elasticsearch.Client {
-	t.Helper()
+// paths returns the recorded requests without their query strings, in order.
+func (f *fakeES) paths() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
-	client, err := elasticsearch.NewClient(elasticsearch.Config{Addresses: []string{url}})
-	require.NoError(t, err)
+	paths := make([]string, 0, len(f.requests))
+	for _, request := range f.requests {
+		// "METHOD path?query" -> "path"
+		withoutMethod := request[strings.Index(request, " ")+1:]
+		paths = append(paths, strings.SplitN(withoutMethod, "?", 2)[0])
+	}
 
-	return client
+	return paths
 }
 
-// TestRun_WritesWhatTheIndexerDerives is the whole tool against a fake cluster: the logs
-// come in, the indexer's derivation runs, and exactly one update per transaction with
-// contracts reaches the target, addressed to the concrete index behind the alias.
-func TestRun_WritesWhatTheIndexerDerives(t *testing.T) {
-	invoked, inner, wallet := bech32(t, contractBytes(1)), bech32(t, contractBytes(2)), bech32(t, walletBytes(3))
-	fake := &fakeES{t: t, aliases: []string{"transactions-000001"}, bulkBody: &bytes.Buffer{}, logs: map[string]logDocument{
-		hashOf("swap"):  {Address: invoked, Events: eventsOf(inner)},
-		hashOf("plain"): {Address: wallet},
-	}}
+func (f *fakeES) countPath(path string) int {
+	n := 0
+	for _, p := range f.paths() {
+		if p == path {
+			n++
+		}
+	}
+
+	return n
+}
+
+func (f *fakeES) request(prefix string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, request := range f.requests {
+		if strings.HasPrefix(request, prefix) {
+			return request
+		}
+	}
+
+	return ""
+}
+
+type fakeCluster struct {
+	*fakeES
+	server *httptest.Server
+	client *elasticsearch.Client
+	admin  indexer.DatabaseClientHandler
+}
+
+func startFake(t *testing.T, fake *fakeES) *fakeCluster {
+	t.Helper()
+
 	server := httptest.NewServer(fake.handler())
-	defer server.Close()
+	t.Cleanup(server.Close)
+
+	client, err := elasticsearch.NewClient(elasticsearch.Config{Addresses: []string{server.URL}})
+	require.NoError(t, err)
+	admin, err := indexer.NewElasticClient(elasticsearch.Config{Addresses: []string{server.URL}})
+	require.NoError(t, err)
+
+	return &fakeCluster{fakeES: fake, server: server, client: client, admin: admin}
+}
+
+func (c *fakeCluster) backfiller(t *testing.T, opts options, out io.Writer) *backfiller {
+	t.Helper()
 
 	derive, err := indexerDerivation()
 	require.NoError(t, err)
 
-	var out bytes.Buffer
-	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), derive, options{batchSize: 10}, &out)
-	require.NoError(t, b.run(t.Context()))
+	if opts.batchSize == 0 {
+		opts.batchSize = 10
+	}
+	if opts.scrollKeepAlive == 0 {
+		opts.scrollKeepAlive = time.Minute
+	}
 
-	want, err := bulkBody("transactions-000001", derive(fake.logs))
+	return newBackfiller(c.client, c.client, c.admin, derive, opts, out)
+}
+
+// TestBackfill_WritesWhatTheIndexerDerives is the whole tool against a fake cluster: the
+// mapping is put before anything is written, the logs come in, the indexer's derivation
+// runs, and exactly one update per transaction with contracts reaches the target, addressed
+// to the concrete index behind the alias.
+func TestBackfill_WritesWhatTheIndexerDerives(t *testing.T) {
+	invoked, inner, wallet := bech32(t, contractBytes(1)), bech32(t, contractBytes(2)), bech32(t, walletBytes(3))
+	cluster := startFake(t, &fakeES{aliases: []string{"transactions-000001"}, logs: map[string]logDocument{
+		hashOf("swap"):  {Address: invoked, Events: eventsOf(inner)},
+		hashOf("plain"): {Address: wallet},
+	}})
+
+	var out bytes.Buffer
+	b := cluster.backfiller(t, options{}, &out)
+	require.NoError(t, b.backfill(context.Background()))
+
+	derive, err := indexerDerivation()
 	require.NoError(t, err)
-	require.Equal(t, string(want), fake.bulkBody.String(), "the bulk body must be exactly the derived updates")
-	require.Equal(t, 1, fake.bulkHits)
+	want, err := bulkBody("transactions-000001", derive(cluster.logs))
+	require.NoError(t, err)
+	require.Equal(t, string(want), cluster.bulkBody.String(), "the bulk body must be exactly the derived updates")
+
+	paths := cluster.paths()
+	require.Equal(t, 1, cluster.countPath("/_bulk"))
+	mappingAt, bulkAt := indexOf(paths, "/transactions-000001/_mapping"), indexOf(paths, "/_bulk")
+	require.True(t, mappingAt >= 0 && mappingAt < bulkAt, "the mapping must be put before the first write; requests: %v", paths)
+
+	search := cluster.request("POST /logs/_search")
+	require.Contains(t, search, "scroll=60000ms", "the first page must open a scroll with the keepalive")
+	require.Contains(t, search, "size=10", "the page size must follow the batch size")
+	require.Contains(t, search, "_source=address%2Cevents.address")
+	require.JSONEq(t, `{"scroll_id":"cursor-1","scroll":"60000ms"}`, string(cluster.scrollNext),
+		"the follow-up must carry the cursor and the keepalive in the body, in the unit Elasticsearch accepts")
+	require.JSONEq(t, `{"scroll_id":["cursor-2"]}`, string(cluster.scrollClear), "the last cursor must be cleared through the body")
 	require.Contains(t, out.String(), "logs read: 2, with contracts: 1")
 	require.Contains(t, out.String(), "updated: 1, already set: 0, no such transaction: 0, failed: 0")
 }
 
-func TestRun_DryRunWritesNothing(t *testing.T) {
-	invoked := bech32(t, contractBytes(1))
-	fake := &fakeES{t: t, aliases: []string{"transactions-000001"}, bulkBody: &bytes.Buffer{}, logs: map[string]logDocument{
-		hashOf("swap"): {Address: invoked},
-	}}
-	server := httptest.NewServer(fake.handler())
-	defer server.Close()
+func indexOf(paths []string, path string) int {
+	for i, p := range paths {
+		if p == path {
+			return i
+		}
+	}
 
-	derive, err := indexerDerivation()
-	require.NoError(t, err)
+	return -1
+}
+
+// TestBackfill_LeavesAnUpToDateMappingAlone is the other side of the mapping guard: a target
+// the new node already started against gets no mapping write, which is also what keeps the
+// tool usable with a user that lacks the manage privilege on such a target.
+func TestBackfill_LeavesAnUpToDateMappingAlone(t *testing.T) {
+	cluster := startFake(t, &fakeES{aliases: []string{"transactions-000001"}, fieldType: "keyword", logs: map[string]logDocument{}})
+
+	require.NoError(t, cluster.backfiller(t, options{}, io.Discard).backfill(context.Background()))
+	require.Equal(t, 0, cluster.countPath("/transactions-000001/_mapping"), "requests: %v", cluster.paths())
+}
+
+// TestBackfill_RefusesATargetMappedWithAnotherType covers the state no run can repair: the
+// field already mapped as text. Writing into it would make every node built with the field
+// refuse to start, so the run must stop before the first bulk, and so must a dry run.
+func TestBackfill_RefusesATargetMappedWithAnotherType(t *testing.T) {
+	invoked := bech32(t, contractBytes(1))
+	for _, dryRun := range []bool{false, true} {
+		cluster := startFake(t, &fakeES{aliases: []string{"transactions-000001"}, fieldType: "text", logs: map[string]logDocument{
+			hashOf("swap"): {Address: invoked},
+		}})
+
+		err := cluster.backfiller(t, options{dryRun: dryRun}, io.Discard).backfill(context.Background())
+		require.ErrorContains(t, err, `maps scAddresses as "text"`, "dryRun=%v", dryRun)
+		require.Equal(t, 0, cluster.countPath("/_bulk"), "dryRun=%v: nothing may be written", dryRun)
+	}
+}
+
+func TestBackfill_DryRunWritesNothingAndReportsTheMapping(t *testing.T) {
+	invoked := bech32(t, contractBytes(1))
+	cluster := startFake(t, &fakeES{aliases: []string{"transactions-000001"}, logs: map[string]logDocument{
+		hashOf("swap"): {Address: invoked},
+	}})
 
 	var out bytes.Buffer
-	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), derive, options{batchSize: 10, dryRun: true}, &out)
-	require.NoError(t, b.run(t.Context()))
+	require.NoError(t, cluster.backfiller(t, options{dryRun: true}, &out).backfill(context.Background()))
 
-	require.Equal(t, 0, fake.bulkHits, "a dry run must not touch the target")
+	require.Equal(t, 0, cluster.countPath("/_bulk"), "a dry run must not touch the documents")
+	require.Equal(t, 0, cluster.countPath("/transactions-000001/_mapping"), "a dry run must not touch the mapping either")
+	require.Contains(t, out.String(), "mapping: scAddresses not mapped on transactions-000001 yet; a real run puts it before writing")
 	require.Contains(t, out.String(), "with contracts: 1 (dry run, nothing written)")
 }
 
-// TestRun_RefusesAnAliasSpanningSeveralIndices covers the rollover case: a bulk update
+// TestBackfill_RefusesAnAliasSpanningSeveralIndices covers the rollover case: a bulk update
 // addressed to such an alias fails per item, so the run must stop before the first batch
 // and name the indices.
-func TestRun_RefusesAnAliasSpanningSeveralIndices(t *testing.T) {
-	fake := &fakeES{t: t, aliases: []string{"transactions-000002", "transactions-000001"}, bulkBody: &bytes.Buffer{}}
-	server := httptest.NewServer(fake.handler())
-	defer server.Close()
+func TestBackfill_RefusesAnAliasSpanningSeveralIndices(t *testing.T) {
+	cluster := startFake(t, &fakeES{aliases: []string{"transactions-000002", "transactions-000001"}})
 
-	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), func(map[string]logDocument) map[string][]string { return nil }, options{batchSize: 10}, io.Discard)
-	err := b.run(t.Context())
+	err := cluster.backfiller(t, options{}, io.Discard).backfill(context.Background())
 
 	require.ErrorContains(t, err, "exactly one index")
 	require.ErrorContains(t, err, "transactions-000001, transactions-000002")
-	require.Equal(t, 0, fake.bulkHits)
+	require.Equal(t, 0, cluster.countPath("/_bulk"))
 }
 
-func TestReport_PrintsWhatIsStillMissing(t *testing.T) {
-	fake := &fakeES{t: t, counts: []int64{480483, 479460}}
-	server := httptest.NewServer(fake.handler())
-	defer server.Close()
+func TestBackfill_SurfacesABulkFailure(t *testing.T) {
+	invoked := bech32(t, contractBytes(1))
+	cluster := startFake(t, &fakeES{failBulk: true, aliases: []string{"transactions-000001"}, logs: map[string]logDocument{
+		hashOf("swap"): {Address: invoked},
+	}})
+
+	require.ErrorContains(t, cluster.backfiller(t, options{}, io.Discard).backfill(context.Background()), "bulk update")
+}
+
+func TestPause_StopsWhenTheRunIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	require.ErrorIs(t, pause(ctx, time.Hour), context.Canceled)
+	require.Less(t, time.Since(started), time.Second, "a cancelled run must not sit out the pause")
+	require.NoError(t, pause(context.Background(), 0))
+}
+
+// TestReport_CountsWhatIsLeftDirectly pins the three counts and, above all, that "without
+// it" is its own query rather than a difference: the two totals are over one population,
+// but a transaction whose log names no contract sits in the first and never in the second.
+func TestReport_CountsWhatIsLeftDirectly(t *testing.T) {
+	cluster := startFake(t, &fakeES{counts: []int64{480483, 479460, 1023}})
 
 	var out bytes.Buffer
-	require.NoError(t, report(t.Context(), clientFor(t, server.URL), &out))
-	require.Contains(t, out.String(), "smart contract transactions with logs: 480483, carrying scAddresses: 479460, missing: 1023")
-}
-
-func TestRun_SurfacesABulkFailure(t *testing.T) {
-	invoked := bech32(t, contractBytes(1))
-	fake := &fakeES{t: t, failBulk: true, aliases: []string{"transactions-000001"}, bulkBody: &bytes.Buffer{}, logs: map[string]logDocument{
-		hashOf("swap"): {Address: invoked},
-	}}
-	server := httptest.NewServer(fake.handler())
-	defer server.Close()
-
-	derive, err := indexerDerivation()
-	require.NoError(t, err)
-
-	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), derive, options{batchSize: 10}, io.Discard)
-	require.ErrorContains(t, b.run(t.Context()), "bulk update")
+	require.NoError(t, report(context.Background(), cluster.client, &out))
+	require.Contains(t, out.String(), "smart contract transactions with logs: 480483, of which carrying scAddresses: 479460, without it: 1023")
+	require.Equal(t, 3, cluster.countPath("/transactions/_count"), "the remainder must be counted, not computed")
 }
 
 func TestReport_SurfacesACountFailure(t *testing.T) {
-	fake := &fakeES{t: t, failCount: true}
-	server := httptest.NewServer(fake.handler())
-	defer server.Close()
+	cluster := startFake(t, &fakeES{failCount: true})
 
-	require.ErrorContains(t, report(t.Context(), clientFor(t, server.URL), io.Discard), "count")
+	require.ErrorContains(t, report(context.Background(), cluster.client, io.Discard), "count")
 }
 
-func TestSearchBody_BoundsTheScrollOnlyWhenAsked(t *testing.T) {
-	unbounded := (&backfiller{opts: options{}}).searchBody()
-	require.Equal(t, map[string]interface{}{"match_all": map[string]interface{}{}}, unbounded["query"])
+func TestParseFlags_ReadsEveryOption(t *testing.T) {
+	opts, err := parseFlags([]string{"-source-url", "http://src:9200", "-target-url", "http://dst:9200", "-batch-size", "25",
+		"-pause", "2s", "-scroll-keepalive", "3m", "-timestamp-from", "5", "-timestamp-to", "9", "-dry-run"})
+	require.NoError(t, err)
 
-	lower := (&backfiller{opts: options{timestampFrom: 100}}).searchBody()
-	require.Equal(t, map[string]interface{}{"range": map[string]interface{}{"timestamp": map[string]interface{}{"gte": int64(100)}}}, lower["query"])
+	require.Equal(t, options{sourceURL: "http://src:9200", targetURL: "http://dst:9200", batchSize: 25, pause: 2 * time.Second,
+		scrollKeepAlive: 3 * time.Minute, timestampFrom: 5, timestampTo: 9, dryRun: true}, opts)
 
-	both := (&backfiller{opts: options{timestampFrom: 100, timestampTo: 200}}).searchBody()
-	require.Equal(t, map[string]interface{}{"range": map[string]interface{}{"timestamp": map[string]interface{}{"gte": int64(100), "lte": int64(200)}}}, both["query"])
+	_, err = parseFlags([]string{"-no-such-flag"})
+	require.Error(t, err)
 }
 
-// TestRun_RefusesToStartWithoutItsTargets covers the flag validation, the one part of main
-// that runs before any client is built.
-func TestRun_RefusesToStartWithoutItsTargets(t *testing.T) {
-	require.ErrorContains(t, run(options{}), "-target-url is required")
-	require.ErrorContains(t, run(options{targetURL: "http://127.0.0.1:1"}), "-source-url is required")
+// TestRun_RefusesToStartOnBadOptions covers the validation that runs before any client is
+// built: the clusters, the values that would read nothing or fail late, and a URL that
+// smuggles a password past the environment.
+func TestRun_RefusesToStartOnBadOptions(t *testing.T) {
+	valid := options{sourceURL: "http://src:9200", targetURL: "http://dst:9200", batchSize: 10, scrollKeepAlive: time.Minute}
+
+	for name, broken := range map[string]func(o *options){
+		"-target-url is required":                     func(o *options) { o.targetURL = "" },
+		"-source-url is required unless -verify-only": func(o *options) { o.sourceURL = "" },
+		"-batch-size must be positive":                func(o *options) { o.batchSize = 0 },
+		"-scroll-keepalive must be positive":          func(o *options) { o.scrollKeepAlive = 0 },
+		"-target-url carries credentials":             func(o *options) { o.targetURL = "http://user:secret@dst:9200" },
+		"-source-url carries credentials":             func(o *options) { o.sourceURL = "http://user:secret@src:9200" },
+	} {
+		opts := valid
+		broken(&opts)
+		require.ErrorContains(t, run(opts), name)
+	}
+}
+
+// TestRun_EndToEnd drives main's run against the fake cluster in both modes that need no
+// real chain: a dry run over the logs, and a verify-only report.
+func TestRun_EndToEnd(t *testing.T) {
+	invoked := bech32(t, contractBytes(1))
+	cluster := startFake(t, &fakeES{aliases: []string{"transactions-000001"}, counts: []int64{3, 2, 1, 3, 2, 1}, logs: map[string]logDocument{
+		hashOf("swap"): {Address: invoked},
+	}})
+
+	require.NoError(t, run(options{sourceURL: cluster.server.URL, targetURL: cluster.server.URL, batchSize: 10, scrollKeepAlive: time.Minute, dryRun: true}))
+	require.Equal(t, 0, cluster.countPath("/_bulk"))
+
+	require.NoError(t, run(options{targetURL: cluster.server.URL, batchSize: 10, scrollKeepAlive: time.Minute, verifyOnly: true}))
+	require.Equal(t, 6, cluster.countPath("/transactions/_count"), "both modes end with the report")
 }

--- a/cmd/indexer-backfill/backfill_test.go
+++ b/cmd/indexer-backfill/backfill_test.go
@@ -61,8 +61,9 @@ func eventsOf(addresses ...string) []struct {
 
 // TestDerivation_IsTheIndexersOwn feeds log documents through the real indexer processor,
 // wired exactly as main wires it, and checks the field comes out as the indexer writes it:
-// the invoked contract and the inner contract, once each, sorted; the wallet and the empty
-// system address left out; a transaction whose log names no contract absent.
+// the invoked contract (reachable only through the log's own address here) and the inner
+// contract, sorted; the wallet and the empty system address left out; a transaction whose
+// log names no contract absent.
 func TestDerivation_IsTheIndexersOwn(t *testing.T) {
 	derive, err := indexerDerivation()
 	require.NoError(t, err)
@@ -71,7 +72,7 @@ func TestDerivation_IsTheIndexersOwn(t *testing.T) {
 	wallet, empty := bech32(t, walletBytes(9)), bech32(t, make([]byte, 32))
 
 	derived := derive(map[string]logDocument{
-		hashOf("swap"):   {Address: invoked, Events: eventsOf(inner, invoked, wallet, empty)},
+		hashOf("swap"):   {Address: invoked, Events: eventsOf(inner, wallet, empty)},
 		hashOf("plain"):  {Address: wallet, Events: eventsOf(wallet)},
 		"not-hex-at-all": {Address: invoked},
 	})
@@ -117,12 +118,14 @@ func TestReadBulkResult_TalliesEveryOutcome(t *testing.T) {
 // fakeES is the slice of Elasticsearch the tool talks to. The product header is what the
 // client checks before trusting a server.
 type fakeES struct {
-	t        *testing.T
-	aliases  []string
-	logs     map[string]logDocument
-	counts   []int64
-	bulkBody *bytes.Buffer
-	bulkHits int
+	failBulk  bool
+	failCount bool
+	t         *testing.T
+	aliases   []string
+	logs      map[string]logDocument
+	counts    []int64
+	bulkBody  *bytes.Buffer
+	bulkHits  int
 }
 
 func (f *fakeES) handler() http.Handler {
@@ -150,6 +153,9 @@ func (f *fakeES) handler() http.Handler {
 			_, _ = io.WriteString(w, `{"succeeded":true}`)
 		case r.URL.Path == "/_search/scroll":
 			_, _ = io.WriteString(w, `{"_scroll_id":"cursor-2","hits":{"hits":[]}}`)
+		case r.URL.Path == "/_bulk" && f.failBulk:
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":{"type":"cluster_block_exception"}}`)
 		case r.URL.Path == "/_bulk":
 			f.bulkHits++
 			raw, _ := io.ReadAll(r.Body)
@@ -161,6 +167,9 @@ func (f *fakeES) handler() http.Handler {
 				}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+		case r.URL.Path == "/"+transactionsAlias+"/_count" && f.failCount:
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, `{"error":{"type":"search_phase_execution_exception"}}`)
 		case r.URL.Path == "/"+transactionsAlias+"/_count":
 			count := f.counts[0]
 			f.counts = f.counts[1:]
@@ -251,4 +260,45 @@ func TestReport_PrintsWhatIsStillMissing(t *testing.T) {
 	var out bytes.Buffer
 	require.NoError(t, report(t.Context(), clientFor(t, server.URL), &out))
 	require.Contains(t, out.String(), "smart contract transactions with logs: 480483, carrying scAddresses: 479460, missing: 1023")
+}
+
+func TestRun_SurfacesABulkFailure(t *testing.T) {
+	invoked := bech32(t, contractBytes(1))
+	fake := &fakeES{t: t, failBulk: true, aliases: []string{"transactions-000001"}, bulkBody: &bytes.Buffer{}, logs: map[string]logDocument{
+		hashOf("swap"): {Address: invoked},
+	}}
+	server := httptest.NewServer(fake.handler())
+	defer server.Close()
+
+	derive, err := indexerDerivation()
+	require.NoError(t, err)
+
+	b := newBackfiller(clientFor(t, server.URL), clientFor(t, server.URL), derive, options{batchSize: 10}, io.Discard)
+	require.ErrorContains(t, b.run(t.Context()), "bulk update")
+}
+
+func TestReport_SurfacesACountFailure(t *testing.T) {
+	fake := &fakeES{t: t, failCount: true}
+	server := httptest.NewServer(fake.handler())
+	defer server.Close()
+
+	require.ErrorContains(t, report(t.Context(), clientFor(t, server.URL), io.Discard), "count")
+}
+
+func TestSearchBody_BoundsTheScrollOnlyWhenAsked(t *testing.T) {
+	unbounded := (&backfiller{opts: options{}}).searchBody()
+	require.Equal(t, map[string]interface{}{"match_all": map[string]interface{}{}}, unbounded["query"])
+
+	lower := (&backfiller{opts: options{timestampFrom: 100}}).searchBody()
+	require.Equal(t, map[string]interface{}{"range": map[string]interface{}{"timestamp": map[string]interface{}{"gte": int64(100)}}}, lower["query"])
+
+	both := (&backfiller{opts: options{timestampFrom: 100, timestampTo: 200}}).searchBody()
+	require.Equal(t, map[string]interface{}{"range": map[string]interface{}{"timestamp": map[string]interface{}{"gte": int64(100), "lte": int64(200)}}}, both["query"])
+}
+
+// TestRun_RefusesToStartWithoutItsTargets covers the flag validation, the one part of main
+// that runs before any client is built.
+func TestRun_RefusesToStartWithoutItsTargets(t *testing.T) {
+	require.ErrorContains(t, run(options{}), "-target-url is required")
+	require.ErrorContains(t, run(options{targetURL: "http://127.0.0.1:1"}), "-source-url is required")
 }

--- a/cmd/indexer-backfill/main.go
+++ b/cmd/indexer-backfill/main.go
@@ -2,21 +2,33 @@
 // indexer learned to derive it, reading each transaction's events from a logs index.
 //
 // The field is derived by the indexer's own ExtractDataFromLogs, fed with the log document
-// as the indexer would have seen it, so a backfilled transaction carries exactly what a
-// freshly indexed one carries. The source and the target are separate clusters on purpose:
-// a logs index can be shorter than the transactions it belongs to (one deployment's logs
-// start months after its first smart contract transaction), so the run reads from whichever
-// cluster holds the complete logs and writes wherever the transactions live.
+// as the indexer would have received it from the node, so a backfilled transaction carries
+// what a freshly indexed one carries. Two things the logs cannot give back: a contract that
+// ran without emitting an event was never in the log, and a failed deploy logs under the
+// sender's address, so its transaction gets no field either way. The source and the target
+// are separate clusters on purpose: a logs index can be shorter than the transactions it
+// belongs to (one deployment's logs start months after its first smart contract
+// transaction), so the run reads from whichever cluster holds the complete logs and writes
+// wherever the transactions live.
+//
+// Before the first write the target's mapping is brought up to date through the same code
+// the indexing node runs at start-up, so a backfill can run before or after that node is
+// deployed: a field first written without a mapping would be typed as text, and the node
+// would then refuse to start against it. That step needs the manage privilege on the
+// transactions index when the property is absent, and only view_index_metadata otherwise.
 //
 // Writes are plain partial updates and the field is a set, so a run is idempotent and a
 // failed run is repeated rather than resumed. Passwords come from the environment
-// (BACKFILL_SOURCE_PASSWORD, BACKFILL_TARGET_PASSWORD), never from flags.
+// (BACKFILL_SOURCE_PASSWORD, BACKFILL_TARGET_PASSWORD), never from flags, and a URL
+// carrying credentials is refused.
 package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -25,6 +37,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v8"
 	hashingFactory "github.com/klever-io/klever-go/crypto/hashing/factory"
 	"github.com/klever-io/klever-go/crypto/pubkeyConverter"
+	"github.com/klever-io/klever-go/indexer"
 	"github.com/klever-io/klever-go/indexer/logsevents"
 	marshalFactory "github.com/klever-io/klever-go/tools/marshal/factory"
 )
@@ -32,19 +45,11 @@ import (
 const addressLength = 32
 
 func main() {
-	var opts options
-	flag.StringVar(&opts.sourceURL, "source-url", "", "cluster holding the complete logs index (read only)")
-	flag.StringVar(&opts.sourceUser, "source-user", "", "user name for the source cluster")
-	flag.StringVar(&opts.targetURL, "target-url", "", "cluster holding the transactions index that receives the field")
-	flag.StringVar(&opts.targetUser, "target-user", "", "user name for the target cluster")
-	flag.IntVar(&opts.batchSize, "batch-size", 500, "log documents read and transactions updated per round trip")
-	flag.DurationVar(&opts.pause, "pause", 0, "pause between batches, to keep a busy cluster comfortable")
-	flag.DurationVar(&opts.scrollKeepAlive, "scroll-keepalive", 5*time.Minute, "how long the source keeps the scroll cursor alive between batches")
-	flag.Int64Var(&opts.timestampFrom, "timestamp-from", 0, "only logs with timestamp >= this value; 0 means unbounded. The unit is whatever the logs mapping stores, check it before relying on this")
-	flag.Int64Var(&opts.timestampTo, "timestamp-to", 0, "only logs with timestamp <= this value; 0 means unbounded")
-	flag.BoolVar(&opts.dryRun, "dry-run", false, "derive and count, write nothing")
-	flag.BoolVar(&opts.verifyOnly, "verify-only", false, "skip the backfill and only report the target's counts")
-	flag.Parse()
+	opts, err := parseFlags(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "indexer-backfill:", err)
+		os.Exit(2)
+	}
 
 	if err := run(opts); err != nil {
 		fmt.Fprintln(os.Stderr, "indexer-backfill:", err)
@@ -52,19 +57,71 @@ func main() {
 	}
 }
 
-func run(opts options) error {
-	if opts.targetURL == "" {
-		return fmt.Errorf("-target-url is required")
-	}
-	if !opts.verifyOnly && opts.sourceURL == "" {
-		return fmt.Errorf("-source-url is required unless -verify-only is set")
+func parseFlags(args []string) (options, error) {
+	var opts options
+	flags := flag.NewFlagSet("indexer-backfill", flag.ContinueOnError)
+	flags.StringVar(&opts.sourceURL, "source-url", "", "cluster holding the complete logs index (read only)")
+	flags.StringVar(&opts.sourceUser, "source-user", "", "user name for the source cluster")
+	flags.StringVar(&opts.targetURL, "target-url", "", "cluster holding the transactions index that receives the field")
+	flags.StringVar(&opts.targetUser, "target-user", "", "user name for the target cluster")
+	flags.IntVar(&opts.batchSize, "batch-size", 500, "log documents read and transactions updated per round trip")
+	flags.DurationVar(&opts.pause, "pause", 0, "pause between batches, to keep a busy cluster comfortable")
+	flags.DurationVar(&opts.scrollKeepAlive, "scroll-keepalive", 5*time.Minute, "how long the source keeps the scroll cursor alive between batches")
+	flags.Int64Var(&opts.timestampFrom, "timestamp-from", 0, "only logs with timestamp >= this value; 0 means unbounded. The unit is whatever the logs mapping stores, check it before relying on this")
+	flags.Int64Var(&opts.timestampTo, "timestamp-to", 0, "only logs with timestamp <= this value; 0 means unbounded")
+	flags.BoolVar(&opts.dryRun, "dry-run", false, "derive and count, write nothing, and report whether the target mapping is ready")
+	flags.BoolVar(&opts.verifyOnly, "verify-only", false, "skip the backfill and only report the target's counts")
+
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
 	}
 
-	target, err := elasticsearch.NewClient(elasticsearch.Config{
+	return opts, nil
+}
+
+// validate rejects what would otherwise fail late or silently: a missing cluster, a batch
+// size that reads nothing and exits clean, a keepalive the client drops from the request,
+// and credentials smuggled in through a URL.
+func (o options) validate() error {
+	if o.targetURL == "" {
+		return errors.New("-target-url is required")
+	}
+	if !o.verifyOnly && o.sourceURL == "" {
+		return errors.New("-source-url is required unless -verify-only is set")
+	}
+	if o.batchSize <= 0 {
+		return errors.New("-batch-size must be positive")
+	}
+	if o.scrollKeepAlive <= 0 {
+		return errors.New("-scroll-keepalive must be positive")
+	}
+	for name, raw := range map[string]string{"-target-url": o.targetURL, "-source-url": o.sourceURL} {
+		if raw == "" {
+			continue
+		}
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+		if parsed.User != nil {
+			return fmt.Errorf("%s carries credentials; pass the password through BACKFILL_SOURCE_PASSWORD or BACKFILL_TARGET_PASSWORD instead", name)
+		}
+	}
+
+	return nil
+}
+
+func run(opts options) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+
+	targetConfig := elasticsearch.Config{
 		Addresses: []string{opts.targetURL},
 		Username:  opts.targetUser,
 		Password:  os.Getenv("BACKFILL_TARGET_PASSWORD"),
-	})
+	}
+	target, err := elasticsearch.NewClient(targetConfig)
 	if err != nil {
 		return fmt.Errorf("target client: %w", err)
 	}
@@ -74,6 +131,13 @@ func run(opts options) error {
 
 	if opts.verifyOnly {
 		return report(ctx, target, os.Stdout)
+	}
+
+	// The mapping goes through the indexer's own client so the tool and the node cannot
+	// disagree on what the field is, or on when a write is refused.
+	mapping, err := indexer.NewElasticClient(targetConfig)
+	if err != nil {
+		return fmt.Errorf("target mapping client: %w", err)
 	}
 
 	source, err := elasticsearch.NewClient(elasticsearch.Config{
@@ -90,8 +154,7 @@ func run(opts options) error {
 		return err
 	}
 
-	backfiller := newBackfiller(source, target, derive, opts, os.Stdout)
-	if err := backfiller.run(ctx); err != nil {
+	if err := newBackfiller(source, target, mapping, derive, opts, os.Stdout).backfill(ctx); err != nil {
 		return err
 	}
 

--- a/cmd/indexer-backfill/main.go
+++ b/cmd/indexer-backfill/main.go
@@ -1,0 +1,129 @@
+// indexer-backfill writes scAddresses onto transaction documents indexed before the
+// indexer learned to derive it, reading each transaction's events from a logs index.
+//
+// The field is derived by the indexer's own ExtractDataFromLogs, fed with the log document
+// as the indexer would have seen it, so a backfilled transaction carries exactly what a
+// freshly indexed one carries. The source and the target are separate clusters on purpose:
+// a logs index can be shorter than the transactions it belongs to (one deployment's logs
+// start months after its first smart contract transaction), so the run reads from whichever
+// cluster holds the complete logs and writes wherever the transactions live.
+//
+// Writes are plain partial updates and the field is a set, so a run is idempotent and a
+// failed run is repeated rather than resumed. Passwords come from the environment
+// (BACKFILL_SOURCE_PASSWORD, BACKFILL_TARGET_PASSWORD), never from flags.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	hashingFactory "github.com/klever-io/klever-go/crypto/hashing/factory"
+	"github.com/klever-io/klever-go/crypto/pubkeyConverter"
+	"github.com/klever-io/klever-go/indexer/logsevents"
+	marshalFactory "github.com/klever-io/klever-go/tools/marshal/factory"
+)
+
+const addressLength = 32
+
+func main() {
+	var opts options
+	flag.StringVar(&opts.sourceURL, "source-url", "", "cluster holding the complete logs index (read only)")
+	flag.StringVar(&opts.sourceUser, "source-user", "", "user name for the source cluster")
+	flag.StringVar(&opts.targetURL, "target-url", "", "cluster holding the transactions index that receives the field")
+	flag.StringVar(&opts.targetUser, "target-user", "", "user name for the target cluster")
+	flag.IntVar(&opts.batchSize, "batch-size", 500, "log documents read and transactions updated per round trip")
+	flag.DurationVar(&opts.pause, "pause", 0, "pause between batches, to keep a busy cluster comfortable")
+	flag.DurationVar(&opts.scrollKeepAlive, "scroll-keepalive", 5*time.Minute, "how long the source keeps the scroll cursor alive between batches")
+	flag.Int64Var(&opts.timestampFrom, "timestamp-from", 0, "only logs with timestamp >= this value; 0 means unbounded. The unit is whatever the logs mapping stores, check it before relying on this")
+	flag.Int64Var(&opts.timestampTo, "timestamp-to", 0, "only logs with timestamp <= this value; 0 means unbounded")
+	flag.BoolVar(&opts.dryRun, "dry-run", false, "derive and count, write nothing")
+	flag.BoolVar(&opts.verifyOnly, "verify-only", false, "skip the backfill and only report the target's counts")
+	flag.Parse()
+
+	if err := run(opts); err != nil {
+		fmt.Fprintln(os.Stderr, "indexer-backfill:", err)
+		os.Exit(1)
+	}
+}
+
+func run(opts options) error {
+	if opts.targetURL == "" {
+		return fmt.Errorf("-target-url is required")
+	}
+	if !opts.verifyOnly && opts.sourceURL == "" {
+		return fmt.Errorf("-source-url is required unless -verify-only is set")
+	}
+
+	target, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{opts.targetURL},
+		Username:  opts.targetUser,
+		Password:  os.Getenv("BACKFILL_TARGET_PASSWORD"),
+	})
+	if err != nil {
+		return fmt.Errorf("target client: %w", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if opts.verifyOnly {
+		return report(ctx, target, os.Stdout)
+	}
+
+	source, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{opts.sourceURL},
+		Username:  opts.sourceUser,
+		Password:  os.Getenv("BACKFILL_SOURCE_PASSWORD"),
+	})
+	if err != nil {
+		return fmt.Errorf("source client: %w", err)
+	}
+
+	derive, err := indexerDerivation()
+	if err != nil {
+		return err
+	}
+
+	backfiller := newBackfiller(source, target, derive, opts, os.Stdout)
+	if err := backfiller.run(ctx); err != nil {
+		return err
+	}
+
+	return report(ctx, target, os.Stdout)
+}
+
+// indexerDerivation wires the indexer's own logs processor with the same address converter
+// the node uses, so the field written here is the field the indexer writes.
+func indexerDerivation() (deriveFunc, error) {
+	converter, err := pubkeyConverter.NewBech32PubkeyConverter(addressLength)
+	if err != nil {
+		return nil, fmt.Errorf("address converter: %w", err)
+	}
+
+	marshalizer, err := marshalFactory.NewInternalMarshalizer()
+	if err != nil {
+		return nil, fmt.Errorf("marshalizer: %w", err)
+	}
+
+	hasher, err := hashingFactory.NewDefaultHasher()
+	if err != nil {
+		return nil, fmt.Errorf("hasher: %w", err)
+	}
+
+	processor, err := logsevents.NewLogsAndEventsProcessor(logsevents.ArgsLogsAndEventsProcessor{
+		PubKeyConverter: converter,
+		Marshalizer:     marshalizer,
+		Hasher:          hasher,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("logs processor: %w", err)
+	}
+
+	return newDerivation(processor, converter), nil
+}

--- a/indexer/common.go
+++ b/indexer/common.go
@@ -2358,8 +2358,20 @@ func prepareSerializedDataForATransaction(
 		return nil, nil, err
 	}
 
-	upsertScript := []byte(fmt.Sprintf(`{"script":{"source":"%s","lang": "painless", "params": %s},"upsert":%s}`,
-		transactionUpdateScript, string(params), string(marshaledTx)))
+	// The envelope is marshaled rather than formatted, so a future edit to the script that
+	// adds a quote or a newline cannot break the bulk line silently.
+	upsertScript, err := json.Marshal(map[string]interface{}{
+		"script": map[string]interface{}{
+			"source": transactionUpdateScript,
+			"lang":   "painless",
+			"params": json.RawMessage(params),
+		},
+		"upsert": json.RawMessage(marshaledTx),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return meta, upsertScript, nil
 }
 

--- a/indexer/common.go
+++ b/indexer/common.go
@@ -2326,6 +2326,10 @@ func prepareSerializedAccountBalanceHistory(address string, account *data.Accoun
 	return meta, serializedData, nil
 }
 
+// transactionUpdateScript runs when a transaction document already exists; see
+// prepareSerializedDataForATransaction for why scAddresses is written here as well.
+const transactionUpdateScript = "ctx._source.hash = params.hash; if (params.scAddresses != null) { ctx._source.scAddresses = params.scAddresses }"
+
 func prepareSerializedDataForATransaction(
 	tx *data.Transaction,
 	index string,
@@ -2341,7 +2345,21 @@ func prepareSerializedDataForATransaction(
 	meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s" } }%s`, index, tx.Hash, "\n"))
 	log.Trace("indexer tx:", "meta", string(meta), "marshaledTx", string(marshaledTx))
 
-	upsertScript := []byte(fmt.Sprintf(`{"script":{"source":"ctx._source.hash = params.hash","lang": "painless", "params": {"hash": "%s"}},"upsert":%s}`, tx.Hash, string(marshaledTx)))
+	// The upsert body carries the whole document, but a document that already exists only
+	// receives what the script writes. scAddresses is set here as well so a resync or an
+	// import-db replay over existing documents fills the field instead of leaving it to a
+	// separate backfill; null when the transaction has none, and the script leaves the
+	// document alone then rather than writing an empty array.
+	params, err := json.Marshal(map[string]interface{}{
+		"hash":        tx.Hash,
+		"scAddresses": tx.SCAddresses,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	upsertScript := []byte(fmt.Sprintf(`{"script":{"source":"%s","lang": "painless", "params": %s},"upsert":%s}`,
+		transactionUpdateScript, string(params), string(marshaledTx)))
 	return meta, upsertScript, nil
 }
 

--- a/indexer/common_test.go
+++ b/indexer/common_test.go
@@ -1117,3 +1117,60 @@ func Test_serializedDataForUpdateAccounts(t *testing.T) {
 		}
 	})
 }
+
+// TestPrepareSerializedDataForATransaction_WritesSmartContractAddressesOnUpdate covers the
+// half of the field that the upsert body cannot: a document that already exists receives
+// only what the script writes, so a resync or an import-db replay would leave scAddresses
+// off every existing document unless the script sets it. The payload is parsed rather
+// than matched as text, because a quoting mistake inside the script source is exactly
+// the kind of defect a substring check reads as a pass.
+func TestPrepareSerializedDataForATransaction_WritesSmartContractAddressesOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	decode := func(t *testing.T, payload []byte) map[string]interface{} {
+		t.Helper()
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(payload, &body), "the bulk item must be valid JSON")
+
+		return body
+	}
+
+	t.Run("with contracts", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &data.Transaction{Hash: "h1", SCAddresses: []string{"klv1a", "klv1b"}}
+		_, payload, err := prepareSerializedDataForATransaction(tx, txIndex)
+		require.NoError(t, err)
+
+		body := decode(t, payload)
+		script := body["script"].(map[string]interface{})
+		params := script["params"].(map[string]interface{})
+
+		require.Equal(t, []interface{}{"klv1a", "klv1b"}, params["scAddresses"],
+			"an existing document gets the field through the script parameters")
+		require.Contains(t, script["source"], "ctx._source.scAddresses = params.scAddresses")
+		require.Contains(t, script["source"], "params.scAddresses != null",
+			"the script must guard the write, so a transaction without contracts never writes an empty array")
+		require.Equal(t, "h1", params["hash"], "the hash write the script always did must survive")
+
+		upsert := body["upsert"].(map[string]interface{})
+		require.Equal(t, []interface{}{"klv1a", "klv1b"}, upsert["scAddresses"],
+			"a new document gets the field through the upsert body")
+	})
+
+	t.Run("without contracts", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &data.Transaction{Hash: "h2"}
+		_, payload, err := prepareSerializedDataForATransaction(tx, txIndex)
+		require.NoError(t, err)
+
+		body := decode(t, payload)
+		params := body["script"].(map[string]interface{})["params"].(map[string]interface{})
+		require.Nil(t, params["scAddresses"], "null, so the guarded script leaves the document alone")
+
+		upsert := body["upsert"].(map[string]interface{})
+		require.NotContains(t, upsert, "scAddresses", "omitempty keeps the field off a document without contracts")
+	})
+}

--- a/indexer/data/transaction.go
+++ b/indexer/data/transaction.go
@@ -32,6 +32,12 @@ type Transaction struct {
 	Logs          *Logs                    `json:"logs,omitempty"`
 	HasLogs       bool                     `json:"hasLogs,omitempty"`
 	HasOperations bool                     `json:"hasOperations,omitempty"`
+	// SCAddresses lists every smart contract that took part in the transaction: the
+	// contract it invoked and every contract that emitted an event while it ran, distinct,
+	// bech32 encoded and sorted. It is derived from the transaction's logs, so a contract
+	// that ran without emitting an event is not listed. Nil when nothing qualifies, and
+	// then absent from the document.
+	SCAddresses []string `json:"scAddresses,omitempty"`
 }
 
 // Logs represents logs with changed fields

--- a/indexer/elasticClient.go
+++ b/indexer/elasticClient.go
@@ -77,13 +77,16 @@ func NewElasticClient(cfg elasticsearch.Config) (*elasticClient, error) {
 	return ec, nil
 }
 
-// CheckAndCreateTemplate creates an index template if it does not already exist
+// CheckAndCreateTemplate creates an index template if it does not already exist. The
+// request reads a copy of the buffer's bytes, never the buffer itself: start-up hands the
+// same buffer to this and to PutTemplate, and a buffer read to its end by the first
+// request has nothing left for the second.
 func (ec *elasticClient) CheckAndCreateTemplate(templateName string, template *bytes.Buffer) error {
 	if ec.templateExists(templateName) {
 		return nil
 	}
 
-	return ec.createIndexTemplate(templateName, template)
+	return ec.createIndexTemplate(templateName, bytes.NewReader(template.Bytes()))
 }
 
 // CheckAndCreatePolicy creates a new index policy if it does not already exist
@@ -148,19 +151,7 @@ func (ec *elasticClient) CheckFieldMapping(index string, properties templates.Ob
 		return nil, fmt.Errorf("%w: index %s: %w", ErrCouldNotUpdateMapping, index, err)
 	}
 
-	mapped, err := mappedFields(live, wanted)
-	if err != nil {
-		return nil, err
-	}
-
-	missing := make([]string, 0, len(names))
-	for _, name := range names {
-		if _, ok := mapped[name]; !ok {
-			missing = append(missing, name)
-		}
-	}
-
-	return missing, nil
+	return missingFields(live, wanted, names)
 }
 
 // liveFieldMappings is the shape of a field mapping response: concrete index, then field,
@@ -171,20 +162,40 @@ type liveFieldMappings map[string]struct {
 	} `json:"mappings"`
 }
 
-// mappedFields returns the wanted properties the live mapping already carries, and refuses
-// the first one it carries with another type.
-func mappedFields(live liveFieldMappings, wanted map[string]string) (map[string]struct{}, error) {
-	mapped := make(map[string]struct{})
-	for concreteIndex, indexMappings := range live {
-		for name, field := range indexMappings.Mappings {
-			if err := checkFieldType(concreteIndex, name, field.Mapping, wanted[name]); err != nil {
-				return nil, err
-			}
-			mapped[name] = struct{}{}
+// missingFields returns, sorted, every wanted property that at least one concrete index
+// behind the queried name does not map. An alias answers with one entry per backing index,
+// and a property present on one of them says nothing about the others, so a PUT is due as
+// long as any index lacks it; the PUT on the alias reaches all of them. A field entry with
+// an empty mapping object is not mapped either. A property carried with another type is an
+// error, since no PUT can change it.
+func missingFields(live liveFieldMappings, wanted map[string]string, names []string) ([]string, error) {
+	missing := make(map[string]struct{}, len(names))
+	if len(live) == 0 {
+		for _, name := range names {
+			missing[name] = struct{}{}
 		}
 	}
 
-	return mapped, nil
+	for concreteIndex, indexMappings := range live {
+		for _, name := range names {
+			field, ok := indexMappings.Mappings[name]
+			if !ok || len(field.Mapping) == 0 {
+				missing[name] = struct{}{}
+				continue
+			}
+			if err := checkFieldType(concreteIndex, name, field.Mapping, wanted[name]); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	sorted := make([]string, 0, len(missing))
+	for name := range missing {
+		sorted = append(sorted, name)
+	}
+	sort.Strings(sorted)
+
+	return sorted, nil
 }
 
 func checkFieldType(index string, name string, mapping map[string]map[string]interface{}, want string) error {
@@ -240,11 +251,18 @@ func (ec *elasticClient) CheckAndUpdateMapping(index string, properties template
 }
 
 // PutTemplate writes an index template whether or not one exists under that name, so a
-// template that gained a property reaches clusters that already carry the old one. A
-// template only shapes indices created after it, which is why the live index is handled
-// by CheckAndUpdateMapping separately.
-func (ec *elasticClient) PutTemplate(templateName string, template *bytes.Buffer) error {
-	res, err := ec.es.Indices.PutTemplate(templateName, template)
+// template that gained a property reaches clusters that already carry the old one. It takes
+// bytes rather than a reader, so no call can consume state its caller still needs, and it
+// refuses an empty body rather than writing it: on a fresh cluster this runs right after
+// the create step, and an empty template would replace the one just installed. A template
+// only shapes indices created after it, which is why the live index is handled by
+// CheckAndUpdateMapping separately.
+func (ec *elasticClient) PutTemplate(templateName string, template []byte) error {
+	if len(template) == 0 {
+		return fmt.Errorf("%w: template %s: empty body", ErrCouldNotCreateTemplate, templateName)
+	}
+
+	res, err := ec.es.Indices.PutTemplate(templateName, bytes.NewReader(template))
 	if err != nil {
 		return err
 	}

--- a/indexer/elasticClient.go
+++ b/indexer/elasticClient.go
@@ -575,7 +575,7 @@ func (ec *elasticClient) aliasExists(alias string) bool {
 func (ec *elasticClient) createIndex(index string) error {
 	res, err := ec.es.Indices.Create(index)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: index %s: %w", ErrCouldNotCreateIndex, index, err)
 	}
 
 	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
@@ -632,7 +632,7 @@ func (ec *elasticClient) createPolicy(policyName string, policy *bytes.Buffer) e
 func (ec *elasticClient) createIndexTemplate(templateName string, template io.Reader) error {
 	res, err := ec.es.Indices.PutTemplate(templateName, template)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: template %s: %w", ErrCouldNotCreateTemplate, templateName, err)
 	}
 
 	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
@@ -648,7 +648,7 @@ func (ec *elasticClient) createIndexTemplate(templateName string, template io.Re
 func (ec *elasticClient) createAlias(alias string, index string) error {
 	res, err := ec.es.Indices.PutAlias([]string{index}, alias)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: alias %s on %s: %w", ErrCouldNotCreateAlias, alias, index, err)
 	}
 
 	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {

--- a/indexer/elasticClient.go
+++ b/indexer/elasticClient.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -112,16 +113,119 @@ func (ec *elasticClient) CheckAndCreateAlias(alias string, indexName string) err
 	return ec.createAlias(alias, indexName)
 }
 
-// CheckAndUpdateMapping adds properties to the mapping of an existing index. Templates only
-// apply when an index is created, so a property added to a template later never reaches an
-// index that already exists; the first document carrying the field would then type it
+// CheckFieldMapping compares the properties with the live mapping of index and returns the
+// names of the properties the index does not map yet. A property the index maps with a
+// different type is an error: Elasticsearch cannot change a field's type in place, so the
+// only way out is a reindex, and a start-up that carried on would write into a mapping the
+// filter on that field is not written for.
+func (ec *elasticClient) CheckFieldMapping(index string, properties templates.Object) ([]string, error) {
+	wanted, err := mappingTypes(properties)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(wanted))
+	for name := range wanted {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	res, err := ec.es.Indices.GetFieldMapping(names, ec.es.Indices.GetFieldMapping.WithIndex(index))
+	if err != nil {
+		return nil, err
+	}
+
+	defer closeResponseBody(res, "elasticClient.CheckFieldMapping")
+
+	if res.IsError() {
+		return nil, fmt.Errorf("%w: index %s: %s", ErrCouldNotUpdateMapping, index, res.String())
+	}
+
+	var live liveFieldMappings
+	// An empty body means nothing is mapped, which the PUT that follows is allowed to fix;
+	// anything else that fails to decode is a cluster answer this code does not understand.
+	if err := json.NewDecoder(res.Body).Decode(&live); err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%w: index %s: %w", ErrCouldNotUpdateMapping, index, err)
+	}
+
+	mapped, err := mappedFields(live, wanted)
+	if err != nil {
+		return nil, err
+	}
+
+	missing := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, ok := mapped[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+
+	return missing, nil
+}
+
+// liveFieldMappings is the shape of a field mapping response: concrete index, then field,
+// then the leaf carrying the type.
+type liveFieldMappings map[string]struct {
+	Mappings map[string]struct {
+		Mapping map[string]map[string]interface{} `json:"mapping"`
+	} `json:"mappings"`
+}
+
+// mappedFields returns the wanted properties the live mapping already carries, and refuses
+// the first one it carries with another type.
+func mappedFields(live liveFieldMappings, wanted map[string]string) (map[string]struct{}, error) {
+	mapped := make(map[string]struct{})
+	for concreteIndex, indexMappings := range live {
+		for name, field := range indexMappings.Mappings {
+			if err := checkFieldType(concreteIndex, name, field.Mapping, wanted[name]); err != nil {
+				return nil, err
+			}
+			mapped[name] = struct{}{}
+		}
+	}
+
+	return mapped, nil
+}
+
+func checkFieldType(index string, name string, mapping map[string]map[string]interface{}, want string) error {
+	for _, leaf := range mapping {
+		if got, _ := leaf["type"].(string); got != want {
+			return fmt.Errorf("%w: index %s maps %s as %q, this build needs %q; the index has to be reindexed",
+				ErrCouldNotUpdateMapping, index, name, got, want)
+		}
+	}
+
+	return nil
+}
+
+// CheckAndUpdateMapping adds the properties an index does not map yet. Templates only apply
+// when an index is created, so a property added to a template later never reaches an index
+// that already exists; the first document carrying the field would then type it
 // dynamically, as text with a keyword subfield, instead of the type the template names.
-// Adding a property is idempotent, so this runs on every start-up. Elasticsearch rejects a
-// change to an existing property's type, and that rejection surfaces here as an error
-// rather than being closed and forgotten, because a mapping that silently failed to apply
-// is exactly the drift this exists to prevent.
-func (ec *elasticClient) CheckAndUpdateMapping(index string, properties *bytes.Buffer) error {
-	res, err := ec.es.Indices.PutMapping([]string{index}, properties)
+// The live mapping is read first, so a node whose index already carries the properties
+// sends no write at all at start-up and needs no manage privilege for it; a property mapped
+// with another type surfaces as an error rather than being closed and forgotten, because a
+// mapping that silently failed to apply is exactly the drift this exists to prevent.
+func (ec *elasticClient) CheckAndUpdateMapping(index string, properties templates.Object) error {
+	missing, err := ec.CheckFieldMapping(index, properties)
+	if err != nil {
+		return err
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	all, ok := properties["properties"].(templates.Object)
+	if !ok {
+		return fmt.Errorf("%w: properties must be an object under \"properties\"", ErrCouldNotUpdateMapping)
+	}
+	subset := templates.Object{}
+	for _, name := range missing {
+		subset[name] = all[name]
+	}
+	body := templates.Object{"properties": subset}
+
+	res, err := ec.es.Indices.PutMapping([]string{index}, body.ToBuffer())
 	if err != nil {
 		return err
 	}
@@ -133,6 +237,48 @@ func (ec *elasticClient) CheckAndUpdateMapping(index string, properties *bytes.B
 	}
 
 	return nil
+}
+
+// PutTemplate writes an index template whether or not one exists under that name, so a
+// template that gained a property reaches clusters that already carry the old one. A
+// template only shapes indices created after it, which is why the live index is handled
+// by CheckAndUpdateMapping separately.
+func (ec *elasticClient) PutTemplate(templateName string, template *bytes.Buffer) error {
+	res, err := ec.es.Indices.PutTemplate(templateName, template)
+	if err != nil {
+		return err
+	}
+
+	defer closeResponseBody(res, "elasticClient.PutTemplate")
+
+	if res.IsError() {
+		return fmt.Errorf("%w: template %s: %s", ErrCouldNotCreateTemplate, templateName, res.String())
+	}
+
+	return nil
+}
+
+// mappingTypes flattens {"properties": {name: {"type": t}}} into name -> t.
+func mappingTypes(properties templates.Object) (map[string]string, error) {
+	all, ok := properties["properties"].(templates.Object)
+	if !ok {
+		return nil, fmt.Errorf("%w: properties must be an object under \"properties\"", ErrCouldNotUpdateMapping)
+	}
+
+	types := make(map[string]string, len(all))
+	for name, raw := range all {
+		field, ok := raw.(templates.Object)
+		if !ok {
+			return nil, fmt.Errorf("%w: property %s must be an object", ErrCouldNotUpdateMapping, name)
+		}
+		fieldType, ok := field["type"].(string)
+		if !ok {
+			return nil, fmt.Errorf("%w: property %s must name a type", ErrCouldNotUpdateMapping, name)
+		}
+		types[name] = fieldType
+	}
+
+	return types, nil
 }
 
 // DoRequest will do a request to elastic server

--- a/indexer/elasticClient.go
+++ b/indexer/elasticClient.go
@@ -112,6 +112,29 @@ func (ec *elasticClient) CheckAndCreateAlias(alias string, indexName string) err
 	return ec.createAlias(alias, indexName)
 }
 
+// CheckAndUpdateMapping adds properties to the mapping of an existing index. Templates only
+// apply when an index is created, so a property added to a template later never reaches an
+// index that already exists; the first document carrying the field would then type it
+// dynamically, as text with a keyword subfield, instead of the type the template names.
+// Adding a property is idempotent, so this runs on every start-up. Elasticsearch rejects a
+// change to an existing property's type, and that rejection surfaces here as an error
+// rather than being closed and forgotten, because a mapping that silently failed to apply
+// is exactly the drift this exists to prevent.
+func (ec *elasticClient) CheckAndUpdateMapping(index string, properties *bytes.Buffer) error {
+	res, err := ec.es.Indices.PutMapping([]string{index}, properties)
+	if err != nil {
+		return err
+	}
+
+	defer closeResponseBody(res, "elasticClient.CheckAndUpdateMapping")
+
+	if res.IsError() {
+		return fmt.Errorf("%w: index %s: %s", ErrCouldNotUpdateMapping, index, res.String())
+	}
+
+	return nil
+}
+
 // DoRequest will do a request to elastic server
 func (ec *elasticClient) DoRequest(req *esapi.IndexRequest) error {
 	res, err := req.Do(context.Background(), ec.es)

--- a/indexer/elasticClient.go
+++ b/indexer/elasticClient.go
@@ -574,11 +574,10 @@ func (ec *elasticClient) aliasExists(alias string) bool {
 // wanted, and the response handler treats it as success.
 func (ec *elasticClient) createIndex(index string) error {
 	res, err := ec.es.Indices.Create(index)
-	if err != nil {
-		return fmt.Errorf("%w: index %s: %w", ErrCouldNotCreateIndex, index, err)
+	if err == nil {
+		err = parseResponse(res, nil, elasticDefaultErrorResponseHandler)
 	}
-
-	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
+	if err != nil {
 		return fmt.Errorf("%w: index %s: %w", ErrCouldNotCreateIndex, index, err)
 	}
 
@@ -631,11 +630,10 @@ func (ec *elasticClient) createPolicy(policyName string, policy *bytes.Buffer) e
 // nothing later would say why.
 func (ec *elasticClient) createIndexTemplate(templateName string, template io.Reader) error {
 	res, err := ec.es.Indices.PutTemplate(templateName, template)
-	if err != nil {
-		return fmt.Errorf("%w: template %s: %w", ErrCouldNotCreateTemplate, templateName, err)
+	if err == nil {
+		err = parseResponse(res, nil, elasticDefaultErrorResponseHandler)
 	}
-
-	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
+	if err != nil {
 		return fmt.Errorf("%w: template %s: %w", ErrCouldNotCreateTemplate, templateName, err)
 	}
 
@@ -647,11 +645,10 @@ func (ec *elasticClient) createIndexTemplate(templateName string, template io.Re
 // response handler.
 func (ec *elasticClient) createAlias(alias string, index string) error {
 	res, err := ec.es.Indices.PutAlias([]string{index}, alias)
-	if err != nil {
-		return fmt.Errorf("%w: alias %s on %s: %w", ErrCouldNotCreateAlias, alias, index, err)
+	if err == nil {
+		err = parseResponse(res, nil, elasticDefaultErrorResponseHandler)
 	}
-
-	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
+	if err != nil {
 		return fmt.Errorf("%w: alias %s on %s: %w", ErrCouldNotCreateAlias, alias, index, err)
 	}
 

--- a/indexer/elasticClient.go
+++ b/indexer/elasticClient.go
@@ -567,14 +567,20 @@ func (ec *elasticClient) aliasExists(alias string) bool {
 	return exists(response, nil)
 }
 
-// CreateIndex creates an elasticsearch index
+// createIndex creates an elasticsearch index. A refusal is an error: the first document
+// would otherwise create the index with a dynamic mapping and nothing would say why. An
+// index that exists by the time the create arrives, because the existence check answered
+// false on a transport error or another node created it first, is the outcome this call
+// wanted, and the response handler treats it as success.
 func (ec *elasticClient) createIndex(index string) error {
 	res, err := ec.es.Indices.Create(index)
 	if err != nil {
 		return err
 	}
 
-	defer closeResponseBody(res, "elasticClient.createIndex")
+	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
+		return fmt.Errorf("%w: index %s: %w", ErrCouldNotCreateIndex, index, err)
+	}
 
 	return nil
 }
@@ -620,26 +626,34 @@ func (ec *elasticClient) createPolicy(policyName string, policy *bytes.Buffer) e
 	return nil
 }
 
-// CreateIndexTemplate creates an elasticsearch index template
+// createIndexTemplate creates an elasticsearch index template. A template the cluster
+// refuses is an error: indices created without it would type every field dynamically, and
+// nothing later would say why.
 func (ec *elasticClient) createIndexTemplate(templateName string, template io.Reader) error {
 	res, err := ec.es.Indices.PutTemplate(templateName, template)
 	if err != nil {
 		return err
 	}
 
-	defer closeResponseBody(res, "elasticClient.createIndexTemplate")
+	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
+		return fmt.Errorf("%w: template %s: %w", ErrCouldNotCreateTemplate, templateName, err)
+	}
 
 	return nil
 }
 
-// CreateAlias creates an index alias
+// createAlias creates an index alias. A refusal is an error, since every write and read
+// goes through the alias; an alias that already exists is treated as success by the
+// response handler.
 func (ec *elasticClient) createAlias(alias string, index string) error {
 	res, err := ec.es.Indices.PutAlias([]string{index}, alias)
 	if err != nil {
 		return err
 	}
 
-	defer closeResponseBody(res, "elasticClient.createAlias")
+	if err := parseResponse(res, nil, elasticDefaultErrorResponseHandler); err != nil {
+		return fmt.Errorf("%w: alias %s on %s: %w", ErrCouldNotCreateAlias, alias, index, err)
+	}
 
 	return nil
 }

--- a/indexer/elasticClientMapping_test.go
+++ b/indexer/elasticClientMapping_test.go
@@ -18,11 +18,13 @@ import (
 // can assert the read happened before the write and that the write carries the property.
 // The product header is what the client checks before trusting a server.
 type mappingCluster struct {
-	mu        sync.Mutex
-	fieldType string // "" means the field is not mapped
-	rejectPut bool
-	requests  []string
-	putBody   []byte
+	mu             sync.Mutex
+	fieldType      string // "" means the field is not mapped
+	secondIndex    string // "" means one backing index; "unmapped" adds one without the field; "empty" adds one with an empty mapping object
+	rejectPut      bool
+	requests       []string
+	putBody        []byte
+	templateBodies [][]byte // every body written to the transactions template, in order
 }
 
 func (c *mappingCluster) handler() http.Handler {
@@ -36,11 +38,18 @@ func (c *mappingCluster) handler() http.Handler {
 
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/"+txIndex+"/_mapping/field/scAddresses":
-			if c.fieldType == "" {
-				_, _ = io.WriteString(w, `{"transactions-000001":{"mappings":{}}}`)
-				return
+			first := `"transactions-000001":{"mappings":{}}`
+			if c.fieldType != "" {
+				first = `"transactions-000001":{"mappings":{"scAddresses":{"full_name":"scAddresses","mapping":{"scAddresses":{"type":"` + c.fieldType + `"}}}}}`
 			}
-			_, _ = io.WriteString(w, `{"transactions-000001":{"mappings":{"scAddresses":{"full_name":"scAddresses","mapping":{"scAddresses":{"type":"`+c.fieldType+`"}}}}}}`)
+			switch c.secondIndex {
+			case "unmapped":
+				_, _ = io.WriteString(w, `{`+first+`,"transactions-000002":{"mappings":{}}}`)
+			case "empty":
+				_, _ = io.WriteString(w, `{`+first+`,"transactions-000002":{"mappings":{"scAddresses":{"full_name":"scAddresses","mapping":{}}}}}`)
+			default:
+				_, _ = io.WriteString(w, `{`+first+`}`)
+			}
 		case r.Method == http.MethodPut && r.URL.Path == "/"+txIndex+"/_mapping":
 			c.putBody, _ = io.ReadAll(r.Body)
 			if c.rejectPut {
@@ -50,6 +59,8 @@ func (c *mappingCluster) handler() http.Handler {
 			}
 			_, _ = io.WriteString(w, `{"acknowledged":true}`)
 		case r.Method == http.MethodPut && r.URL.Path == "/_template/"+txIndex:
+			body, _ := io.ReadAll(r.Body)
+			c.templateBodies = append(c.templateBodies, body)
 			if c.rejectPut {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad template"}}`)
@@ -68,6 +79,20 @@ func (c *mappingCluster) seen() []string {
 	defer c.mu.Unlock()
 
 	return append([]string(nil), c.requests...)
+}
+
+func (c *mappingCluster) mappingPutBody() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.putBody
+}
+
+func (c *mappingCluster) templatesWritten() [][]byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([][]byte(nil), c.templateBodies...)
 }
 
 func newMappingClient(t *testing.T, url string) *elasticClient {
@@ -98,7 +123,7 @@ func TestCheckAndUpdateMapping(t *testing.T) {
 
 		require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses", "PUT /transactions/_mapping"}, cluster.seen(),
 			"the live mapping is read first, then the missing property is written")
-		require.True(t, bytes.Contains(cluster.putBody, []byte(`"scAddresses":{"type":"keyword"}`)), "body: %s", cluster.putBody)
+		require.True(t, bytes.Contains(cluster.mappingPutBody(), []byte(`"scAddresses":{"type":"keyword"}`)), "body: %s", cluster.mappingPutBody())
 	})
 
 	t.Run("an index that already maps the property gets no write", func(t *testing.T) {
@@ -148,6 +173,27 @@ func TestCheckAndUpdateMapping(t *testing.T) {
 	})
 }
 
+// TestCheckAndUpdateMapping_WritesWhenAnyBackingIndexLacksTheField covers an alias with
+// several indices behind it: the field mapped on one of them says nothing about the others,
+// and an entry with an empty mapping object is not a mapping.
+func TestCheckAndUpdateMapping_WritesWhenAnyBackingIndexLacksTheField(t *testing.T) {
+	t.Parallel()
+
+	for _, second := range []string{"unmapped", "empty"} {
+		t.Run(second, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := &mappingCluster{fieldType: "keyword", secondIndex: second}
+			server := httptest.NewServer(cluster.handler())
+			defer server.Close()
+
+			require.NoError(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
+			require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses", "PUT /transactions/_mapping"}, cluster.seen(),
+				"one index carrying the field must not suppress the write for the one that lacks it")
+		})
+	}
+}
+
 func TestCheckFieldMapping_ReportsWhatIsMissing(t *testing.T) {
 	t.Parallel()
 
@@ -161,6 +207,55 @@ func TestCheckFieldMapping_ReportsWhatIsMissing(t *testing.T) {
 	require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses"}, cluster.seen(), "a check reads and never writes")
 }
 
+// TestCheckAndCreateTemplate_LeavesTheBufferForTheNextRequest pins the contract the start-up
+// path relies on: the create step and the rewrite share one buffer out of the templates map,
+// so the create request must read a copy of it and leave the buffer intact for the rewrite.
+func TestCheckAndCreateTemplate_LeavesTheBufferForTheNextRequest(t *testing.T) {
+	t.Parallel()
+
+	cluster := &mappingCluster{}
+	server := httptest.NewServer(cluster.handler())
+	defer server.Close()
+
+	client := newMappingClient(t, server.URL)
+	template := addedProperties.ToBuffer()
+	want := append([]byte(nil), template.Bytes()...)
+
+	require.NoError(t, client.CheckAndCreateTemplate(txIndex, template))
+	require.Equal(t, want, template.Bytes(), "the create request must not consume the caller's buffer")
+	require.NoError(t, client.PutTemplate(txIndex, template.Bytes()))
+
+	require.Equal(t, []string{"HEAD /_template/transactions", "PUT /_template/transactions", "PUT /_template/transactions"}, cluster.seen())
+	require.Equal(t, [][]byte{want, want}, cluster.templatesWritten(), "both writes must carry the full template")
+}
+
+// TestNewElasticProcessor_OnAFreshClusterWritesTheTransactionsTemplateTwiceInFull is the
+// start-up on a cluster that has nothing yet: every existence check answers 404, so the
+// create step sends the templates, and the rewrite that follows must send the transactions
+// template again in full, not the empty remainder of a buffer the create request read. On a
+// cluster that already carries the template the create step never reads the buffer, which
+// is why only a fresh cluster shows this.
+func TestNewElasticProcessor_OnAFreshClusterWritesTheTransactionsTemplateTwiceInFull(t *testing.T) {
+	cluster := &mappingCluster{}
+	server := httptest.NewServer(cluster.handler())
+	defer server.Close()
+
+	indexTemplates, indexPolicies, err := GetElasticTemplatesAndPolicies(false)
+	require.NoError(t, err)
+	want := append([]byte(nil), indexTemplates[txIndex].Bytes()...)
+
+	args := createMockElasticProcessorArgs()
+	args.DBClient = newMappingClient(t, server.URL)
+	args.IndexTemplates, args.IndexPolicies = indexTemplates, indexPolicies
+
+	_, err = NewElasticProcessor(args)
+	require.NoError(t, err)
+
+	require.Contains(t, cluster.seen(), "HEAD /_template/transactions", "the premise: the create step checked, found nothing, and wrote")
+	require.Equal(t, [][]byte{want, want}, cluster.templatesWritten(), "the create step and the rewrite must both carry the full template")
+	require.Equal(t, want, indexTemplates[txIndex].Bytes(), "start-up must leave the shared buffer intact")
+}
+
 func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {
 	t.Parallel()
 
@@ -171,7 +266,7 @@ func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {
 		server := httptest.NewServer(cluster.handler())
 		defer server.Close()
 
-		require.NoError(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer()))
+		require.NoError(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer().Bytes()))
 		require.Equal(t, []string{"PUT /_template/transactions"}, cluster.seen(), "no existence check may short-circuit the write")
 	})
 
@@ -182,6 +277,17 @@ func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {
 		server := httptest.NewServer(cluster.handler())
 		defer server.Close()
 
-		require.ErrorIs(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer()), ErrCouldNotCreateTemplate)
+		require.ErrorIs(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer().Bytes()), ErrCouldNotCreateTemplate)
+	})
+
+	t.Run("an empty body is refused before it reaches the cluster", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		require.ErrorIs(t, newMappingClient(t, server.URL).PutTemplate(txIndex, nil), ErrCouldNotCreateTemplate)
+		require.Empty(t, cluster.seen(), "a consumed buffer must not turn into an empty template on the cluster")
 	})
 }

--- a/indexer/elasticClientMapping_test.go
+++ b/indexer/elasticClientMapping_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -13,15 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mappingCluster is the slice of Elasticsearch the mapping bootstrap talks to: the field
-// mapping read and the mapping write. It records what it was asked, in order, so a test
-// can assert the read happened before the write and that the write carries the property.
-// The product header is what the client checks before trusting a server.
+// mappingCluster is the slice of Elasticsearch start-up talks to: the existence checks,
+// which all answer 404, the template, index and alias creates, and the field mapping read
+// and write. It records what it was asked, in order, so a test can assert the read happened
+// before the write and that the write carries the property. The product header is what the
+// client checks before trusting a server.
 type mappingCluster struct {
 	mu             sync.Mutex
 	fieldType      string // "" means the field is not mapped
 	secondIndex    string // "" means one backing index; "unmapped" adds one without the field; "empty" adds one with an empty mapping object
-	rejectPut      bool
+	rejectPut      bool   // every write is refused with 400
+	indexTaken     bool   // an index create answers that the index already exists
 	requests       []string
 	putBody        []byte
 	templateBodies [][]byte // every body written to the transactions template, in order
@@ -58,12 +61,33 @@ func (c *mappingCluster) handler() http.Handler {
 				return
 			}
 			_, _ = io.WriteString(w, `{"acknowledged":true}`)
-		case r.Method == http.MethodPut && r.URL.Path == "/_template/"+txIndex:
-			body, _ := io.ReadAll(r.Body)
-			c.templateBodies = append(c.templateBodies, body)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/_template/"):
+			if r.URL.Path == "/_template/"+txIndex {
+				body, _ := io.ReadAll(r.Body)
+				c.templateBodies = append(c.templateBodies, body)
+			}
 			if c.rejectPut {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad template"}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/_alias"):
+			if c.rejectPut {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad alias"}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "-000001"):
+			if c.indexTaken {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":{"type":"resource_already_exists_exception","reason":"index already exists"}}`)
+				return
+			}
+			if c.rejectPut {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad index"}}`)
 				return
 			}
 			_, _ = io.WriteString(w, `{"acknowledged":true}`)
@@ -254,6 +278,61 @@ func TestNewElasticProcessor_OnAFreshClusterWritesTheTransactionsTemplateTwiceIn
 	require.Contains(t, cluster.seen(), "HEAD /_template/transactions", "the premise: the create step checked, found nothing, and wrote")
 	require.Equal(t, [][]byte{want, want}, cluster.templatesWritten(), "the create step and the rewrite must both carry the full template")
 	require.Equal(t, want, indexTemplates[txIndex].Bytes(), "start-up must leave the shared buffer intact")
+}
+
+// TestCreateSteps_ARefusalIsAnError pins that a template, index or alias the cluster refuses
+// stops start-up instead of being closed and forgotten, and that an index which exists by
+// the time the create arrives is not an error, since that is what the call wanted.
+func TestCreateSteps_ARefusalIsAnError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("template", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{rejectPut: true}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		err := newMappingClient(t, server.URL).CheckAndCreateTemplate(txIndex, addedProperties.ToBuffer())
+		require.ErrorIs(t, err, ErrCouldNotCreateTemplate)
+		require.ErrorContains(t, err, "bad template", "the cluster's reason must reach the operator")
+	})
+
+	t.Run("index", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{rejectPut: true}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		err := newMappingClient(t, server.URL).CheckAndCreateIndex("transactions-000001")
+		require.ErrorIs(t, err, ErrCouldNotCreateIndex)
+		require.ErrorContains(t, err, "bad index")
+	})
+
+	t.Run("index that exists by the time the create arrives", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{indexTaken: true}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		require.NoError(t, newMappingClient(t, server.URL).CheckAndCreateIndex("transactions-000001"))
+		require.Equal(t, []string{"HEAD /transactions-000001", "PUT /transactions-000001"}, cluster.seen(),
+			"the premise: the existence check said no, the create was sent, the cluster said it exists")
+	})
+
+	t.Run("alias", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{rejectPut: true}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		err := newMappingClient(t, server.URL).CheckAndCreateAlias(txIndex, "transactions-000001")
+		require.ErrorIs(t, err, ErrCouldNotCreateAlias)
+		require.ErrorContains(t, err, "bad alias")
+	})
 }
 
 func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {

--- a/indexer/elasticClientMapping_test.go
+++ b/indexer/elasticClientMapping_test.go
@@ -1,0 +1,87 @@
+package indexer
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/klever-io/klever-go/indexer/templates"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckAndUpdateMapping drives the mapping update against a fake cluster, because the
+// one thing it must never do is report success for a mapping the cluster rejected: that is
+// the silent drift the method exists to prevent. The product header is what the client
+// checks before trusting a server.
+func TestCheckAndUpdateMapping(t *testing.T) {
+	t.Parallel()
+
+	newServer := func(status int, body string, seen *[]byte, path *string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Elastic-Product", "Elasticsearch")
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/" {
+				_, _ = io.WriteString(w, `{"version":{"number":"8.4.0"},"tagline":"You Know, for Search"}`)
+				return
+			}
+			*path = r.Method + " " + r.URL.Path
+			*seen, _ = io.ReadAll(r.Body)
+			w.WriteHeader(status)
+			_, _ = io.WriteString(w, body)
+		}))
+	}
+
+	properties := templates.Object{"properties": templates.TransactionsAddedProperties}
+
+	t.Run("puts the properties on the index", func(t *testing.T) {
+		t.Parallel()
+
+		var seen []byte
+		var path string
+		server := newServer(http.StatusOK, `{"acknowledged":true}`, &seen, &path)
+		defer server.Close()
+
+		ec, err := NewElasticClient(elasticsearch.Config{Addresses: []string{server.URL}})
+		require.NoError(t, err)
+
+		require.NoError(t, ec.CheckAndUpdateMapping(txIndex, properties.ToBuffer()))
+		require.Equal(t, "PUT /"+txIndex+"/_mapping", path)
+		require.True(t, bytes.Contains(seen, []byte(`"scAddresses":{"type":"keyword"}`)), "body: %s", seen)
+	})
+
+	t.Run("a rejected mapping is an error, not a closed response", func(t *testing.T) {
+		t.Parallel()
+
+		var seen []byte
+		var path string
+		server := newServer(http.StatusBadRequest,
+			`{"error":{"type":"illegal_argument_exception","reason":"mapper [scAddresses] cannot be changed from type [text] to [keyword]"}}`,
+			&seen, &path)
+		defer server.Close()
+
+		ec, err := NewElasticClient(elasticsearch.Config{Addresses: []string{server.URL}})
+		require.NoError(t, err)
+
+		err = ec.CheckAndUpdateMapping(txIndex, properties.ToBuffer())
+		require.ErrorIs(t, err, ErrCouldNotUpdateMapping)
+		require.ErrorContains(t, err, "cannot be changed from type [text] to [keyword]",
+			"the cluster's reason must reach the operator")
+	})
+
+	t.Run("an unreachable cluster is an error", func(t *testing.T) {
+		t.Parallel()
+
+		var seen []byte
+		var path string
+		server := newServer(http.StatusOK, `{}`, &seen, &path)
+		server.Close()
+
+		ec, err := NewElasticClient(elasticsearch.Config{Addresses: []string{server.URL}})
+		require.NoError(t, err)
+
+		require.Error(t, ec.CheckAndUpdateMapping(txIndex, properties.ToBuffer()))
+	})
+}

--- a/indexer/elasticClientMapping_test.go
+++ b/indexer/elasticClientMapping_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/elastic/go-elasticsearch/v8"
@@ -12,76 +13,175 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCheckAndUpdateMapping drives the mapping update against a fake cluster, because the
-// one thing it must never do is report success for a mapping the cluster rejected: that is
-// the silent drift the method exists to prevent. The product header is what the client
-// checks before trusting a server.
+// mappingCluster is the slice of Elasticsearch the mapping bootstrap talks to: the field
+// mapping read and the mapping write. It records what it was asked, in order, so a test
+// can assert the read happened before the write and that the write carries the property.
+// The product header is what the client checks before trusting a server.
+type mappingCluster struct {
+	mu        sync.Mutex
+	fieldType string // "" means the field is not mapped
+	rejectPut bool
+	requests  []string
+	putBody   []byte
+}
+
+func (c *mappingCluster) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		w.Header().Set("Content-Type", "application/json")
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.requests = append(c.requests, r.Method+" "+r.URL.Path)
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/"+txIndex+"/_mapping/field/scAddresses":
+			if c.fieldType == "" {
+				_, _ = io.WriteString(w, `{"transactions-000001":{"mappings":{}}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"transactions-000001":{"mappings":{"scAddresses":{"full_name":"scAddresses","mapping":{"scAddresses":{"type":"`+c.fieldType+`"}}}}}}`)
+		case r.Method == http.MethodPut && r.URL.Path == "/"+txIndex+"/_mapping":
+			c.putBody, _ = io.ReadAll(r.Body)
+			if c.rejectPut {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"mapper [scAddresses] cannot be changed"}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		case r.Method == http.MethodPut && r.URL.Path == "/_template/"+txIndex:
+			if c.rejectPut {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad template"}}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"error":{"type":"resource_not_found_exception"}}`)
+		}
+	})
+}
+
+func (c *mappingCluster) seen() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([]string(nil), c.requests...)
+}
+
+func newMappingClient(t *testing.T, url string) *elasticClient {
+	t.Helper()
+
+	ec, err := NewElasticClient(elasticsearch.Config{Addresses: []string{url}})
+	require.NoError(t, err)
+
+	return ec
+}
+
+var addedProperties = templates.Object{"properties": templates.TransactionsAddedProperties}
+
+// TestCheckAndUpdateMapping covers the three states a live index can be in and the one
+// thing the bootstrap must never do: report success for a mapping the cluster rejected,
+// or write when nothing is missing.
 func TestCheckAndUpdateMapping(t *testing.T) {
 	t.Parallel()
 
-	newServer := func(status int, body string, seen *[]byte, path *string) *httptest.Server {
-		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("X-Elastic-Product", "Elasticsearch")
-			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/" {
-				_, _ = io.WriteString(w, `{"version":{"number":"8.4.0"},"tagline":"You Know, for Search"}`)
-				return
-			}
-			*path = r.Method + " " + r.URL.Path
-			*seen, _ = io.ReadAll(r.Body)
-			w.WriteHeader(status)
-			_, _ = io.WriteString(w, body)
-		}))
-	}
-
-	properties := templates.Object{"properties": templates.TransactionsAddedProperties}
-
-	t.Run("puts the properties on the index", func(t *testing.T) {
+	t.Run("puts only what the index does not map yet, after reading", func(t *testing.T) {
 		t.Parallel()
 
-		var seen []byte
-		var path string
-		server := newServer(http.StatusOK, `{"acknowledged":true}`, &seen, &path)
+		cluster := &mappingCluster{}
+		server := httptest.NewServer(cluster.handler())
 		defer server.Close()
 
-		ec, err := NewElasticClient(elasticsearch.Config{Addresses: []string{server.URL}})
-		require.NoError(t, err)
+		require.NoError(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
 
-		require.NoError(t, ec.CheckAndUpdateMapping(txIndex, properties.ToBuffer()))
-		require.Equal(t, "PUT /"+txIndex+"/_mapping", path)
-		require.True(t, bytes.Contains(seen, []byte(`"scAddresses":{"type":"keyword"}`)), "body: %s", seen)
+		require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses", "PUT /transactions/_mapping"}, cluster.seen(),
+			"the live mapping is read first, then the missing property is written")
+		require.True(t, bytes.Contains(cluster.putBody, []byte(`"scAddresses":{"type":"keyword"}`)), "body: %s", cluster.putBody)
 	})
 
-	t.Run("a rejected mapping is an error, not a closed response", func(t *testing.T) {
+	t.Run("an index that already maps the property gets no write", func(t *testing.T) {
 		t.Parallel()
 
-		var seen []byte
-		var path string
-		server := newServer(http.StatusBadRequest,
-			`{"error":{"type":"illegal_argument_exception","reason":"mapper [scAddresses] cannot be changed from type [text] to [keyword]"}}`,
-			&seen, &path)
+		cluster := &mappingCluster{fieldType: "keyword"}
+		server := httptest.NewServer(cluster.handler())
 		defer server.Close()
 
-		ec, err := NewElasticClient(elasticsearch.Config{Addresses: []string{server.URL}})
-		require.NoError(t, err)
+		require.NoError(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
+		require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses"}, cluster.seen(),
+			"a node on an up-to-date index must not need the manage privilege at start-up")
+	})
 
-		err = ec.CheckAndUpdateMapping(txIndex, properties.ToBuffer())
+	t.Run("a property mapped with another type is an error, not a write", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{fieldType: "text"}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		err := newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties)
 		require.ErrorIs(t, err, ErrCouldNotUpdateMapping)
-		require.ErrorContains(t, err, "cannot be changed from type [text] to [keyword]",
-			"the cluster's reason must reach the operator")
+		require.ErrorContains(t, err, `maps scAddresses as "text"`, "the operator must learn which type the index carries")
+		require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses"}, cluster.seen(), "no write may follow")
+	})
+
+	t.Run("a rejected write is an error, not a closed response", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{rejectPut: true}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		err := newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties)
+		require.ErrorIs(t, err, ErrCouldNotUpdateMapping)
+		require.ErrorContains(t, err, "cannot be changed", "the cluster's reason must reach the operator")
 	})
 
 	t.Run("an unreachable cluster is an error", func(t *testing.T) {
 		t.Parallel()
 
-		var seen []byte
-		var path string
-		server := newServer(http.StatusOK, `{}`, &seen, &path)
+		server := httptest.NewServer((&mappingCluster{}).handler())
 		server.Close()
 
-		ec, err := NewElasticClient(elasticsearch.Config{Addresses: []string{server.URL}})
-		require.NoError(t, err)
+		require.Error(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
+	})
+}
 
-		require.Error(t, ec.CheckAndUpdateMapping(txIndex, properties.ToBuffer()))
+func TestCheckFieldMapping_ReportsWhatIsMissing(t *testing.T) {
+	t.Parallel()
+
+	cluster := &mappingCluster{}
+	server := httptest.NewServer(cluster.handler())
+	defer server.Close()
+
+	missing, err := newMappingClient(t, server.URL).CheckFieldMapping(txIndex, addedProperties)
+	require.NoError(t, err)
+	require.Equal(t, []string{"scAddresses"}, missing)
+	require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses"}, cluster.seen(), "a check reads and never writes")
+}
+
+func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		require.NoError(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer()))
+		require.Equal(t, []string{"PUT /_template/transactions"}, cluster.seen(), "no existence check may short-circuit the write")
+	})
+
+	t.Run("a rejected template is an error", func(t *testing.T) {
+		t.Parallel()
+
+		cluster := &mappingCluster{rejectPut: true}
+		server := httptest.NewServer(cluster.handler())
+		defer server.Close()
+
+		require.ErrorIs(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer()), ErrCouldNotCreateTemplate)
 	})
 }

--- a/indexer/elasticClientMapping_test.go
+++ b/indexer/elasticClientMapping_test.go
@@ -28,6 +28,7 @@ type mappingCluster struct {
 	requests       []string
 	putBody        []byte
 	templateBodies [][]byte // every body written to the transactions template, in order
+	ioErr          error    // the first read or write that failed inside the handler
 }
 
 func (c *mappingCluster) handler() http.Handler {
@@ -47,55 +48,88 @@ func (c *mappingCluster) handler() http.Handler {
 			}
 			switch c.secondIndex {
 			case "unmapped":
-				_, _ = io.WriteString(w, `{`+first+`,"transactions-000002":{"mappings":{}}}`)
+				c.write(w, `{`+first+`,"transactions-000002":{"mappings":{}}}`)
 			case "empty":
-				_, _ = io.WriteString(w, `{`+first+`,"transactions-000002":{"mappings":{"scAddresses":{"full_name":"scAddresses","mapping":{}}}}}`)
+				c.write(w, `{`+first+`,"transactions-000002":{"mappings":{"scAddresses":{"full_name":"scAddresses","mapping":{}}}}}`)
 			default:
-				_, _ = io.WriteString(w, `{`+first+`}`)
+				c.write(w, `{`+first+`}`)
 			}
 		case r.Method == http.MethodPut && r.URL.Path == "/"+txIndex+"/_mapping":
-			c.putBody, _ = io.ReadAll(r.Body)
+			c.putBody = c.read(r)
 			if c.rejectPut {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"mapper [scAddresses] cannot be changed"}}`)
+				c.write(w, `{"error":{"type":"illegal_argument_exception","reason":"mapper [scAddresses] cannot be changed"}}`)
 				return
 			}
-			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+			c.write(w, `{"acknowledged":true}`)
 		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/_template/"):
 			if r.URL.Path == "/_template/"+txIndex {
-				body, _ := io.ReadAll(r.Body)
+				body := c.read(r)
 				c.templateBodies = append(c.templateBodies, body)
 			}
 			if c.rejectPut {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad template"}}`)
+				c.write(w, `{"error":{"type":"illegal_argument_exception","reason":"bad template"}}`)
 				return
 			}
-			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+			c.write(w, `{"acknowledged":true}`)
 		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/_alias"):
 			if c.rejectPut {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad alias"}}`)
+				c.write(w, `{"error":{"type":"illegal_argument_exception","reason":"bad alias"}}`)
 				return
 			}
-			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+			c.write(w, `{"acknowledged":true}`)
 		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "-000001"):
 			if c.indexTaken {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = io.WriteString(w, `{"error":{"type":"resource_already_exists_exception","reason":"index already exists"}}`)
+				c.write(w, `{"error":{"type":"resource_already_exists_exception","reason":"index already exists"}}`)
 				return
 			}
 			if c.rejectPut {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = io.WriteString(w, `{"error":{"type":"illegal_argument_exception","reason":"bad index"}}`)
+				c.write(w, `{"error":{"type":"illegal_argument_exception","reason":"bad index"}}`)
 				return
 			}
-			_, _ = io.WriteString(w, `{"acknowledged":true}`)
+			c.write(w, `{"acknowledged":true}`)
 		default:
 			w.WriteHeader(http.StatusNotFound)
-			_, _ = io.WriteString(w, `{"error":{"type":"resource_not_found_exception"}}`)
+			c.write(w, `{"error":{"type":"resource_not_found_exception"}}`)
 		}
 	})
+}
+
+// write and read record the first I/O failure inside the handler, which holds c.mu, so a
+// partial fixture surfaces as a test failure rather than as a puzzling client error.
+func (c *mappingCluster) write(w io.Writer, s string) {
+	if _, err := io.WriteString(w, s); err != nil && c.ioErr == nil {
+		c.ioErr = err
+	}
+}
+
+func (c *mappingCluster) read(r *http.Request) []byte {
+	body, err := io.ReadAll(r.Body)
+	if err != nil && c.ioErr == nil {
+		c.ioErr = err
+	}
+
+	return body
+}
+
+// serve starts the fake and, when the test ends, closes it and fails the test on any I/O
+// error the handler recorded.
+func serve(t *testing.T, cluster *mappingCluster) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(cluster.handler())
+	t.Cleanup(func() {
+		server.Close()
+		cluster.mu.Lock()
+		defer cluster.mu.Unlock()
+		require.NoError(t, cluster.ioErr, "the fake must have served every request in full")
+	})
+
+	return server
 }
 
 func (c *mappingCluster) seen() []string {
@@ -140,8 +174,7 @@ func TestCheckAndUpdateMapping(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		require.NoError(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
 
@@ -154,8 +187,7 @@ func TestCheckAndUpdateMapping(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{fieldType: "keyword"}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		require.NoError(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
 		require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses"}, cluster.seen(),
@@ -166,8 +198,7 @@ func TestCheckAndUpdateMapping(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{fieldType: "text"}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		err := newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties)
 		require.ErrorIs(t, err, ErrCouldNotUpdateMapping)
@@ -179,8 +210,7 @@ func TestCheckAndUpdateMapping(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{rejectPut: true}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		err := newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties)
 		require.ErrorIs(t, err, ErrCouldNotUpdateMapping)
@@ -190,7 +220,7 @@ func TestCheckAndUpdateMapping(t *testing.T) {
 	t.Run("an unreachable cluster is an error", func(t *testing.T) {
 		t.Parallel()
 
-		server := httptest.NewServer((&mappingCluster{}).handler())
+		server := serve(t, &mappingCluster{})
 		server.Close()
 
 		require.Error(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
@@ -208,8 +238,7 @@ func TestCheckAndUpdateMapping_WritesWhenAnyBackingIndexLacksTheField(t *testing
 			t.Parallel()
 
 			cluster := &mappingCluster{fieldType: "keyword", secondIndex: second}
-			server := httptest.NewServer(cluster.handler())
-			defer server.Close()
+			server := serve(t, cluster)
 
 			require.NoError(t, newMappingClient(t, server.URL).CheckAndUpdateMapping(txIndex, addedProperties))
 			require.Equal(t, []string{"GET /transactions/_mapping/field/scAddresses", "PUT /transactions/_mapping"}, cluster.seen(),
@@ -222,8 +251,7 @@ func TestCheckFieldMapping_ReportsWhatIsMissing(t *testing.T) {
 	t.Parallel()
 
 	cluster := &mappingCluster{}
-	server := httptest.NewServer(cluster.handler())
-	defer server.Close()
+	server := serve(t, cluster)
 
 	missing, err := newMappingClient(t, server.URL).CheckFieldMapping(txIndex, addedProperties)
 	require.NoError(t, err)
@@ -238,8 +266,7 @@ func TestCheckAndCreateTemplate_LeavesTheBufferForTheNextRequest(t *testing.T) {
 	t.Parallel()
 
 	cluster := &mappingCluster{}
-	server := httptest.NewServer(cluster.handler())
-	defer server.Close()
+	server := serve(t, cluster)
 
 	client := newMappingClient(t, server.URL)
 	template := addedProperties.ToBuffer()
@@ -261,8 +288,7 @@ func TestCheckAndCreateTemplate_LeavesTheBufferForTheNextRequest(t *testing.T) {
 // is why only a fresh cluster shows this.
 func TestNewElasticProcessor_OnAFreshClusterWritesTheTransactionsTemplateTwiceInFull(t *testing.T) {
 	cluster := &mappingCluster{}
-	server := httptest.NewServer(cluster.handler())
-	defer server.Close()
+	server := serve(t, cluster)
 
 	indexTemplates, indexPolicies, err := GetElasticTemplatesAndPolicies(false)
 	require.NoError(t, err)
@@ -290,8 +316,7 @@ func TestCreateSteps_ARefusalIsAnError(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{rejectPut: true}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		err := newMappingClient(t, server.URL).CheckAndCreateTemplate(txIndex, addedProperties.ToBuffer())
 		require.ErrorIs(t, err, ErrCouldNotCreateTemplate)
@@ -302,8 +327,7 @@ func TestCreateSteps_ARefusalIsAnError(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{rejectPut: true}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		err := newMappingClient(t, server.URL).CheckAndCreateIndex("transactions-000001")
 		require.ErrorIs(t, err, ErrCouldNotCreateIndex)
@@ -314,8 +338,7 @@ func TestCreateSteps_ARefusalIsAnError(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{indexTaken: true}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		require.NoError(t, newMappingClient(t, server.URL).CheckAndCreateIndex("transactions-000001"))
 		require.Equal(t, []string{"HEAD /transactions-000001", "PUT /transactions-000001"}, cluster.seen(),
@@ -326,12 +349,23 @@ func TestCreateSteps_ARefusalIsAnError(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{rejectPut: true}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		err := newMappingClient(t, server.URL).CheckAndCreateAlias(txIndex, "transactions-000001")
 		require.ErrorIs(t, err, ErrCouldNotCreateAlias)
 		require.ErrorContains(t, err, "bad alias")
+	})
+
+	t.Run("an unreachable cluster is an error naming the resource", func(t *testing.T) {
+		t.Parallel()
+
+		server := serve(t, &mappingCluster{})
+		server.Close()
+		client := newMappingClient(t, server.URL)
+
+		require.ErrorIs(t, client.CheckAndCreateTemplate(txIndex, addedProperties.ToBuffer()), ErrCouldNotCreateTemplate)
+		require.ErrorIs(t, client.CheckAndCreateIndex("transactions-000001"), ErrCouldNotCreateIndex)
+		require.ErrorIs(t, client.CheckAndCreateAlias(txIndex, "transactions-000001"), ErrCouldNotCreateAlias)
 	})
 }
 
@@ -342,8 +376,7 @@ func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		require.NoError(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer().Bytes()))
 		require.Equal(t, []string{"PUT /_template/transactions"}, cluster.seen(), "no existence check may short-circuit the write")
@@ -353,8 +386,7 @@ func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{rejectPut: true}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		require.ErrorIs(t, newMappingClient(t, server.URL).PutTemplate(txIndex, addedProperties.ToBuffer().Bytes()), ErrCouldNotCreateTemplate)
 	})
@@ -363,8 +395,7 @@ func TestPutTemplate_WritesWhetherOrNotOneExists(t *testing.T) {
 		t.Parallel()
 
 		cluster := &mappingCluster{}
-		server := httptest.NewServer(cluster.handler())
-		defer server.Close()
+		server := serve(t, cluster)
 
 		require.ErrorIs(t, newMappingClient(t, server.URL).PutTemplate(txIndex, nil), ErrCouldNotCreateTemplate)
 		require.Empty(t, cluster.seen(), "a consumed buffer must not turn into an empty template on the cluster")

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -269,10 +269,11 @@ func (ei *elasticProcessor) createIndexes() error {
 // predate the properties in templates.TransactionsAddedProperties: the stored template is
 // rewritten so indices created from now on carry them, and the live index gains whichever
 // of them it does not map yet. Both run on every start-up; the live index is read before it
-// is written, so a node whose index is already up to date sends no write.
+// is written, so a node whose index is already up to date sends no write. The template is
+// the same buffer the create step was handed, which is why that step must not consume it.
 func (ei *elasticProcessor) ensureFieldMappings(indexTemplates map[string]*bytes.Buffer) error {
 	if template := getTemplateByName(txIndex, indexTemplates); template != nil {
-		err := ei.elasticClient.PutTemplate(txIndex, template)
+		err := ei.elasticClient.PutTemplate(txIndex, template.Bytes())
 		if err != nil {
 			log.Error("put template", "index", txIndex, "err", err)
 			return err

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -168,7 +168,7 @@ func (ei *elasticProcessor) initWithKibana(indexTemplates, indexPolicies map[str
 		return err
 	}
 
-	return ei.ensureFieldMappings()
+	return ei.ensureFieldMappings(indexTemplates)
 }
 
 func (ei *elasticProcessor) initNoKibana(indexTemplates map[string]*bytes.Buffer) error {
@@ -192,7 +192,7 @@ func (ei *elasticProcessor) initNoKibana(indexTemplates map[string]*bytes.Buffer
 		return err
 	}
 
-	return ei.ensureFieldMappings()
+	return ei.ensureFieldMappings(indexTemplates)
 }
 
 // nolint: unused
@@ -265,13 +265,23 @@ func (ei *elasticProcessor) createIndexes() error {
 	return nil
 }
 
-// ensureFieldMappings puts the properties added to the transactions template after a
-// deployment may already carry the index onto the live index, on every start-up. See
-// templates.TransactionsAddedProperties for why the template alone is not enough.
-func (ei *elasticProcessor) ensureFieldMappings() error {
+// ensureFieldMappings brings the transactions mapping up to date on a cluster that may
+// predate the properties in templates.TransactionsAddedProperties: the stored template is
+// rewritten so indices created from now on carry them, and the live index gains whichever
+// of them it does not map yet. Both run on every start-up; the live index is read before it
+// is written, so a node whose index is already up to date sends no write.
+func (ei *elasticProcessor) ensureFieldMappings(indexTemplates map[string]*bytes.Buffer) error {
+	if template := getTemplateByName(txIndex, indexTemplates); template != nil {
+		err := ei.elasticClient.PutTemplate(txIndex, template)
+		if err != nil {
+			log.Error("put template", "index", txIndex, "err", err)
+			return err
+		}
+	}
+
 	properties := templates.Object{"properties": templates.TransactionsAddedProperties}
 
-	err := ei.elasticClient.CheckAndUpdateMapping(txIndex, properties.ToBuffer())
+	err := ei.elasticClient.CheckAndUpdateMapping(txIndex, properties)
 	if err != nil {
 		log.Error("check and update mapping", "index", txIndex, "err", err)
 		return err

--- a/indexer/elasticProcessor.go
+++ b/indexer/elasticProcessor.go
@@ -168,7 +168,7 @@ func (ei *elasticProcessor) initWithKibana(indexTemplates, indexPolicies map[str
 		return err
 	}
 
-	return nil
+	return ei.ensureFieldMappings()
 }
 
 func (ei *elasticProcessor) initNoKibana(indexTemplates map[string]*bytes.Buffer) error {
@@ -192,7 +192,7 @@ func (ei *elasticProcessor) initNoKibana(indexTemplates map[string]*bytes.Buffer
 		return err
 	}
 
-	return nil
+	return ei.ensureFieldMappings()
 }
 
 // nolint: unused
@@ -262,6 +262,21 @@ func (ei *elasticProcessor) createIndexes() error {
 			return err
 		}
 	}
+	return nil
+}
+
+// ensureFieldMappings puts the properties added to the transactions template after a
+// deployment may already carry the index onto the live index, on every start-up. See
+// templates.TransactionsAddedProperties for why the template alone is not enough.
+func (ei *elasticProcessor) ensureFieldMappings() error {
+	properties := templates.Object{"properties": templates.TransactionsAddedProperties}
+
+	err := ei.elasticClient.CheckAndUpdateMapping(txIndex, properties.ToBuffer())
+	if err != nil {
+		log.Error("check and update mapping", "index", txIndex, "err", err)
+		return err
+	}
+
 	return nil
 }
 

--- a/indexer/errors.go
+++ b/indexer/errors.go
@@ -20,6 +20,9 @@ var ErrCouldNotCreatePolicy = errors.New("could not create policy")
 // ErrCouldNotUpdateMapping signals that a mapping property could not be added to an index
 var ErrCouldNotUpdateMapping = errors.New("could not update mapping")
 
+// ErrCouldNotCreateTemplate signals that an index template could not be written
+var ErrCouldNotCreateTemplate = errors.New("could not create template")
+
 // ErrNilPubkeyConverter signals that an operation has been attempted to or with a nil public key converter implementation
 var ErrNilPubkeyConverter = errors.New("nil pubkey converter")
 

--- a/indexer/errors.go
+++ b/indexer/errors.go
@@ -23,6 +23,12 @@ var ErrCouldNotUpdateMapping = errors.New("could not update mapping")
 // ErrCouldNotCreateTemplate signals that an index template could not be written
 var ErrCouldNotCreateTemplate = errors.New("could not create template")
 
+// ErrCouldNotCreateIndex signals that an index could not be created
+var ErrCouldNotCreateIndex = errors.New("could not create index")
+
+// ErrCouldNotCreateAlias signals that an alias could not be created
+var ErrCouldNotCreateAlias = errors.New("could not create alias")
+
 // ErrNilPubkeyConverter signals that an operation has been attempted to or with a nil public key converter implementation
 var ErrNilPubkeyConverter = errors.New("nil pubkey converter")
 

--- a/indexer/errors.go
+++ b/indexer/errors.go
@@ -17,6 +17,9 @@ var ErrNoElasticUrlProvided = errors.New("no elastic url provided")
 // ErrCouldNotCreatePolicy -
 var ErrCouldNotCreatePolicy = errors.New("could not create policy")
 
+// ErrCouldNotUpdateMapping signals that a mapping property could not be added to an index
+var ErrCouldNotUpdateMapping = errors.New("could not update mapping")
+
 // ErrNilPubkeyConverter signals that an operation has been attempted to or with a nil public key converter implementation
 var ErrNilPubkeyConverter = errors.New("nil pubkey converter")
 

--- a/indexer/eventsProcessor.go
+++ b/indexer/eventsProcessor.go
@@ -90,13 +90,44 @@ func (ep *eventsProcessor) SaveBlock(args *indexerData.ArgsSaveBlockData) {
 			ep.dispatchAccountEventsFromAlteredAccounts(args.Header.GetTimestamp(), prepared.Altered.Accounts)
 		}
 		if indexerEnabled {
-			args.Prepared = prepared
+			args.Prepared = detachPreparedBlockData(prepared)
 		}
 	}
 
 	if indexerEnabled {
 		ep.indexer.SaveBlock(args)
 	}
+}
+
+// detachPreparedBlockData gives the indexer its own transaction structs. The websocket hub
+// marshals the prepared transactions on its own goroutines while the indexer worker runs
+// ExtractDataFromLogs on them, which writes hasLogs, hasOperations, scAddresses and the
+// status onto the same structs; sharing the pointers is an unsynchronized write against a
+// concurrent read. The copies keep the websocket stream the snapshot it was prepared as.
+// Nil in, nil out, so a block without transactions needs no special case.
+func detachPreparedBlockData(prepared *data.PreparedBlockData) *data.PreparedBlockData {
+	if prepared == nil {
+		return nil
+	}
+
+	txs := make([]*data.Transaction, len(prepared.Txs))
+	txsMap := make(map[string]*data.Transaction, len(prepared.TxsMap))
+	byOriginal := make(map[*data.Transaction]*data.Transaction, len(prepared.Txs))
+	for i, tx := range prepared.Txs {
+		detached := *tx
+		txs[i] = &detached
+		byOriginal[tx] = &detached
+	}
+	for hash, tx := range prepared.TxsMap {
+		if detached, ok := byOriginal[tx]; ok {
+			txsMap[hash] = detached
+			continue
+		}
+		detached := *tx
+		txsMap[hash] = &detached
+	}
+
+	return &data.PreparedBlockData{Txs: txs, TxsMap: txsMap, Altered: prepared.Altered}
 }
 
 func (ep *eventsProcessor) prepare(args *indexerData.ArgsSaveBlockData) *data.PreparedBlockData {

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -1407,3 +1407,36 @@ func BenchmarkEventsProcessor_SaveBlock_500tx_IndexerOnly(b *testing.B) {
 }
 func BenchmarkEventsProcessor_SaveBlock_50tx_Both(b *testing.B)  { benchSaveBlock(b, 50, true, true) }
 func BenchmarkEventsProcessor_SaveBlock_500tx_Both(b *testing.B) { benchSaveBlock(b, 500, true, true) }
+
+// TestDetachPreparedBlockData covers what the websocket path hands the indexer: its own
+// transaction structs. The hub marshals the prepared transactions on its own goroutines
+// while the indexer worker writes hasLogs, hasOperations, scAddresses and the status onto
+// the structs it was given, so the two must not share pointers.
+func TestDetachPreparedBlockData(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, detachPreparedBlockData(nil), "a block without transactions has nothing to detach")
+
+	first := &data.Transaction{Hash: "aa", Sender: "s1"}
+	second := &data.Transaction{Hash: "bb", Sender: "s2"}
+	prepared := &data.PreparedBlockData{
+		Txs:     []*data.Transaction{first, second},
+		TxsMap:  map[string]*data.Transaction{"aa": first, "bb": second},
+		Altered: &data.AlteredData{},
+	}
+
+	detached := detachPreparedBlockData(prepared)
+
+	require.Len(t, detached.Txs, 2)
+	require.NotSame(t, first, detached.Txs[0], "the indexer must get its own struct")
+	require.NotSame(t, second, detached.Txs[1])
+	require.Same(t, detached.Txs[0], detached.TxsMap["aa"], "the map must point at the copies, not at the originals")
+	require.Same(t, detached.Txs[1], detached.TxsMap["bb"])
+	require.Same(t, prepared.Altered, detached.Altered, "altered data is read, not written, on the indexer path")
+
+	detached.Txs[0].SCAddresses = []string{"klv1contract"}
+	detached.Txs[0].HasLogs = true
+	require.Nil(t, first.SCAddresses, "a write on the indexer's copy must not reach the websocket's struct")
+	require.False(t, first.HasLogs)
+	require.Equal(t, "s1", detached.Txs[0].Sender, "the copy carries the prepared content")
+}

--- a/indexer/eventsProcessor_test.go
+++ b/indexer/eventsProcessor_test.go
@@ -1434,6 +1434,14 @@ func TestDetachPreparedBlockData(t *testing.T) {
 	require.Same(t, detached.Txs[1], detached.TxsMap["bb"])
 	require.Same(t, prepared.Altered, detached.Altered, "altered data is read, not written, on the indexer path")
 
+	mapOnly := &data.Transaction{Hash: "cc", Sender: "s3"}
+	withMapOnly := detachPreparedBlockData(&data.PreparedBlockData{
+		Txs:    []*data.Transaction{first},
+		TxsMap: map[string]*data.Transaction{"aa": first, "cc": mapOnly},
+	})
+	require.NotSame(t, mapOnly, withMapOnly.TxsMap["cc"], "a transaction that exists only in the map must be copied too")
+	require.Equal(t, "s3", withMapOnly.TxsMap["cc"].Sender)
+
 	detached.Txs[0].SCAddresses = []string{"klv1contract"}
 	detached.Txs[0].HasLogs = true
 	require.Nil(t, first.SCAddresses, "a write on the indexer's copy must not reach the websocket's struct")

--- a/indexer/interface.go
+++ b/indexer/interface.go
@@ -54,6 +54,7 @@ type DatabaseClientHandler interface {
 	CheckAndCreateAlias(alias string, index string) error
 	CheckAndCreateTemplate(templateName string, template *bytes.Buffer) error
 	CheckAndCreatePolicy(policyName string, policy *bytes.Buffer) error
+	CheckAndUpdateMapping(index string, properties *bytes.Buffer) error
 	DocExists(index string, id string) bool
 	ConvertObjectToOrder(obj object) (*data.Order, error)
 	ConvertObjectToData(obj object, data any) error

--- a/indexer/interface.go
+++ b/indexer/interface.go
@@ -56,7 +56,7 @@ type DatabaseClientHandler interface {
 	CheckAndCreatePolicy(policyName string, policy *bytes.Buffer) error
 	CheckFieldMapping(index string, properties templates.Object) ([]string, error)
 	CheckAndUpdateMapping(index string, properties templates.Object) error
-	PutTemplate(templateName string, template *bytes.Buffer) error
+	PutTemplate(templateName string, template []byte) error
 	DocExists(index string, id string) bool
 	ConvertObjectToOrder(obj object) (*data.Order, error)
 	ConvertObjectToData(obj object, data any) error

--- a/indexer/interface.go
+++ b/indexer/interface.go
@@ -54,7 +54,9 @@ type DatabaseClientHandler interface {
 	CheckAndCreateAlias(alias string, index string) error
 	CheckAndCreateTemplate(templateName string, template *bytes.Buffer) error
 	CheckAndCreatePolicy(policyName string, policy *bytes.Buffer) error
-	CheckAndUpdateMapping(index string, properties *bytes.Buffer) error
+	CheckFieldMapping(index string, properties templates.Object) ([]string, error)
+	CheckAndUpdateMapping(index string, properties templates.Object) error
+	PutTemplate(templateName string, template *bytes.Buffer) error
 	DocExists(index string, id string) bool
 	ConvertObjectToOrder(obj object) (*data.Order, error)
 	ConvertObjectToData(obj object, data any) error

--- a/indexer/logsevents/logsProcessor.go
+++ b/indexer/logsevents/logsProcessor.go
@@ -88,28 +88,35 @@ func (lep *logsAndEventsProcessor) smartContractAddresses(
 	logAddress []byte,
 	events []transaction.EventHandler,
 ) []string {
-	seen := make(map[string]struct{}, len(existing)+1)
-	for _, address := range existing {
-		seen[address] = struct{}{}
+	// Allocated on the first qualifying address: most logs belong to plain transfers and
+	// name no contract at all, and this runs once per log of every block.
+	var seen map[string]struct{}
+	add := func(encoded string) {
+		if seen == nil {
+			seen = make(map[string]struct{}, len(existing)+2)
+			for _, address := range existing {
+				seen[address] = struct{}{}
+			}
+		}
+		seen[encoded] = struct{}{}
 	}
-
-	add := func(address []byte) {
-		if !core.IsSmartContractAddress(address) || core.IsEmptyAddress(address) {
+	addIfContract := func(address []byte) {
+		if core.IsEmptyAddress(address) || !core.IsSmartContractAddress(address) {
 			return
 		}
-		seen[lep.pubKeyConverter.Encode(address)] = struct{}{}
+		add(lep.pubKeyConverter.Encode(address))
 	}
 
-	add(logAddress)
+	addIfContract(logAddress)
 	for _, event := range events {
 		if check.IfNil(event) {
 			continue
 		}
-		add(event.GetAddress())
+		addIfContract(event.GetAddress())
 	}
 
 	if len(seen) == 0 {
-		return nil
+		return existing
 	}
 
 	addresses := make([]string, 0, len(seen))

--- a/indexer/logsevents/logsProcessor.go
+++ b/indexer/logsevents/logsProcessor.go
@@ -2,6 +2,7 @@ package logsevents
 
 import (
 	"encoding/hex"
+	"sort"
 	"time"
 
 	"github.com/klever-io/klever-go/common"
@@ -59,6 +60,7 @@ func (lep *logsAndEventsProcessor) ExtractDataFromLogs(
 		tx, ok := lep.logsData.txsMap[txHashHexEncoded]
 		if ok {
 			tx.HasLogs = true
+			tx.SCAddresses = lep.smartContractAddresses(tx.SCAddresses, txLog.GetAddress(), events)
 			continue
 		}
 	}
@@ -67,6 +69,56 @@ func (lep *logsAndEventsProcessor) ExtractDataFromLogs(
 		ScDeploys:  lep.logsData.scDeploys,
 		AlteredSCs: lep.logsData.alteredSC,
 	}
+}
+
+// smartContractAddresses returns the distinct smart contracts that took part in a
+// transaction, bech32 encoded and sorted, merged into whatever an earlier log of the same
+// transaction already contributed. The log's own address is the contract the transaction
+// invoked; each event's address is the contract that emitted it, which differs from the
+// log's address inside an inner call and is how a contract reached through another
+// contract gets listed. Wallets are left out, and so is the empty system address, which
+// IsSmartContractAddress accepts through its IsEmptyAddress branch. Nil when nothing
+// qualifies, so the field stays off the document.
+//
+// This runs in the events loop rather than as an eventsProcessor on purpose: processEvent
+// returns on the first processor that reports an event as processed, so a processor keyed
+// on the same identifiers as an existing one would either shadow it or be shadowed by it.
+func (lep *logsAndEventsProcessor) smartContractAddresses(
+	existing []string,
+	logAddress []byte,
+	events []transaction.EventHandler,
+) []string {
+	seen := make(map[string]struct{}, len(existing)+1)
+	for _, address := range existing {
+		seen[address] = struct{}{}
+	}
+
+	add := func(address []byte) {
+		if !core.IsSmartContractAddress(address) || core.IsEmptyAddress(address) {
+			return
+		}
+		seen[lep.pubKeyConverter.Encode(address)] = struct{}{}
+	}
+
+	add(logAddress)
+	for _, event := range events {
+		if check.IfNil(event) {
+			continue
+		}
+		add(event.GetAddress())
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	addresses := make([]string, 0, len(seen))
+	for address := range seen {
+		addresses = append(addresses, address)
+	}
+	sort.Strings(addresses)
+
+	return addresses
 }
 
 func newLogsData(

--- a/indexer/logsevents/scAddresses_test.go
+++ b/indexer/logsevents/scAddresses_test.go
@@ -1,0 +1,150 @@
+package logsevents_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/klever-io/klever-go/common"
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	nodeData "github.com/klever-io/klever-go/data"
+	"github.com/klever-io/klever-go/data/indexer"
+	"github.com/klever-io/klever-go/data/transaction"
+	"github.com/klever-io/klever-go/indexer/data"
+	"github.com/klever-io/klever-go/indexer/logsevents"
+	"github.com/stretchr/testify/require"
+)
+
+// scAddress builds a 32-byte address that core.IsSmartContractAddress accepts: the leading
+// bytes zero, then the VM type, then a tail that tells contracts apart.
+func scAddress(tail byte) []byte {
+	address := make([]byte, 32)
+	copy(address[core.NumInitCharactersForScAddress-core.VMTypeLen:], common.WasmVirtualMachine)
+	address[31] = tail
+
+	return address
+}
+
+func walletAddress(tail byte) []byte {
+	address := make([]byte, 32)
+	for i := range address {
+		address[i] = 0xAB
+	}
+	address[31] = tail
+
+	return address
+}
+
+// logsExtractor is the one method these tests drive; the constructor returns an unexported
+// type, so the tests name the behaviour rather than the type.
+type logsExtractor interface {
+	ExtractDataFromLogs(pool *indexer.Pool, txs []*data.Transaction, timestamp int64) *data.PreparedLogsResults
+}
+
+func newLogsProcessorForTest(t *testing.T) logsExtractor {
+	t.Helper()
+
+	proc, err := logsevents.NewLogsAndEventsProcessor(logsevents.ArgsLogsAndEventsProcessor{
+		PubKeyConverter: &mock.PubkeyConverterStub{
+			EncodeCalled: func(pkBytes []byte) string { return hex.EncodeToString(pkBytes) },
+			LenCalled:    func() int { return 32 },
+		},
+		Marshalizer: &mock.MarshalizerMock{},
+		Hasher:      &mock.HasherMock{},
+	})
+	require.NoError(t, err)
+
+	return proc
+}
+
+func logFor(txHash string, logAddress []byte, eventAddresses ...[]byte) *nodeData.LogData {
+	events := make([]*transaction.Event, 0, len(eventAddresses))
+	for _, address := range eventAddresses {
+		events = append(events, &transaction.Event{Address: address, Identifier: []byte("anyEvent")})
+	}
+
+	return &nodeData.LogData{
+		LogHandler: &transaction.Log{Address: logAddress, Events: events},
+		TxHash:     txHash,
+	}
+}
+
+// TestExtractDataFromLogs_ListsEveryContractThatTookPart is the field issue 434 asks for.
+//
+// A transaction that invokes contract A, which calls contract B, carries B only in its
+// events: contract.parameter.address names A, and B leaves no receipt unless it moved
+// value. The log's own address is A; the event addresses are whichever contract emitted
+// each event. Both land in scAddresses, distinct and sorted, and nothing else does.
+func TestExtractDataFromLogs_ListsEveryContractThatTookPart(t *testing.T) {
+	t.Parallel()
+
+	contractA, contractB := scAddress(1), scAddress(2)
+	tx := &data.Transaction{Hash: hex.EncodeToString([]byte("h1"))}
+
+	pool := &indexer.Pool{Logs: []*nodeData.LogData{
+		logFor("h1", contractA, contractB, contractA, walletAddress(9), make([]byte, 32)),
+	}}
+
+	newLogsProcessorForTest(t).ExtractDataFromLogs(pool, []*data.Transaction{tx}, 100)
+
+	require.True(t, tx.HasLogs)
+	require.Equal(t, []string{hex.EncodeToString(contractA), hex.EncodeToString(contractB)}, tx.SCAddresses,
+		"the invoked contract and the contract that emitted an event, once each, sorted; "+
+			"the wallet and the empty system address must not be listed")
+}
+
+// TestExtractDataFromLogs_ExcludesTheEmptySystemAddress pins the one address that passes
+// core.IsSmartContractAddress without being a contract: the all-zero address is accepted
+// through its IsEmptyAddress branch, and burn transfers put it in a log. A count keyed on
+// it would credit "the burn address was used" to every such transaction.
+func TestExtractDataFromLogs_ExcludesTheEmptySystemAddress(t *testing.T) {
+	t.Parallel()
+
+	empty := make([]byte, 32)
+	require.True(t, core.IsSmartContractAddress(empty), "the premise: the empty address passes the SC check")
+
+	tx := &data.Transaction{Hash: hex.EncodeToString([]byte("h1"))}
+	pool := &indexer.Pool{Logs: []*nodeData.LogData{logFor("h1", empty, empty)}}
+
+	newLogsProcessorForTest(t).ExtractDataFromLogs(pool, []*data.Transaction{tx}, 100)
+
+	require.True(t, tx.HasLogs)
+	require.Nil(t, tx.SCAddresses, "nothing qualifies, so the field stays off the document")
+}
+
+// TestExtractDataFromLogs_MergesSeveralLogsOfOneTransaction covers a transaction that
+// appears more than once in the pool's logs: the second log must add to the first, not
+// replace it.
+func TestExtractDataFromLogs_MergesSeveralLogsOfOneTransaction(t *testing.T) {
+	t.Parallel()
+
+	contractA, contractB := scAddress(1), scAddress(2)
+	tx := &data.Transaction{Hash: hex.EncodeToString([]byte("h1"))}
+	pool := &indexer.Pool{Logs: []*nodeData.LogData{
+		logFor("h1", contractB),
+		logFor("h1", contractA),
+	}}
+
+	newLogsProcessorForTest(t).ExtractDataFromLogs(pool, []*data.Transaction{tx}, 100)
+
+	require.Equal(t, []string{hex.EncodeToString(contractA), hex.EncodeToString(contractB)}, tx.SCAddresses)
+}
+
+// TestExtractDataFromLogs_LeavesTransactionsWithoutContractsAlone is the omitempty half: a
+// plain transfer has a log with a wallet address and no contract events, and must not gain
+// an empty array, which would be indexed and would make "has the field" a wrong test for
+// "touched a contract".
+func TestExtractDataFromLogs_LeavesTransactionsWithoutContractsAlone(t *testing.T) {
+	t.Parallel()
+
+	withWalletLog := &data.Transaction{Hash: hex.EncodeToString([]byte("h1"))}
+	withoutLog := &data.Transaction{Hash: hex.EncodeToString([]byte("h2"))}
+	pool := &indexer.Pool{Logs: []*nodeData.LogData{logFor("h1", walletAddress(1), walletAddress(2))}}
+
+	newLogsProcessorForTest(t).ExtractDataFromLogs(pool, []*data.Transaction{withWalletLog, withoutLog}, 100)
+
+	require.True(t, withWalletLog.HasLogs)
+	require.Nil(t, withWalletLog.SCAddresses)
+	require.False(t, withoutLog.HasLogs)
+	require.Nil(t, withoutLog.SCAddresses)
+}

--- a/indexer/mock/databaseWriterStub.go
+++ b/indexer/mock/databaseWriterStub.go
@@ -23,6 +23,7 @@ type DatabaseWriterStub struct {
 	DoUpdateCalled                func(index string, id string, body *bytes.Buffer) error
 	ConvertObjectToOrderCalled    func(obj object) (*data.Order, error)
 	ConvertObjectToDataCalled     func(obj object, data any) error
+	CheckAndUpdateMappingCalled   func(index string, properties *bytes.Buffer) error
 }
 
 type object = map[string]interface{}
@@ -136,6 +137,15 @@ func (dwm *DatabaseWriterStub) CheckAndCreateTemplate(_ string, _ *bytes.Buffer)
 
 // CheckAndCreatePolicy -
 func (dwm *DatabaseWriterStub) CheckAndCreatePolicy(_ string, _ *bytes.Buffer) error {
+	return nil
+}
+
+// CheckAndUpdateMapping -
+func (dwm *DatabaseWriterStub) CheckAndUpdateMapping(index string, properties *bytes.Buffer) error {
+	if dwm.CheckAndUpdateMappingCalled != nil {
+		return dwm.CheckAndUpdateMappingCalled(index, properties)
+	}
+
 	return nil
 }
 

--- a/indexer/mock/databaseWriterStub.go
+++ b/indexer/mock/databaseWriterStub.go
@@ -23,7 +23,9 @@ type DatabaseWriterStub struct {
 	DoUpdateCalled                func(index string, id string, body *bytes.Buffer) error
 	ConvertObjectToOrderCalled    func(obj object) (*data.Order, error)
 	ConvertObjectToDataCalled     func(obj object, data any) error
-	CheckAndUpdateMappingCalled   func(index string, properties *bytes.Buffer) error
+	CheckFieldMappingCalled       func(index string, properties templates.Object) ([]string, error)
+	CheckAndUpdateMappingCalled   func(index string, properties templates.Object) error
+	PutTemplateCalled             func(templateName string, template *bytes.Buffer) error
 }
 
 type object = map[string]interface{}
@@ -140,10 +142,28 @@ func (dwm *DatabaseWriterStub) CheckAndCreatePolicy(_ string, _ *bytes.Buffer) e
 	return nil
 }
 
+// CheckFieldMapping -
+func (dwm *DatabaseWriterStub) CheckFieldMapping(index string, properties templates.Object) ([]string, error) {
+	if dwm.CheckFieldMappingCalled != nil {
+		return dwm.CheckFieldMappingCalled(index, properties)
+	}
+
+	return nil, nil
+}
+
 // CheckAndUpdateMapping -
-func (dwm *DatabaseWriterStub) CheckAndUpdateMapping(index string, properties *bytes.Buffer) error {
+func (dwm *DatabaseWriterStub) CheckAndUpdateMapping(index string, properties templates.Object) error {
 	if dwm.CheckAndUpdateMappingCalled != nil {
 		return dwm.CheckAndUpdateMappingCalled(index, properties)
+	}
+
+	return nil
+}
+
+// PutTemplate -
+func (dwm *DatabaseWriterStub) PutTemplate(templateName string, template *bytes.Buffer) error {
+	if dwm.PutTemplateCalled != nil {
+		return dwm.PutTemplateCalled(templateName, template)
 	}
 
 	return nil

--- a/indexer/mock/databaseWriterStub.go
+++ b/indexer/mock/databaseWriterStub.go
@@ -25,7 +25,7 @@ type DatabaseWriterStub struct {
 	ConvertObjectToDataCalled     func(obj object, data any) error
 	CheckFieldMappingCalled       func(index string, properties templates.Object) ([]string, error)
 	CheckAndUpdateMappingCalled   func(index string, properties templates.Object) error
-	PutTemplateCalled             func(templateName string, template *bytes.Buffer) error
+	PutTemplateCalled             func(templateName string, template []byte) error
 }
 
 type object = map[string]interface{}
@@ -161,7 +161,7 @@ func (dwm *DatabaseWriterStub) CheckAndUpdateMapping(index string, properties te
 }
 
 // PutTemplate -
-func (dwm *DatabaseWriterStub) PutTemplate(templateName string, template *bytes.Buffer) error {
+func (dwm *DatabaseWriterStub) PutTemplate(templateName string, template []byte) error {
 	if dwm.PutTemplateCalled != nil {
 		return dwm.PutTemplateCalled(templateName, template)
 	}

--- a/indexer/scAddresses_test.go
+++ b/indexer/scAddresses_test.go
@@ -1,0 +1,187 @@
+package indexer
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/klever-io/klever-go/common"
+	"github.com/klever-io/klever-go/common/mock"
+	"github.com/klever-io/klever-go/core"
+	nodeData "github.com/klever-io/klever-go/data"
+	dataBlock "github.com/klever-io/klever-go/data/block"
+	"github.com/klever-io/klever-go/data/indexer"
+	"github.com/klever-io/klever-go/data/transaction"
+	imock "github.com/klever-io/klever-go/indexer/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// contractAddressForTest builds a 32-byte address core.IsSmartContractAddress accepts.
+func contractAddressForTest(tail byte) []byte {
+	address := make([]byte, 32)
+	copy(address[core.NumInitCharactersForScAddress-core.VMTypeLen:], common.WasmVirtualMachine)
+	address[31] = tail
+
+	return address
+}
+
+// hexEncodingArgs are the processor arguments with an address converter whose output is
+// safe to look for in a JSON body. The default test converter returns the raw bytes as a
+// string, which a contract address (leading zero bytes) turns into escaped control
+// characters.
+func hexEncodingArgs() ArgElasticProcessor {
+	args := createMockElasticProcessorArgs()
+	args.AddressPubkeyConverter = &mock.PubkeyConverterStub{
+		EncodeCalled: func(pkBytes []byte) string { return hex.EncodeToString(pkBytes) },
+		DecodeCalled: hex.DecodeString,
+		LenCalled:    func() int { return 32 },
+	}
+
+	return args
+}
+
+// TestSaveTransactions_IndexesTheContractsATransactionTookPartIn is the end-to-end check for
+// the field issue 434 asks for: the contract addresses come out of the logs and land in the
+// bulk request, on the transaction document, both in the upsert body and in the update
+// script's parameters. The bulk body is what Elasticsearch receives, so that is what is read.
+func TestSaveTransactions_IndexesTheContractsATransactionTookPartIn(t *testing.T) {
+	var sent bytes.Buffer
+	dbWriter := &imock.DatabaseWriterStub{
+		DoBulkRequestCalled: func(buff *bytes.Buffer, _ string) error {
+			sent.Write(buff.Bytes())
+			return nil
+		},
+	}
+
+	invoked, inner := contractAddressForTest(1), contractAddressForTest(2)
+	tx, err := createTransactionHandlerMock(
+		&transaction.TransferContract{ToAddress: []byte("klv1d05ju9jaj6u99zph0ant9jh7gksg"), Amount: 45},
+		transaction.TXContract_TransferContractType,
+		[]byte("klv1d05ju9jaj6u99zph0ant9jh7gksf"),
+	)
+	require.NoError(t, err)
+
+	header := &dataBlock.Block{
+		Header:   &dataBlock.BlockHeader{Nonce: 7, Timestamp: 100},
+		TxHashes: [][]byte{[]byte("h1")},
+	}
+	pool := &indexer.Pool{
+		Txs: map[string]nodeData.TransactionHandler{"h1": tx},
+		Logs: []*nodeData.LogData{{
+			TxHash: "h1",
+			LogHandler: &transaction.Log{Address: invoked, Events: []*transaction.Event{
+				{Address: inner, Identifier: []byte("swapTokensFixedInput")},
+				{Address: invoked, Identifier: []byte(core.CompletedTxEventIdentifier)},
+			}},
+		}},
+	}
+
+	ep := newTestElasticSearchDatabase(dbWriter, hexEncodingArgs())
+	require.NoError(t, ep.SaveTransactions(header, pool, nil))
+
+	want := []interface{}{hex.EncodeToString(invoked), hex.EncodeToString(inner)}
+	item := transactionBulkItem(t, sent.Bytes(), hex.EncodeToString([]byte("h1")))
+
+	// Two paths, both checked on their own: the upsert body is what a new document is
+	// created from, the script parameters are all an existing document receives. A count of
+	// occurrences would not tell them apart, since the per-contract update item carries a
+	// second copy of the upsert body.
+	require.Equal(t, want, item["upsert"].(map[string]interface{})["scAddresses"],
+		"a new document must get the field from the upsert body")
+	require.Equal(t, want, item["script"].(map[string]interface{})["params"].(map[string]interface{})["scAddresses"],
+		"an existing document must get the field from the script parameters")
+}
+
+// transactionBulkItem returns the decoded payload of the first bulk item that updates the
+// transaction document txHash: bulk bodies are NDJSON, an action line followed by its
+// payload line, and the transaction's own item is the first one addressed to its id.
+func transactionBulkItem(t *testing.T, bulk []byte, txHash string) map[string]interface{} {
+	t.Helper()
+
+	lines := bytes.Split(bytes.TrimSpace(bulk), []byte("\n"))
+	for i := 0; i+1 < len(lines); i += 2 {
+		var action map[string]map[string]interface{}
+		require.NoError(t, json.Unmarshal(lines[i], &action), "action line %d must be JSON", i)
+		if action["update"]["_id"] != txHash {
+			continue
+		}
+
+		var payload map[string]interface{}
+		require.NoError(t, json.Unmarshal(lines[i+1], &payload), "payload line %d must be JSON", i+1)
+
+		return payload
+	}
+
+	require.FailNow(t, "no bulk item updates the transaction", "id %s in:\n%s", txHash, bulk)
+	return nil
+}
+
+// TestSaveTransactions_LeavesTheFieldOffTransactionsWithoutContracts is the other half: a
+// transaction with no contract in its logs must not carry an empty array, and the script
+// parameters must carry null so the guarded script leaves an existing document alone.
+func TestSaveTransactions_LeavesTheFieldOffTransactionsWithoutContracts(t *testing.T) {
+	var sent bytes.Buffer
+	dbWriter := &imock.DatabaseWriterStub{
+		DoBulkRequestCalled: func(buff *bytes.Buffer, _ string) error {
+			sent.Write(buff.Bytes())
+			return nil
+		},
+	}
+
+	tx, err := createTransactionHandlerMock(
+		&transaction.TransferContract{ToAddress: []byte("klv1d05ju9jaj6u99zph0ant9jh7gksg"), Amount: 45},
+		transaction.TXContract_TransferContractType,
+		[]byte("klv1d05ju9jaj6u99zph0ant9jh7gksf"),
+	)
+	require.NoError(t, err)
+
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 7, Timestamp: 100}, TxHashes: [][]byte{[]byte("h1")}}
+	pool := &indexer.Pool{Txs: map[string]nodeData.TransactionHandler{"h1": tx}, Logs: []*nodeData.LogData{}}
+
+	ep := newTestElasticSearchDatabase(dbWriter, hexEncodingArgs())
+	require.NoError(t, ep.SaveTransactions(header, pool, nil))
+
+	require.NotContains(t, sent.String(), `"scAddresses":[`)
+	require.Contains(t, sent.String(), `"scAddresses":null`, "the script parameter must be null, not absent and not empty")
+}
+
+// TestNewElasticProcessor_PutsTheAddedPropertiesOnTheTransactionsIndex covers start-up: the
+// template only reaches indices created after it, so the processor must put the added
+// properties onto the live transactions index itself, every time it starts, and must refuse
+// to start when that fails. A processor that started anyway would write the field into an
+// index that types it dynamically, and the filter written for the keyword type would miss it.
+func TestNewElasticProcessor_PutsTheAddedPropertiesOnTheTransactionsIndex(t *testing.T) {
+	t.Run("puts the keyword mapping on the transactions alias", func(t *testing.T) {
+		var gotIndex string
+		var gotBody map[string]interface{}
+		args := createMockElasticProcessorArgs()
+		args.DBClient = &imock.DatabaseWriterStub{
+			CheckAndUpdateMappingCalled: func(index string, properties *bytes.Buffer) error {
+				gotIndex = index
+				require.NoError(t, json.Unmarshal(properties.Bytes(), &gotBody))
+				return nil
+			},
+		}
+
+		_, err := NewElasticProcessor(args)
+		require.NoError(t, err)
+
+		require.Equal(t, txIndex, gotIndex)
+		properties, ok := gotBody["properties"].(map[string]interface{})
+		require.True(t, ok, "the body must be a mapping update, {\"properties\": ...}")
+		require.Equal(t, map[string]interface{}{"type": "keyword"}, properties["scAddresses"])
+	})
+
+	t.Run("a failed mapping update stops start-up", func(t *testing.T) {
+		mappingErr := errors.New("mapping rejected")
+		args := createMockElasticProcessorArgs()
+		args.DBClient = &imock.DatabaseWriterStub{
+			CheckAndUpdateMappingCalled: func(string, *bytes.Buffer) error { return mappingErr },
+		}
+
+		_, err := NewElasticProcessor(args)
+		require.ErrorIs(t, err, mappingErr)
+	})
+}

--- a/indexer/scAddresses_test.go
+++ b/indexer/scAddresses_test.go
@@ -182,9 +182,9 @@ func TestNewElasticProcessor_PutsTheAddedPropertiesOnTheTransactionsIndex(t *tes
 		args := createMockElasticProcessorArgs()
 		args.IndexTemplates = map[string]*bytes.Buffer{txIndex: noKibana.Transactions.ToBuffer(), blockIndex: noKibana.Blocks.ToBuffer()}
 		args.DBClient = &imock.DatabaseWriterStub{
-			PutTemplateCalled: func(name string, template *bytes.Buffer) error {
+			PutTemplateCalled: func(name string, template []byte) error {
 				gotTemplates = append(gotTemplates, name)
-				require.True(t, bytes.Contains(template.Bytes(), []byte(`"scAddresses":{"type":"keyword"}`)), "template: %s", template.String())
+				require.True(t, bytes.Contains(template, []byte(`"scAddresses":{"type":"keyword"}`)), "template: %s", template)
 				return nil
 			},
 		}
@@ -210,7 +210,7 @@ func TestNewElasticProcessor_PutsTheAddedPropertiesOnTheTransactionsIndex(t *tes
 		args := createMockElasticProcessorArgs()
 		args.IndexTemplates = map[string]*bytes.Buffer{txIndex: noKibana.Transactions.ToBuffer()}
 		args.DBClient = &imock.DatabaseWriterStub{
-			PutTemplateCalled: func(string, *bytes.Buffer) error { return templateErr },
+			PutTemplateCalled: func(string, []byte) error { return templateErr },
 		}
 
 		_, err := NewElasticProcessor(args)

--- a/indexer/scAddresses_test.go
+++ b/indexer/scAddresses_test.go
@@ -14,7 +14,10 @@ import (
 	dataBlock "github.com/klever-io/klever-go/data/block"
 	"github.com/klever-io/klever-go/data/indexer"
 	"github.com/klever-io/klever-go/data/transaction"
+	"github.com/klever-io/klever-go/indexer/data"
 	imock "github.com/klever-io/klever-go/indexer/mock"
+	"github.com/klever-io/klever-go/indexer/templates"
+	"github.com/klever-io/klever-go/indexer/templates/noKibana"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,18 +152,18 @@ func TestSaveTransactions_LeavesTheFieldOffTransactionsWithoutContracts(t *testi
 
 // TestNewElasticProcessor_PutsTheAddedPropertiesOnTheTransactionsIndex covers start-up: the
 // template only reaches indices created after it, so the processor must put the added
-// properties onto the live transactions index itself, every time it starts, and must refuse
-// to start when that fails. A processor that started anyway would write the field into an
-// index that types it dynamically, and the filter written for the keyword type would miss it.
+// properties onto the live transactions index itself, every time it starts, rewrite the
+// stored template so later indices carry them too, and refuse to start when either fails.
+// A processor that started anyway would write the field into an index that types it
+// dynamically, and the filter written for the keyword type would miss it.
 func TestNewElasticProcessor_PutsTheAddedPropertiesOnTheTransactionsIndex(t *testing.T) {
-	t.Run("puts the keyword mapping on the transactions alias", func(t *testing.T) {
+	t.Run("checks and updates the mapping on the transactions alias", func(t *testing.T) {
 		var gotIndex string
-		var gotBody map[string]interface{}
+		var gotProperties templates.Object
 		args := createMockElasticProcessorArgs()
 		args.DBClient = &imock.DatabaseWriterStub{
-			CheckAndUpdateMappingCalled: func(index string, properties *bytes.Buffer) error {
-				gotIndex = index
-				require.NoError(t, json.Unmarshal(properties.Bytes(), &gotBody))
+			CheckAndUpdateMappingCalled: func(index string, properties templates.Object) error {
+				gotIndex, gotProperties = index, properties
 				return nil
 			},
 		}
@@ -169,19 +172,84 @@ func TestNewElasticProcessor_PutsTheAddedPropertiesOnTheTransactionsIndex(t *tes
 		require.NoError(t, err)
 
 		require.Equal(t, txIndex, gotIndex)
-		properties, ok := gotBody["properties"].(map[string]interface{})
+		properties, ok := gotProperties["properties"].(templates.Object)
 		require.True(t, ok, "the body must be a mapping update, {\"properties\": ...}")
-		require.Equal(t, map[string]interface{}{"type": "keyword"}, properties["scAddresses"])
+		require.Equal(t, templates.Object{"type": "keyword"}, properties["scAddresses"])
+	})
+
+	t.Run("rewrites the stored transactions template", func(t *testing.T) {
+		var gotTemplates []string
+		args := createMockElasticProcessorArgs()
+		args.IndexTemplates = map[string]*bytes.Buffer{txIndex: noKibana.Transactions.ToBuffer(), blockIndex: noKibana.Blocks.ToBuffer()}
+		args.DBClient = &imock.DatabaseWriterStub{
+			PutTemplateCalled: func(name string, template *bytes.Buffer) error {
+				gotTemplates = append(gotTemplates, name)
+				require.True(t, bytes.Contains(template.Bytes(), []byte(`"scAddresses":{"type":"keyword"}`)), "template: %s", template.String())
+				return nil
+			},
+		}
+
+		_, err := NewElasticProcessor(args)
+		require.NoError(t, err)
+		require.Equal(t, []string{txIndex}, gotTemplates, "only the transactions template is rewritten unconditionally")
 	})
 
 	t.Run("a failed mapping update stops start-up", func(t *testing.T) {
 		mappingErr := errors.New("mapping rejected")
 		args := createMockElasticProcessorArgs()
 		args.DBClient = &imock.DatabaseWriterStub{
-			CheckAndUpdateMappingCalled: func(string, *bytes.Buffer) error { return mappingErr },
+			CheckAndUpdateMappingCalled: func(string, templates.Object) error { return mappingErr },
 		}
 
 		_, err := NewElasticProcessor(args)
 		require.ErrorIs(t, err, mappingErr)
 	})
+
+	t.Run("a failed template write stops start-up", func(t *testing.T) {
+		templateErr := errors.New("template rejected")
+		args := createMockElasticProcessorArgs()
+		args.IndexTemplates = map[string]*bytes.Buffer{txIndex: noKibana.Transactions.ToBuffer()}
+		args.DBClient = &imock.DatabaseWriterStub{
+			PutTemplateCalled: func(string, *bytes.Buffer) error { return templateErr },
+		}
+
+		_, err := NewElasticProcessor(args)
+		require.ErrorIs(t, err, templateErr)
+	})
+}
+
+// TestSaveTransactions_WritesTheFieldOnThePreparedPath covers the production path of every
+// websocket-enabled node: the transactions arrive already prepared, and the field must be
+// derived on those structs before they are serialized, exactly as on the fallback path.
+func TestSaveTransactions_WritesTheFieldOnThePreparedPath(t *testing.T) {
+	var sent bytes.Buffer
+	dbWriter := &imock.DatabaseWriterStub{
+		DoBulkRequestCalled: func(buff *bytes.Buffer, _ string) error {
+			sent.Write(buff.Bytes())
+			return nil
+		},
+	}
+
+	invoked := contractAddressForTest(1)
+	tx, err := createTransactionHandlerMock(
+		&transaction.TransferContract{ToAddress: []byte("klv1d05ju9jaj6u99zph0ant9jh7gksg"), Amount: 45},
+		transaction.TXContract_TransferContractType,
+		[]byte("klv1d05ju9jaj6u99zph0ant9jh7gksf"),
+	)
+	require.NoError(t, err)
+
+	header := &dataBlock.Block{Header: &dataBlock.BlockHeader{Nonce: 7, Timestamp: 100}, TxHashes: [][]byte{[]byte("h1")}}
+	pool := &indexer.Pool{
+		Txs:  map[string]nodeData.TransactionHandler{"h1": tx},
+		Logs: []*nodeData.LogData{{TxHash: "h1", LogHandler: &transaction.Log{Address: invoked}}},
+	}
+
+	ep := newTestElasticSearchDatabase(dbWriter, hexEncodingArgs())
+	txs, txsMap, altered, err := ep.prepareTransactionsForDatabase(header, pool)
+	require.NoError(t, err)
+
+	require.NoError(t, ep.SaveTransactions(header, pool, &data.PreparedBlockData{Txs: txs, TxsMap: txsMap, Altered: altered}))
+
+	item := transactionBulkItem(t, sent.Bytes(), hex.EncodeToString([]byte("h1")))
+	require.Equal(t, []interface{}{hex.EncodeToString(invoked)}, item["upsert"].(map[string]interface{})["scAddresses"])
 }

--- a/indexer/templates/addedProperties_test.go
+++ b/indexer/templates/addedProperties_test.go
@@ -1,0 +1,33 @@
+package templates_test
+
+import (
+	"testing"
+
+	"github.com/klever-io/klever-go/indexer/templates"
+	"github.com/klever-io/klever-go/indexer/templates/noKibana"
+	"github.com/klever-io/klever-go/indexer/templates/withKibana"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransactionsTemplatesCarryTheAddedProperties holds both transactions templates to
+// templates.TransactionsAddedProperties, the same definition elasticProcessor puts onto a
+// live index at start-up. A new index built from a template that lacks the property, or
+// that types it differently, would disagree with every existing index on the field's type,
+// and a filter written for one would miss the other.
+func TestTransactionsTemplatesCarryTheAddedProperties(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, templates.Object{"type": "keyword"}, templates.TransactionsAddedProperties["scAddresses"],
+		"scAddresses is filtered with an exact term, which needs the keyword type")
+
+	for name, template := range map[string]templates.Object{
+		"noKibana":   noKibana.Transactions,
+		"withKibana": withKibana.Transactions,
+	} {
+		properties := template["mappings"].(templates.Object)["properties"].(templates.Object)
+		for field, mapping := range templates.TransactionsAddedProperties {
+			require.Equal(t, mapping, properties[field],
+				"%s transactions template must map %s exactly as the live index gets it", name, field)
+		}
+	}
+}

--- a/indexer/templates/noKibana/transactions.go
+++ b/indexer/templates/noKibana/transactions.go
@@ -1,5 +1,7 @@
 package noKibana
 
+import "github.com/klever-io/klever-go/indexer/templates"
+
 // Transactions will hold the configuration for the transactions index
 var Transactions = Object{
 	"index_patterns": Array{
@@ -26,6 +28,7 @@ var Transactions = Object{
 					},
 				},
 			},
+			"scAddresses": templates.TransactionsAddedProperties["scAddresses"],
 		},
 	},
 }

--- a/indexer/templates/types.go
+++ b/indexer/templates/types.go
@@ -20,3 +20,16 @@ func (o *Object) ToBuffer() *bytes.Buffer {
 
 	return buff
 }
+
+// TransactionsAddedProperties are mapping properties added to the transactions index after
+// deployments may already carry that index. Both transactions templates include them, so a
+// new index gets them at creation; elasticProcessor puts the same properties onto a live
+// index at start-up, because a template only applies when an index is created and a field
+// first written without a mapping is typed dynamically, as text with a keyword subfield,
+// which is not the keyword type a filter on it is written for. One definition, two uses,
+// so the template and the live index cannot disagree on the type.
+var TransactionsAddedProperties = Object{
+	"scAddresses": Object{
+		"type": "keyword",
+	},
+}

--- a/indexer/templates/withKibana/transactions.go
+++ b/indexer/templates/withKibana/transactions.go
@@ -1,5 +1,7 @@
 package withKibana
 
+import "github.com/klever-io/klever-go/indexer/templates"
+
 // Transactions will hold the configuration for the transactions index
 var Transactions = Object{
 	"index_patterns": Array{
@@ -26,6 +28,7 @@ var Transactions = Object{
 					},
 				},
 			},
+			"scAddresses": templates.TransactionsAddedProperties["scAddresses"],
 		},
 	},
 }


### PR DESCRIPTION
Indexer side of klever-proxy-go#434 (KLC-2642). Every transaction document gains `scAddresses`: the contracts that took part in it, derived from its logs. The proxy filter that reads it comes in a separate PR, behind an explicit switch, once this is deployed and backfilled.

## Why the field

A transaction that invokes contract A, which calls contract B, names only A in `contract.parameter.address`, and B leaves a receipt only when it moved value. Measured on mainnet, 51 to 53% of smart contract transactions carry no transfer receipt at all, a contract's own `ping` included, so neither existing field can say which contracts a transaction used. The logs can: every contract that ran emits events, each carrying the address of the contract that emitted it. Numbers and the option analysis are in the issue thread.

## What lands on the document

`scAddresses`, a keyword array: the contract the transaction invoked (the log's own address) and every contract that emitted an event while it ran, distinct, bech32 encoded, sorted. Wallets are left out, and so is the empty system address, which `IsSmartContractAddress` accepts through its `IsEmptyAddress` branch and which burn transfers put in a log. A transaction without contracts gets no field, not an empty array.

Collected in `ExtractDataFromLogs`' events loop rather than as an `eventsProcessor`, because `processEvent` returns on the first processor that reports an event as processed, so a processor keyed on existing identifiers would shadow one or be shadowed.

A contract that ran without emitting any event is not listed. That is the remaining gap and it is smaller than the receipts gap: every invoked contract emits at least `completedTxEvent`, and an inner call with no event at all leaves nothing in the log to derive from.

## Three places the field has to reach, and why each

- **The upsert body**, for a new document: rides on the json tag.
- **The update script**, for a document that already exists: the upsert body is ignored then, so without this a resync or an `import-db` replay would leave every existing document without the field. Guarded on a null parameter, so such a replay never writes an empty array either.
- **The mapping**, from one definition (`templates.TransactionsAddedProperties`): both transactions templates, the stored template rewritten at start-up so indices created later on an existing cluster carry it, and the live index checked at start-up and given only what it does not map yet, because a template only applies at index creation and a field first written without a mapping is typed dynamically as text with a keyword subfield, not the keyword a term filter is written for. A node whose index is up to date sends no write, so steady state needs no `manage` privilege; the first start after this change does, on `transactions`. A property mapped with another type stops start-up with the type the index carries, rather than being closed and forgotten.

## Backfill: `cmd/indexer-backfill`

Scrolls a source `logs` index, hands each document to the indexer's own `ExtractDataFromLogs` exactly as the indexer would have received it from the node, and writes what the indexer derives as a partial update on the target transaction. The derivation is the indexer's by construction, not a copy. Before the first write the target's mapping is brought up to date through the same client code the node runs at start-up, so the tool can run before or after that node is deployed without typing the field as text; a target already mapped with another type is refused before anything is written, in a dry run too. Source and target are separate clusters on purpose: the cluster in this repo's `external.yaml` has a `logs` index that starts 2026-03-23 while its transactions go back to the first smart contract transaction (2025-10-28), so its backfill must read logs from the cluster that holds them all. Idempotent; updates carry `retry_on_conflict` for the live head; a transaction the target does not hold is counted, not created; an alias spanning several indices is refused up front; `-dry-run` derives, counts and reports the mapping state without writing; the run ends with three counts over one population (smart contract transactions with logs, of which carrying the field, of which without it), the last counted directly rather than subtracted. Passwords come from the environment, never from flags, and a URL carrying credentials is refused.

A transaction carries at most one smart contract call (`ErrSmartContractFailMaxContracts`), so one log per hash is the rule and the `logs` index is a complete source for the derivation; the indexer's merge across several logs of one hash is defensive.

## Rollout

The order between deploying the node and running the backfill no longer matters: both bring the mapping up to date before writing, and both refuse an index mapped with another type. What does matter:

1. The Elasticsearch user of the node (and of the tool, for a first run) needs `manage` on `transactions` once, to add the property; afterwards a start-up only reads the field mapping. Verify the production role before the release.
2. Run `indexer-backfill -dry-run` against the target, then the real run with the production `logs` as source.
3. Acceptance: the closing report's "without it" count is 0, or every remaining document is explained (a log that names no contract, such as a failed deploy logged under the sender, leaves its transaction without a field on a backfill and on a fresh index alike). The same number by hand: `contract.type:63 AND hasLogs:true AND NOT exists:scAddresses` on `transactions`.
4. Only then the proxy switch (separate PR in klever-proxy-go).

## What was checked

- Every new assertion was run once against a broken variant of the code it guards and failed on the assertion written for it: the empty-address exclusion dropped, merge replaced by overwrite, the sort reversed, the old update script restored, the start-up mapping skipped, a wrong type in a template, `omitempty` removed, a rejected mapping swallowed, the mapping written without reading first, a wrong live type tolerated, the template put short-circuited, the prepared data shared instead of copied, and for the tool an unsorted body, a missing document counted as failed, a multi-index alias accepted, the dry-run guard removed, the log's own address dropped from the input, the mapping guard skipped, a dry run writing, `retry_on_conflict` dropped, the keepalive rendered as `Duration.String()`, the remainder subtracted, the credentials check dropped, and a pause ignoring cancellation.
- Four independent review passes (security, scoped review, Go review, adversarial full-diff) ran before this was pushed; their findings are in the description above as the things this now does, and one was declined with a reason: the websocket race is fixed by giving the indexer its own structs rather than by moving the log extraction onto the commit goroutine, because the latter changes what websocket subscribers receive and that is their contract to change.
- `go build ./...`, `go vet`, `gofmt`, `go test` (8 packages), `golangci-lint --new-from-rev=origin/develop` (0 issues), `gitleaks` (clean). semgrep, osv-scanner, govulncheck and actionlint are not installed on the dev machine and were not run.
- No exported function signature changed. `DatabaseClientHandler` gains `CheckFieldMapping`, `CheckAndUpdateMapping` and `PutTemplate`; both implementers are in this diff.
- Coverage on the new indexer code is 92 to 100% per function; the CLI wiring in `main.go` is the uncovered remainder.

## Deliberately not in this PR

- The proxy filter and its switch (klever-proxy-go, after the backfill).
- The websocket stream keeps carrying transactions as prepared, without `hasLogs` or `scAddresses`; carrying them there means running the log extraction on the commit goroutine and is a change to what subscribers receive.
- A resumable scroll. A run over the whole SC history is a few hundred thousand updates and idempotent, so a failed run is repeated, and `-timestamp-from/-to` narrows one when needed. The unit of those bounds follows the logs mapping, which is a `long` on the cluster measured here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds `scAddresses` to transaction documents.
- Derives distinct, sorted, bech32-encoded smart-contract addresses from transaction logs.
- Excludes wallet addresses and the empty system address.
- Omits the field when no contract address is present.
- Updates Elasticsearch mappings, templates, startup checks, upserts, and update scripts.
- Adds `cmd/indexer-backfill` with bounded scans, dry runs, mapping validation, retries, cancellation, credential safeguards, and reporting.
- Copies transaction data before indexing to prevent websocket and indexer data races.
- Adds coverage for extraction, persistence, mapping checks, failure handling, and CLI validation.

## Blockchain impact

- No consensus, KVM, networking, state-transition, or state-management logic changes.
- Transaction processing changes affect only indexer-derived document data.
- Transaction document integrity is protected by deterministic address derivation and idempotent updates.
- Node stability is improved by data-race prevention, mapping validation, error propagation, conflict retries, cancellation, and scroll cleanup reporting.
- Startup stops when Elasticsearch rejects template, index, alias, or mapping operations. This prevents indexing against incompatible schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->